### PR TITLE
Correct handle end of the communication and client disconnect

### DIFF
--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -89,10 +89,13 @@ class SMTP(asyncio.StreamReaderProtocol):
         self._writer = writer
 
     def connection_lost(self, exc):
-        log.exception('Disconnect')
-        self._connection_closed = True
+        if exc is not None:
+            self._handler_coroutine.cancel()
         super().connection_lost(exc)
-        yield from self._handler_coroutine
+
+    def eof_received(self):
+        self._handler_coroutine.cancel()
+        return super().eof_received()
 
     def _set_post_data_state(self):
         """Reset state variables to their post-DATA state."""

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -88,11 +88,6 @@ class SMTP(asyncio.StreamReaderProtocol):
         self._reader = reader
         self._writer = writer
 
-    def connection_lost(self, exc):
-        if exc is not None:
-            self._handler_coroutine.cancel()
-        super().connection_lost(exc)
-
     def eof_received(self):
         self._handler_coroutine.cancel()
         return super().eof_received()


### PR DESCRIPTION
How to reproduce:

Run smtpd server with code:
```python
import asyncio
import logging

from aiosmtpd.handlers import Sink
from aiosmtpd.controller import Controller


async def amain(loop):
    cont = Controller(Sink(), hostname='::0', port=8025)
    cont.start()


if __name__ == '__main__':
    logging.basicConfig(level=logging.DEBUG)
    loop = asyncio.get_event_loop()
    loop.create_task(amain(loop=loop))
    loop.run_forever()
```

and try send mail:
```python

from smtplib import SMTP

client = SMTP(
    '127.0.0.1', 8025
)

client.sendmail(
    'from@test',
    ['to@test'],
    """\
From: from@test
To: to@test
Subject: A test

Test mail
"""
)
```

You will see a lot of errors in server output log:
```
WARNING:asyncio:socket.send() raised exception.
DEBUG:mail.log:b'500 Error: bad syntax\r\n'
INFO:mail.log:Data: ''
WARNING:asyncio:socket.send() raised exception.
DEBUG:mail.log:b'500 Error: bad syntax\r\n'
INFO:mail.log:Data: ''
WARNING:asyncio:socket.send() raised exception.
DEBUG:mail.log:b'500 Error: bad syntax\r\n'
INFO:mail.log:Data: ''
WARNING:asyncio:socket.send() raised exception.
DEBUG:mail.log:b'500 Error: bad syntax\r\n'
INFO:mail.log:Data: ''
WARNING:asyncio:socket.send() raised exception.
....
```