### PR TITLE
Refactor DATA method

### DIFF
--- a/aiosmtpd/handlers.py
+++ b/aiosmtpd/handlers.py
@@ -19,7 +19,7 @@ from public import public
 
 EMPTYSTRING = ''
 COMMASPACE = ', '
-NEWLINE = '\r\n'
+CRLF = '\r\n'
 log = logging.getLogger('mail.debug')
 
 
@@ -94,7 +94,7 @@ class Proxy:
         lines = data.splitlines(keepends=True)
         # Look for the last header
         i = 0
-        ending = NEWLINE
+        ending = CRLF
         for line in lines:                          # pragma: nobranch
             if NLCRE.match(line):
                 ending = line

--- a/aiosmtpd/handlers.py
+++ b/aiosmtpd/handlers.py
@@ -89,15 +89,15 @@ class Proxy:
         self._port = remote_port
 
     def process_message(self, peer, mailfrom, rcpttos, data, **kws):
-        lines = data.split('\n')
+        lines = data.splitlines(keepends=True)
         # Look for the last header
         i = 0
         for line in lines:                          # pragma: nobranch
-            if not line:
+            if line in ('\r', '\n', '\r\n'):
                 break
             i += 1
-        lines.insert(i, 'X-Peer: %s' % peer[0])
-        data = NEWLINE.join(lines)
+        lines.insert(i, 'X-Peer: %s\r\n' % peer[0])
+        data = ''.join(lines)
         refused = self._deliver(mailfrom, rcpttos, data)
         # TBD: what to do with refused addresses?
         log.info('we got some refusals: %s', refused)

--- a/aiosmtpd/handlers.py
+++ b/aiosmtpd/handlers.py
@@ -13,11 +13,13 @@ import mailbox
 import smtplib
 
 from email import message_from_bytes, message_from_string
+from email.feedparser import NLCRE
 from public import public
 
 
+EMPTYSTRING = ''
 COMMASPACE = ', '
-NEWLINE = '\n'
+NEWLINE = '\r\n'
 log = logging.getLogger('mail.debug')
 
 
@@ -92,12 +94,14 @@ class Proxy:
         lines = data.splitlines(keepends=True)
         # Look for the last header
         i = 0
+        ending = NEWLINE
         for line in lines:                          # pragma: nobranch
-            if line in ('\r', '\n', '\r\n'):
+            if NLCRE.match(line):
+                ending = line
                 break
             i += 1
-        lines.insert(i, 'X-Peer: %s\r\n' % peer[0])
-        data = ''.join(lines)
+        lines.insert(i, 'X-Peer: %s%s' % (peer[0], ending))
+        data = EMPTYSTRING.join(lines)
         refused = self._deliver(mailfrom, rcpttos, data)
         # TBD: what to do with refused addresses?
         log.info('we got some refusals: %s', refused)

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -23,6 +23,7 @@ log = logging.getLogger('mail.log')
 
 NEWLINE = '\n'
 DATA_SIZE_DEFAULT = 33554432
+EMPTYBYTES = b''
 
 
 @public
@@ -62,7 +63,7 @@ class SMTP(asyncio.StreamReaderProtocol):
             self._dotsep = '.'
             self._newline = NEWLINE
         else:
-            self._emptystring = b''
+            self._emptystring = EMPTYBYTES
             self._linesep = b'\r\n'
             self._dotsep = ord(b'.')
             self._newline = b'\n'
@@ -528,7 +529,7 @@ class SMTP(asyncio.StreamReaderProtocol):
             text = data[i]
             if text and text[:1] == b'.':
                 data[i] = text[1:]
-        received_data = b''.join(data)
+        received_data = EMPTYBYTES.join(data)
         if self._decode_data:
             received_data = received_data.decode('utf-8')
         args = (self.peer, self.mailfrom, self.rcpttos, received_data)

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -512,8 +512,9 @@ class SMTP(asyncio.StreamReaderProtocol):
                     data[-1] = data[-1].rstrip(b'\r\n')
                 break
             num_bytes += len(line)
-            if (not size_exceeded) and self.data_size_limit and \
-                    num_bytes > self.data_size_limit:
+            if (not size_exceeded and
+                    self.data_size_limit and
+                    num_bytes > self.data_size_limit):
                 size_exceeded = True
                 yield from self.push('552 Error: Too much mail data')
             if not size_exceeded:

--- a/aiosmtpd/tests/test_handlers.py
+++ b/aiosmtpd/tests/test_handlers.py
@@ -5,7 +5,7 @@ import unittest
 
 from aiosmtpd.controller import Controller
 from aiosmtpd.handlers import (
-    AsyncMessage, Debugging, Mailbox, Message, NEWLINE, Proxy, Sink)
+    AsyncMessage, Debugging, Mailbox, Message, Proxy, Sink)
 from aiosmtpd.smtp import SMTP as Server
 from contextlib import ExitStack
 from io import StringIO
@@ -14,6 +14,8 @@ from operator import itemgetter
 from smtplib import SMTP, SMTPRecipientsRefused
 from tempfile import TemporaryDirectory
 from unittest.mock import call, patch
+
+CRLF = '\r\n'
 
 
 class UTF8Controller(Controller):
@@ -407,15 +409,14 @@ Testing
                 'anne@example.com', ['bart@example.com'], self.message)
             client.quit()
             mock().connect.assert_called_once_with('localhost', 9025)
-            # SMTP always fixes eols, so it must be always CRLF as delimeter
-            msg = NEWLINE.join([
+            # SMTP always fixes eols, so it must be always CRLF as delimiter
+            msg = CRLF.join([
                 'From: Anne Person <anne@example.com>',
                 'To: Bart Person <bart@example.com>',
                 'Subject: A test',
                 'X-Peer: ::1',
                 '',
-                'Testing',
-            ])
+                'Testing'])
             mock().sendmail.assert_called_once_with(
                 'anne@example.com', ['bart@example.com'], msg)
             mock().quit.assert_called_once_with()

--- a/aiosmtpd/tests/test_handlers.py
+++ b/aiosmtpd/tests/test_handlers.py
@@ -409,11 +409,11 @@ Testing
             mock().connect.assert_called_once_with('localhost', 9025)
             mock().sendmail.assert_called_once_with(
                 'anne@example.com', ['bart@example.com'], """\
-From: Anne Person <anne@example.com>
-To: Bart Person <bart@example.com>
-Subject: A test
-X-Peer: ::1
-
+From: Anne Person <anne@example.com>\r
+To: Bart Person <bart@example.com>\r
+Subject: A test\r
+X-Peer: ::1\r
+\r
 Testing""")
             mock().quit.assert_called_once_with()
 

--- a/aiosmtpd/tests/test_handlers.py
+++ b/aiosmtpd/tests/test_handlers.py
@@ -5,7 +5,7 @@ import unittest
 
 from aiosmtpd.controller import Controller
 from aiosmtpd.handlers import (
-    AsyncMessage, Debugging, Mailbox, Message, Proxy, Sink)
+    AsyncMessage, Debugging, Mailbox, Message, Proxy, Sink, NEWLINE)
 from aiosmtpd.smtp import SMTP as Server
 from contextlib import ExitStack
 from io import StringIO
@@ -407,14 +407,17 @@ Testing
                 'anne@example.com', ['bart@example.com'], self.message)
             client.quit()
             mock().connect.assert_called_once_with('localhost', 9025)
+            # SMTP always fixes eols, so it must be always CRLF as delimeter
+            msg = NEWLINE.join([
+                'From: Anne Person <anne@example.com>',
+                'To: Bart Person <bart@example.com>',
+                'Subject: A test',
+                'X-Peer: ::1',
+                '',
+                'Testing',
+            ])
             mock().sendmail.assert_called_once_with(
-                'anne@example.com', ['bart@example.com'], """\
-From: Anne Person <anne@example.com>\r
-To: Bart Person <bart@example.com>\r
-Subject: A test\r
-X-Peer: ::1\r
-\r
-Testing""")
+                'anne@example.com', ['bart@example.com'], msg)
             mock().quit.assert_called_once_with()
 
     def test_recipients_refused(self):

--- a/aiosmtpd/tests/test_handlers.py
+++ b/aiosmtpd/tests/test_handlers.py
@@ -5,7 +5,7 @@ import unittest
 
 from aiosmtpd.controller import Controller
 from aiosmtpd.handlers import (
-    AsyncMessage, Debugging, Mailbox, Message, Proxy, Sink, NEWLINE)
+    AsyncMessage, Debugging, Mailbox, Message, NEWLINE, Proxy, Sink)
 from aiosmtpd.smtp import SMTP as Server
 from contextlib import ExitStack
 from io import StringIO

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -68,10 +68,13 @@ class ErroringHandler:
 class TestProtocol(unittest.TestCase):
     def setUp(self):
         self.transport = Mock()
+        self._old_loop = asyncio.get_event_loop()
         self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
 
     def tearDown(self):
         self.loop.close()
+        asyncio.set_event_loop(self._old_loop)
 
     def _get_protocol(self, *args, **kwargs):
         protocol = Server(*args, loop=self.loop, **kwargs)

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -4,7 +4,7 @@ import socket
 import unittest
 
 from aiosmtpd.controller import Controller
-from aiosmtpd.handlers import Sink
+from aiosmtpd.handlers import Sink, NEWLINE
 from aiosmtpd.smtp import SMTP as Server, __ident__ as GREETING
 from smtplib import SMTP, SMTPDataError, SMTPResponseException
 
@@ -620,7 +620,7 @@ Testing
         self.addCleanup(controller.stop)
         with SMTP(controller.hostname, controller.port) as client:
             client.helo('example.com')
-            mail = '\r\n'.join(['Test', '.', 'mail'])
+            mail = NEWLINE.join(['Test', '.', 'mail'])
             client.sendmail('anne@example.com', ['bart@example.com'], mail)
             self.assertEqual(len(handler.box), 1)
             mail = handler.box[0]

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -22,9 +22,10 @@ class NoDecodeController(Controller):
 class ReceivingHandler:
     box = None
 
+    def __init__(self):
+        self.box = []
+
     def process_message(self, *args, **kws):
-        if not self.box:
-            self.box = []
         self.box.append(args)
 
 
@@ -606,11 +607,11 @@ Testing
         with SMTP(controller.hostname, controller.port) as client:
             client.helo('example.com')
             mail = '\r\n'.join(['z' * 20] * 10)
-            with self.assertRaises(SMTPResponseException) as ctx:
+            with self.assertRaises(SMTPResponseException) as cm:
                 client.sendmail('anne@example.com', ['bart@example.com'], mail)
-            e = ctx.exception
-            self.assertEqual(e.smtp_code, 552)
-            self.assertEqual(e.smtp_error, b'Error: Too much mail data')
+            self.assertEqual(cm.exception.smtp_code, 552)
+            self.assertEqual(cm.exception.smtp_error,
+                             b'Error: Too much mail data')
 
     def test_dots_escaped(self):
         handler = ReceivingHandler()

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -1,14 +1,14 @@
 """Test the SMTP protocol."""
 
-import asyncio
 import socket
+import asyncio
 import unittest
-from unittest.mock import Mock
 
 from aiosmtpd.controller import Controller
 from aiosmtpd.handlers import Sink
 from aiosmtpd.smtp import SMTP as Server, __ident__ as GREETING
 from smtplib import SMTP, SMTPDataError, SMTPResponseException
+from unittest.mock import Mock
 
 CRLF = '\r\n'
 BCRLF = b'\r\n'

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -4,7 +4,7 @@ import socket
 import unittest
 
 from aiosmtpd.controller import Controller
-from aiosmtpd.handlers import Sink, NEWLINE
+from aiosmtpd.handlers import NEWLINE, Sink
 from aiosmtpd.smtp import SMTP as Server, __ident__ as GREETING
 from smtplib import SMTP, SMTPDataError, SMTPResponseException
 


### PR DESCRIPTION
Here is two fixes with DATA method.
1. Respect original line endings. That`s not obvious, as RFC says that line endings must be only CR LF but on practice there can be anything, and better to keep it "as is" to not confuse on email debug. Anyway it is good idea to have ability to get real original data of email. Also, email.parse_message works fine with any line endings, so there is no real need to fix them.
2. Size limit had a side effect. If limit is reached, all other lines of DATA will fallback to root handler and will be handled as syntax errors. Better to read them, but ignore.

Also I removed using of instance properties for local variables. Seems that it is migrated from state-machine implementation.