### PR TITLE
Assign Controller server to the server instance variable

### DIFF
--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -42,12 +42,12 @@ class Controller:
         sock = self.make_socket()
         sock.bind((self.hostname, self.port))
         asyncio.set_event_loop(self.loop)
-        server = self.loop.run_until_complete(
+        self.server = self.loop.run_until_complete(
             self.loop.create_server(self.factory, sock=sock))
         self.loop.call_soon(ready_event.set)
         self.loop.run_forever()
-        server.close()
-        self.loop.run_until_complete(server.wait_closed())
+        self.server.close()
+        self.loop.run_until_complete(self.server.wait_closed())
         self.loop.close()
 
     def start(self):


### PR DESCRIPTION
By exposing the server you enable, among other things, the possibility to use any available port by binding to port 0 and then getting it from the socket.

```
cont = Controller(handler, port=0)
cont.start()
port = cont.server.sockets[0].getsockname()[1]
```

However, I'm not sure whether or not `asyncio.Server` is thread-safe or not so this might be a no go. Perhaps that's even why the server wasn't assigned to the instance variable in the first place?