### PR TITLE
Add a few useful hooks to make subclassing easier.

### DIFF
--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -28,12 +28,18 @@ class Controller:
         self._wsock.close()
 
     def factory(self):
+        """Allow subclasses to customize the handler/server creation."""
         return SMTP(self.handler)
 
-    def _run(self, ready_event):
+    def make_socket(self):
+        """Allow subclasses to customize socket creation."""
         sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
         sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, False)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, True)
+        return sock
+
+    def _run(self, ready_event):
+        sock = self.make_socket()
         sock.bind((self.hostname, self.port))
         asyncio.set_event_loop(self.loop)
         server = self.loop.run_until_complete(

--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -7,6 +7,13 @@
 * Fix typo in `Message.prepare_message()` handler.  The crafted `X-RcptTos`
   header is renamed to `X-RcptTo` for backward compatibility with older
   libraries.
+* Add a few hooks to make subclassing easier:
+  - `SMTP.ehlo_hook()` is called just before the final, non-continuing 250
+    response to allow subclasses to add additional EHLO sub-responses.
+  - `SMTP.rset_hook()` is called just before the final 250 command to allow
+    subclasses to provide additional `RSET` functionality.
+  - `Controller.make_socket()` allows subclasses to customize the creation of
+    the socket before binding.
 
 1.0a2 (2016-11-22)
 ==================


### PR DESCRIPTION
I'm in the process of converting the GNU Mailman 3 trunk from lazr.smtptest to aiosmtpd.  Of course, it's *much* nicer to use asyncio than asynchat/asyncore-based smtpd.py, but there are a few hooks I found I needed to make it just that much more comfortable.  These allow subclasses to not have to reimplement entire methods just to add a little bit of functionality.  

  - `SMTP.ehlo_hook()` is called just before the final, non-continuing 250
    response to allow subclasses to add additional EHLO sub-responses.
  - `SMTP.rset_hook()` is called just before the final 250 command to allow
    subclasses to provide additional `RSET` functionality.
  - `Controller.make_socket()` allows subclasses to customize the creation of
    the socket before binding.
