### PR TITLE
Add socket error handling to Controller thread

### DIFF
--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -18,8 +18,8 @@ class Controller:
         self.server = None
         self.thread = None
         self.thread_exception = None
-        self.ready_timeout = os.getenv('AIOSMTPD_CONTROLLER_TIMEOUT',
-                                       ready_timeout)
+        self.ready_timeout = os.getenv(
+            'AIOSMTPD_CONTROLLER_TIMEOUT', ready_timeout)
         # For exiting the loop.
         self._rsock, self._wsock = socket.socketpair()
         self.loop.add_reader(self._rsock, self._reader)

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -1,3 +1,4 @@
+import os
 import socket
 import asyncio
 import threading
@@ -8,13 +9,17 @@ from public import public
 
 @public
 class Controller:
-    def __init__(self, handler, loop=None, hostname='::0', port=8025):
+    def __init__(self, handler, loop=None, hostname='::0', port=8025,
+                 ready_timeout=1.0):
         self.handler = handler
         self.server = None
         self.hostname = '::0' if hostname is None else hostname
         self.port = port
         self.loop = asyncio.new_event_loop() if loop is None else loop
         self.thread = None
+        self.thread_exception = None
+        self.ready_timeout = os.getenv('AIOSMTPD_CONTROLLER_TIMEOUT',
+                                       ready_timeout)
         # For exiting the loop.
         self._rsock, self._wsock = socket.socketpair()
         self.loop.add_reader(self._rsock, self._reader)
@@ -39,8 +44,12 @@ class Controller:
         return sock
 
     def _run(self, ready_event):
-        sock = self.make_socket()
-        sock.bind((self.hostname, self.port))
+        try:
+            sock = self.make_socket()
+            sock.bind((self.hostname, self.port))
+        except socket.error as error:
+            self.thread_exception = error
+            return
         asyncio.set_event_loop(self.loop)
         server = self.loop.run_until_complete(
             self.loop.create_server(self.factory, sock=sock))
@@ -57,7 +66,9 @@ class Controller:
         self.thread.daemon = True
         self.thread.start()
         # Wait a while until the server is responding.
-        ready_event.wait()
+        ready_event.wait(self.ready_timeout)
+        if self.thread_exception is not None:
+            raise self.thread_exception
 
     def stop(self):
         assert self.thread is not None, 'SMTP daemon not running'

--- a/aiosmtpd/docs/controller.rst
+++ b/aiosmtpd/docs/controller.rst
@@ -26,6 +26,12 @@ SMTP connections in the separate thread.
     >>> controller = Controller(MessageHandler())
     >>> controller.start()
 
+The SMTP thread might run into errors during it's setup phase, to catch this
+the main thread will timeout when waiting for the SMTP server to become ready.
+By default the timeout is set to 1 second but can be changed either by using
+the ``AIOSMTPD_CONTROLLER_TIMEOUT`` environment variable or by passing a
+different ``ready_timeout`` duration to the Controller's constructor.
+
 Connect to the server...
 
     >>> from smtplib import SMTP

--- a/aiosmtpd/docs/controller.rst
+++ b/aiosmtpd/docs/controller.rst
@@ -26,7 +26,7 @@ SMTP connections in the separate thread.
     >>> controller = Controller(MessageHandler())
     >>> controller.start()
 
-The SMTP thread might run into errors during it's setup phase, to catch this
+The SMTP thread might run into errors during its setup phase; to catch this
 the main thread will timeout when waiting for the SMTP server to become ready.
 By default the timeout is set to 1 second but can be changed either by using
 the ``AIOSMTPD_CONTROLLER_TIMEOUT`` environment variable or by passing a

--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -1,6 +1,7 @@
 """Test other aspects of the server implementation."""
 
 
+import socket
 import unittest
 
 from aiosmtpd.controller import Controller
@@ -38,3 +39,12 @@ class TestServer(unittest.TestCase):
         server = Server(Sink())
         server.command_size_limits['DATA'] = 1024
         self.assertEqual(server.max_command_size_limit, 1024)
+
+    def test_socket_error(self):
+        # Testing starting a server with a port already in use
+        s1 = UTF8Controller(Sink(), port=8025)
+        s2 = UTF8Controller(Sink(), port=8025)
+        self.addCleanup(s1.stop)
+        self.addCleanup(s2.stop)
+        s1.start()
+        self.assertRaises(socket.error, s2.start)


### PR DESCRIPTION
Simple fix for https://github.com/aio-libs/aiosmtpd/issues/35

~~Currently the timeout is opt-in, you might want to consider adding a default value to it if it works out well.~~