### PR TITLE
Simple AUTH PLAIN implementation

### DIFF
--- a/aiosmtpd/main.py
+++ b/aiosmtpd/main.py
@@ -65,6 +65,10 @@ def parseargs(args=None):
         'classargs', metavar='CLASSARGS',
         nargs='*', default=(),
         help="""Additional arguments passed to the handler CLASS.""")
+    parser.add_argument(
+        '-a', '--auth_required',
+        default=False, action='store_true',
+        help="""Requires Authentication.""")
     args = parser.parse_args(args)
     # Find the handler class.
     path, dot, name = args.classpath.rpartition('.')
@@ -113,7 +117,8 @@ def main(args=None):
 
     factory = partial(
         SMTP, args.handler,
-        data_size_limit=args.size, enable_SMTPUTF8=args.smtputf8)
+        data_size_limit=args.size, enable_SMTPUTF8=args.smtputf8,
+        auth_required=args.auth_required)
 
     logging.basicConfig(level=logging.ERROR)
     log = logging.getLogger('mail.log')

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -319,12 +319,14 @@ class SMTP(asyncio.StreamReaderProtocol):
         blob = None
         if len(args) == 1:
             yield from self.push('334')  # your turn, send me login/password
-            blob = yield from self._reader.readline()
+            line = yield from self._reader.readline()
+            blob = line.strip()
             if blob == '*':
                 yield from self.push("501 Auth aborted")
                 return
         else:
             blob = args[1]
+        log.debug('login/password %s', blob)
         if blob == '=':
             login = None
             password = None

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -299,6 +299,9 @@ class SMTP(asyncio.StreamReaderProtocol):
         self._tls_protocol.connection_made(socket_transport)
 
     def smtp_AUTH(self, arg):
+        if not self.seen_greeting:
+            yield from self.push('503 Error: send HELO first')
+            return
         args = arg.split(' ')
         if len(args) > 2:
             yield from self.push('500 Too many values')

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -317,19 +317,18 @@ class SMTP(asyncio.StreamReaderProtocol):
             yield from self.push('500 PLAIN method or die')
             return
         blob = None
-        is_password = True
         if len(args) == 1:
             yield from self.push('334')  # your turn, send me login/password
             blob = yield from self._reader.readline()
             if blob == '*':
                 yield from self.push("501 Auth aborted")
                 return
-            if blob == '=':
-                password = None
-                is_password = False
         else:
             blob = args[1]
-        if is_password:
+        if blob == '=':
+            login = None
+            password = None
+        else:
             try:
                 loginpassword = b64decode(blob, validate=True)
             except Exception:

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -71,6 +71,7 @@ class SMTP(asyncio.StreamReaderProtocol):
         self.auth_method = auth_method
         self._set_rset_state()
         self.seen_greeting = ''
+        self.autheticated = False
         self.extended_smtp = False
         self.command_size_limits.clear()
         if hostname:
@@ -298,20 +299,46 @@ class SMTP(asyncio.StreamReaderProtocol):
         self._tls_protocol.connection_made(socket_transport)
 
     def smtp_AUTH(self, arg):
-        try:
-            method, blob = arg.split(" ", 2)
-        except ValueError:  # not enough args
-            yield from self.push('500 value is missing')
+        args = arg.split(' ')
+        if len(args) > 2:
+            yield from self.push('500 Too many values')
             return
+        if len(args) == 0:
+            yield from self.push('500 Not enough value')
+            return
+        if self.autheticated:
+            yield from self.push('503 Already authenticated')
+            return
+        method = args[0]
         if method != 'PLAIN':
             yield from self.push('500 PLAIN method or die')
             return
-        try:
-            _, login, password = b64decode(blob).split(b"\x00")
-        except ValueError:  # not enough args
-            yield from self.push("500 Can't decode auth value")
-            return
+        blob = None
+        is_password = True
+        if len(args) == 1:
+            yield from self.push('334')  # your turn, send me login/password
+            blob = yield from self._reader.readline()
+            if blob == '*':
+                yield from self.push("501 Auth aborted")
+                return
+            if blob == '=':
+                password = None
+                is_password = False
+        else:
+            blob = args[1]
+        if is_password:
+            try:
+                loginpassword = b64decode(blob, validate=True)
+            except Exception:
+                yield from self.push("501 5.5.2 Can't decode base64")
+                return
+            try:
+                _, login, password = loginpassword.split(b"\x00")
+            except ValueError:  # not enough args
+                yield from self.push("500 Can't split auth value")
+                return
         if self.auth_method(login, password):
+            self.authenticated = True
             yield from self.push('235 2.7.0 Authentication successful')
         else:
             yield from self.push('535 5.7.8 Authentication credentials '

--- a/aiosmtpd/tests/test_main.py
+++ b/aiosmtpd/tests/test_main.py
@@ -179,6 +179,7 @@ class TestLoop(unittest.TestCase):
         self.assertEqual(len(positional[0].args), 1)
         self.assertIsInstance(positional[0].args[0], Debugging)
         self.assertEqual(positional[0].keywords, dict(
+            auth_required=False,
             data_size_limit=None,
             enable_SMTPUTF8=False))
         self.assertEqual(list(keywords), ['sock'])
@@ -206,6 +207,7 @@ class TestLoop(unittest.TestCase):
         main(('-n', '-s', '3000'))
         positional, keywords = self.create_server.call_args
         self.assertEqual(positional[0].keywords, dict(
+            auth_required=False,
             data_size_limit=3000,
             enable_SMTPUTF8=False))
 
@@ -215,6 +217,7 @@ class TestLoop(unittest.TestCase):
         main(('-n', '--size', '3000'))
         positional, keywords = self.create_server.call_args
         self.assertEqual(positional[0].keywords, dict(
+            auth_required=False,
             data_size_limit=3000,
             enable_SMTPUTF8=False))
 
@@ -224,6 +227,7 @@ class TestLoop(unittest.TestCase):
         main(('-n', '-u'))
         positional, keywords = self.create_server.call_args
         self.assertEqual(positional[0].keywords, dict(
+            auth_required=False,
             data_size_limit=None,
             enable_SMTPUTF8=True))
 
@@ -233,6 +237,7 @@ class TestLoop(unittest.TestCase):
         main(('-n', '--smtputf8'))
         positional, keywords = self.create_server.call_args
         self.assertEqual(positional[0].keywords, dict(
+            auth_required=False,
             data_size_limit=None,
             enable_SMTPUTF8=True))
 

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -86,7 +86,8 @@ class TestSMTP(unittest.TestCase):
             lines = response.splitlines()
             self.assertEqual(lines[0], bytes(socket.getfqdn(), 'utf-8'))
             self.assertEqual(lines[1], b'SIZE 33554432')
-            self.assertEqual(lines[2], b'HELP')
+            self.assertEqual(lines[2], b'AUTH PLAIN')
+            self.assertEqual(lines[3], b'HELP')
 
     def test_ehlo_duplicate(self):
         with SMTP(*self.address) as client:
@@ -151,7 +152,7 @@ class TestSMTP(unittest.TestCase):
             self.assertEqual(code, 250)
             self.assertEqual(response,
                              b'Supported commands: EHLO HELO MAIL RCPT '
-                             b'DATA RSET NOOP QUIT VRFY')
+                             b'DATA RSET NOOP QUIT VRFY AUTH')
 
     def test_help_helo(self):
         with SMTP(*self.address) as client:
@@ -238,7 +239,7 @@ class TestSMTP(unittest.TestCase):
             self.assertEqual(code, 501)
             self.assertEqual(response,
                              b'Supported commands: EHLO HELO MAIL RCPT '
-                             b'DATA RSET NOOP QUIT VRFY')
+                             b'DATA RSET NOOP QUIT VRFY AUTH')
 
     def test_expn(self):
         with SMTP(*self.address) as client:


### PR DESCRIPTION
Here is a naive implementation of AUTH PLAIN.

The auth method, as an argument, is not pythonic enough.
