### PR TITLE
X-RcptTos header -> X-RcptTo

### DIFF
--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -4,6 +4,9 @@
 
 1.0a3 (20XX-XX-XX)
 ==================
+* Fix typo in `Message.prepare_message()` handler.  The crafted `X-RcptTos`
+  header is renamed to `X-RcptTo` for backward compatibility with older
+  libraries.
 
 1.0a2 (2016-11-22)
 ==================

--- a/aiosmtpd/docs/controller.rst
+++ b/aiosmtpd/docs/controller.rst
@@ -49,7 +49,7 @@ The message was received, and we can print it.
     Message-ID: <ant>
     X-Peer: ...
     X-MailFrom: aperson@example.com
-    X-RcptTos: bperson@example.com
+    X-RcptTo: bperson@example.com
     <BLANKLINE>
     Hi Bart, this is Anne.
 

--- a/aiosmtpd/handlers.py
+++ b/aiosmtpd/handlers.py
@@ -147,7 +147,7 @@ class Message:
             message = message_from_string(data, self.message_class)
         message['X-Peer'] = str(peer)
         message['X-MailFrom'] = mailfrom
-        message['X-RcptTos'] = COMMASPACE.join(rcpttos)
+        message['X-RcptTo'] = COMMASPACE.join(rcpttos)
 
         return message
 

--- a/aiosmtpd/tests/test_handlers.py
+++ b/aiosmtpd/tests/test_handlers.py
@@ -160,7 +160,7 @@ Testing
         self.assertIsNotNone(self.handled_message['X-Peer'])
         self.assertEqual(
             self.handled_message['X-MailFrom'], 'anne@example.com')
-        self.assertEqual(self.handled_message['X-RcptTos'], 'bart@example.com')
+        self.assertEqual(self.handled_message['X-RcptTo'], 'bart@example.com')
 
     def test_message_decoded(self):
         # With a server that decodes the data, the messages come in as
@@ -185,7 +185,7 @@ Testing
         self.assertIsNotNone(self.handled_message['X-Peer'])
         self.assertEqual(
             self.handled_message['X-MailFrom'], 'anne@example.com')
-        self.assertEqual(self.handled_message['X-RcptTos'], 'bart@example.com')
+        self.assertEqual(self.handled_message['X-RcptTo'], 'bart@example.com')
 
 
 class TestAsyncMessage(unittest.TestCase):
@@ -218,7 +218,7 @@ Testing
         self.assertIsNotNone(self.handled_message['X-Peer'])
         self.assertEqual(
             self.handled_message['X-MailFrom'], 'anne@example.com')
-        self.assertEqual(self.handled_message['X-RcptTos'], 'bart@example.com')
+        self.assertEqual(self.handled_message['X-RcptTo'], 'bart@example.com')
 
     def test_message_decoded(self):
         # With a server that decodes the data, the messages come in as
@@ -243,7 +243,7 @@ Testing
         self.assertIsNotNone(self.handled_message['X-Peer'])
         self.assertEqual(
             self.handled_message['X-MailFrom'], 'anne@example.com')
-        self.assertEqual(self.handled_message['X-RcptTos'], 'bart@example.com')
+        self.assertEqual(self.handled_message['X-RcptTo'], 'bart@example.com')
 
 
 class TestMailbox(unittest.TestCase):


### PR DESCRIPTION
Older libraries such as lazr.smtpttest used `X-RcptTo` (singular).  Change the `Message` handler header to match.