### PR TITLE
Use flufl.testing's flake8 plugin.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ Python 3.""",
         ],
     entry_points={
         'console_scripts': ['smtpd = aiosmtpd.main:main'],
-        'flake8.extension': ['B40 = public.tests.flake8:ImportOrder'],
         },
     classifiers=[
         'License :: OSI Approved',

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,7 @@ commands =
     python -m flake8 aiosmtpd
 deps =
     flake8
+    flufl.testing
 
 [testenv:docs]
 basepython = python3
@@ -48,3 +49,4 @@ deps:
 max-line-length = 79
 jobs = 1
 exclude = conf.py
+enable-extensions = U4


### PR DESCRIPTION
atpublic no longer has that flake8 plugin, so installing aiosmtpd 0.3 fails.