### PR TITLE
Refactor DATA method

### DIFF
--- a/aiosmtpd/handlers.py
+++ b/aiosmtpd/handlers.py
@@ -89,15 +89,15 @@ class Proxy:
         self._port = remote_port
 
     def process_message(self, peer, mailfrom, rcpttos, data, **kws):
-        lines = data.split('\n')
+        lines = data.splitlines(keepends=True)
         # Look for the last header
         i = 0
         for line in lines:                          # pragma: nobranch
-            if not line:
+            if line in ['\r', '\n', '\r\n']:
                 break
             i += 1
-        lines.insert(i, 'X-Peer: %s' % peer[0])
-        data = NEWLINE.join(lines)
+        lines.insert(i, 'X-Peer: %s\r\n' % peer[0])
+        data = ''.join(lines)
         refused = self._deliver(mailfrom, rcpttos, data)
         # TBD: what to do with refused addresses?
         log.info('we got some refusals: %s', refused)

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -144,8 +144,6 @@ class SMTP(asyncio.StreamReaderProtocol):
     def _set_rset_state(self):
         """Reset all state variables except the greeting."""
         self._set_post_data_state()
-        self.received_data = ''
-        self.received_lines = []
 
     @asyncio.coroutine
     def push(self, msg):
@@ -505,29 +503,34 @@ class SMTP(asyncio.StreamReaderProtocol):
             return
         yield from self.push('354 End data with <CR><LF>.<CR><LF>')
         data = []
-        self.num_bytes = 0
+        num_bytes = 0
+        size_exceeded = False
         while not self.connection_closed:
             line = yield from self._reader.readline()
             if line == b'.\r\n':
+                if data:
+                    data[-1] = data[-1].rstrip(b'\r\n')
                 break
-            self.num_bytes += len(line)
-            if self.data_size_limit and self.num_bytes > self.data_size_limit:
+            num_bytes += len(line)
+            if (not size_exceeded) and self.data_size_limit and \
+                    num_bytes > self.data_size_limit:
+                size_exceeded = True
                 yield from self.push('552 Error: Too much mail data')
-            # XXX this rstrip may not exactly preserve the old behavior
-            line = line.rstrip(b'\r\n')
-            if self._decode_data:
-                data.append(line.decode('utf-8'))
-            else:
+                self._set_post_data_state()
+            if not size_exceeded:
                 data.append(line)
+        if size_exceeded:
+            return
         # Remove extraneous carriage returns and de-transparency
         # according to RFC 5321, Section 4.5.2.
         for i in range(len(data)):
             text = data[i]
-            if text and text[0] == self._dotsep:
+            if text and text[:1] == b'.':
                 data[i] = text[1:]
-        self.received_data = self._newline.join(data)
-        args = (self.peer, self.mailfrom, self.rcpttos,
-                self.received_data)
+        received_data = b''.join(data)
+        if self._decode_data:
+            received_data = received_data.decode('utf-8')
+        args = (self.peer, self.mailfrom, self.rcpttos, received_data)
         kwargs = {}
         if not self._decode_data:
             kwargs = {

--- a/aiosmtpd/tests/test_handlers.py
+++ b/aiosmtpd/tests/test_handlers.py
@@ -409,11 +409,11 @@ Testing
             mock().connect.assert_called_once_with('localhost', 9025)
             mock().sendmail.assert_called_once_with(
                 'anne@example.com', ['bart@example.com'], """\
-From: Anne Person <anne@example.com>
-To: Bart Person <bart@example.com>
-Subject: A test
-X-Peer: ::1
-
+From: Anne Person <anne@example.com>\r
+To: Bart Person <bart@example.com>\r
+Subject: A test\r
+X-Peer: ::1\r
+\r
 Testing""")
             mock().quit.assert_called_once_with()
 


### PR DESCRIPTION
Here is two fixes with DATA method. 
1. Respect original line endings. That`s not obvious, as RFC says that line endings must be only <CR><LF> but on practice there can be anything, and better to keep it "as is" to not confuse on email debug. Anyway it is good idea to have ability to get real original data of email. Anyway email.parse_message works fine with any line endings.
2. Size limit had a side effect. If limit is reached, all other lines of DATA will fallback to root handler and will be handled as syntax errors. Better to read them but ignore.

Also I removed using of instance properties or local variables. Seems that it is migrated from state-machine implementation.