### PR TITLE
Crossplatform  Windows compatibility

### DIFF
--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -8,8 +8,8 @@ from public import public
 
 try:
     from socket import socketpair
-except ImportError:
-    from asyncio.windows_utils import socketpair  # pragma: nocover
+except ImportError:                                          # pragma: nocover
+    from asyncio.windows_utils import socketpair
 
 
 @public

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -1,4 +1,3 @@
-import socket
 import asyncio
 import threading
 

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -16,7 +16,7 @@ class Controller:
         self.loop = asyncio.new_event_loop() if loop is None else loop
         self.thread = None
         # For exiting the loop.
-        self._rsock, self._wsock = socket.socketpair()
+        self._rsock, self._wsock = self.loop._socketpair()
         self.loop.add_reader(self._rsock, self._reader)
 
     def _reader(self):

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -6,6 +6,11 @@ import threading
 from aiosmtpd.smtp import SMTP
 from public import public
 
+try:
+    from socket import socketpair
+except ImportError:
+    from asyncio.windows_utils import socketpair  # pragma: nocover
+
 
 @public
 class Controller:
@@ -21,7 +26,7 @@ class Controller:
         self.ready_timeout = os.getenv(
             'AIOSMTPD_CONTROLLER_TIMEOUT', ready_timeout)
         # For exiting the loop.
-        self._rsock, self._wsock = self.loop._socketpair()
+        self._rsock, self._wsock = socketpair()
         self.loop.add_reader(self._rsock, self._reader)
 
     def _reader(self):

--- a/aiosmtpd/main.py
+++ b/aiosmtpd/main.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import signal
-import socket
 import asyncio
 import logging
 

--- a/aiosmtpd/main.py
+++ b/aiosmtpd/main.py
@@ -126,10 +126,10 @@ def main(args=None):
     if args.debug > 2:
         loop.set_debug(enabled=True)
 
-    sock = setup_sock(args.host, args.port)
     log.info('Server listening on %s:%s', args.host, args.port)
 
-    server = loop.run_until_complete(loop.create_server(factory, sock=sock))
+    server = loop.run_until_complete(
+        loop.create_server(factory, host=args.host, port=args.port))
     loop.add_signal_handler(signal.SIGINT, loop.stop)
 
     log.info('Starting asyncio loop')
@@ -141,47 +141,6 @@ def main(args=None):
     log.info('Completed asyncio loop')
     loop.run_until_complete(server.wait_closed())
     loop.close()
-
-
-def setup_sock(host, port):
-    try:
-        # First try to determine the socket type.
-        info = socket.getaddrinfo(
-            host, port,
-            socket.AF_UNSPEC,
-            socket.SOCK_STREAM,
-            0,
-            socket.AI_PASSIVE,
-            )
-    except socket.gaierror:
-        # Infer the type from the host.
-        addr = host, port
-        if ':' in host:
-            addr += 0, 0
-            type_ = socket.AF_INET6
-        else:
-            type_ = socket.AF_INET
-        info_0 = type_, socket.SOCK_STREAM, 0, '', addr
-        info = info_0,
-
-    family, type, proto, canonname, addr = next(iter(info))
-    sock = bind(family, type, proto)
-    log = logging.getLogger('mail.log')
-    log.info('Binding to %s', addr)
-    sock.bind(addr)
-    return sock
-
-
-def bind(family, type, proto):
-    """Create (or recreate) the actual socket object."""
-    sock = socket.socket(family, type, proto)
-    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, True)
-
-    # If listening on IPv6, activate dual-stack.
-    if family == socket.AF_INET6:
-        sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, False)
-
-    return sock
 
 
 if __name__ == '__main__':                          # pragma: nocover

--- a/aiosmtpd/tests/test_main.py
+++ b/aiosmtpd/tests/test_main.py
@@ -183,9 +183,7 @@ class TestLoop(unittest.TestCase):
         self.assertEqual(positional[0].keywords, dict(
             data_size_limit=None,
             enable_SMTPUTF8=False))
-        keywords = list(keywords)
-        keywords.sort()
-        self.assertListEqual(keywords, ['host', 'port'])
+        self.assertListEqual(sorted(keywords), ['host', 'port'])
         # run_until_complete() was called once.  The argument isn't important.
         self.assertTrue(self.run_until_complete.called)
         # add_signal_handler() is called with two arguments.

--- a/aiosmtpd/tests/test_main.py
+++ b/aiosmtpd/tests/test_main.py
@@ -10,7 +10,7 @@ from aiosmtpd.smtp import SMTP
 from contextlib import ExitStack
 from functools import partial
 from io import StringIO
-from unittest.mock import call, patch
+from unittest.mock import patch
 
 try:
     import pwd

--- a/aiosmtpd/tests/test_main.py
+++ b/aiosmtpd/tests/test_main.py
@@ -1,11 +1,11 @@
+import os
 import signal
-import socket
 import asyncio
 import logging
 import unittest
 
 from aiosmtpd.handlers import Debugging
-from aiosmtpd.main import main, parseargs, setup_sock
+from aiosmtpd.main import main, parseargs
 from aiosmtpd.smtp import SMTP
 from contextlib import ExitStack
 from functools import partial
@@ -17,6 +17,7 @@ try:
 except ImportError:
     pwd = None
 
+set_uid = getattr(os, 'setuid', None)
 
 log = logging.getLogger('mail.log')
 
@@ -83,6 +84,7 @@ class TestMain(unittest.TestCase):
                 stderr.getvalue(),
                 'Cannot import module "pwd"; try running with -n option.\n')
 
+    @unittest.skipIf(set_uid is None, 'setuid is unvailable')
     def test_n(self):
         with ExitStack() as resources:
             resources.enter_context(patch('aiosmtpd.main.pwd', None))
@@ -95,6 +97,7 @@ class TestMain(unittest.TestCase):
             # triggered in the setuid section.
             self.assertRaises(RuntimeError, main, ('-n',))
 
+    @unittest.skipIf(set_uid is None, 'setuid is unvailable')
     def test_nosetuid(self):
         with ExitStack() as resources:
             resources.enter_context(patch('aiosmtpd.main.pwd', None))
@@ -181,7 +184,9 @@ class TestLoop(unittest.TestCase):
         self.assertEqual(positional[0].keywords, dict(
             data_size_limit=None,
             enable_SMTPUTF8=False))
-        self.assertEqual(list(keywords), ['sock'])
+        keywords = list(keywords)
+        keywords.sort()
+        self.assertListEqual(keywords, ['host', 'port'])
         # run_until_complete() was called once.  The argument isn't important.
         self.assertTrue(self.run_until_complete.called)
         # add_signal_handler() is called with two arguments.
@@ -307,40 +312,3 @@ class TestParseArgs(unittest.TestCase):
             self.assertEqual(cm.exception.code, 2)
         usage_lines = stderr.getvalue().splitlines()
         self.assertEqual(usage_lines[-1][-24:], 'Invalid port number: foo')
-
-
-class TestSocket(unittest.TestCase):
-    # Usually the socket will be set up from socket.getaddrinfo() but if that
-    # raises socket.gaierror, then it tries to infer the IPv4/IPv6 type from
-    # the host name.
-    def setUp(self):
-        self._resources = ExitStack()
-        self.addCleanup(self._resources.close)
-        self._resources.enter_context(patch('aiosmtpd.main.socket.getaddrinfo',
-                                            side_effect=socket.gaierror))
-
-    def test_ipv4(self):
-        bind = self._resources.enter_context(patch('aiosmtpd.main.bind'))
-        mock_sock = setup_sock('host.example.com', 8025)
-        bind.assert_called_once_with(socket.AF_INET, socket.SOCK_STREAM, 0)
-        mock_sock.bind.assert_called_once_with(('host.example.com', 8025))
-
-    def test_ipv6(self):
-        bind = self._resources.enter_context(patch('aiosmtpd.main.bind'))
-        mock_sock = setup_sock('::1', 8025)
-        bind.assert_called_once_with(socket.AF_INET6, socket.SOCK_STREAM, 0)
-        mock_sock.bind.assert_called_once_with(('::1', 8025, 0, 0))
-
-    def test_bind_ipv4(self):
-        self._resources.enter_context(patch('aiosmtpd.main.socket.socket'))
-        mock_sock = setup_sock('host.example.com', 8025)
-        mock_sock.setsockopt.assert_called_once_with(
-            socket.SOL_SOCKET, socket.SO_REUSEADDR, True)
-
-    def test_bind_ipv6(self):
-        self._resources.enter_context(patch('aiosmtpd.main.socket.socket'))
-        mock_sock = setup_sock('::1', 8025)
-        self.assertEqual(mock_sock.setsockopt.call_args_list, [
-            call(socket.SOL_SOCKET, socket.SO_REUSEADDR, True),
-            call(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, False),
-            ])

--- a/aiosmtpd/tests/test_main.py
+++ b/aiosmtpd/tests/test_main.py
@@ -17,8 +17,7 @@ try:
 except ImportError:
     pwd = None
 
-set_uid = getattr(os, 'setuid', None)
-
+has_setuid = hasattr(os, 'setuid')
 log = logging.getLogger('mail.log')
 
 
@@ -84,7 +83,7 @@ class TestMain(unittest.TestCase):
                 stderr.getvalue(),
                 'Cannot import module "pwd"; try running with -n option.\n')
 
-    @unittest.skipIf(set_uid is None, 'setuid is unvailable')
+    @unittest.skipUnless(has_setuid, 'setuid is unvailable')
     def test_n(self):
         with ExitStack() as resources:
             resources.enter_context(patch('aiosmtpd.main.pwd', None))
@@ -97,7 +96,7 @@ class TestMain(unittest.TestCase):
             # triggered in the setuid section.
             self.assertRaises(RuntimeError, main, ('-n',))
 
-    @unittest.skipIf(set_uid is None, 'setuid is unvailable')
+    @unittest.skipUnless(has_setuid, 'setuid is unvailable')
     def test_nosetuid(self):
         with ExitStack() as resources:
             resources.enter_context(patch('aiosmtpd.main.pwd', None))

--- a/aiosmtpd/tests/test_main.py
+++ b/aiosmtpd/tests/test_main.py
@@ -183,7 +183,7 @@ class TestLoop(unittest.TestCase):
         self.assertEqual(positional[0].keywords, dict(
             data_size_limit=None,
             enable_SMTPUTF8=False))
-        self.assertListEqual(sorted(keywords), ['host', 'port'])
+        self.assertEqual(sorted(keywords), ['host', 'port'])
         # run_until_complete() was called once.  The argument isn't important.
         self.assertTrue(self.run_until_complete.called)
         # add_signal_handler() is called with two arguments.

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -35,7 +35,7 @@ class ReceivingHandler:
 
 
 class SizedController(Controller):
-    def __init__(self, handler, size, loop=None, hostname='::0', port=8025):
+    def __init__(self, handler, size, loop=None, hostname='::1', port=8025):
         self.size = size
         super().__init__(handler, loop, hostname, port)
 

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -37,9 +37,9 @@ class ReceivingHandler:
 
 
 class SizedController(Controller):
-    def __init__(self, handler, size, loop=None, hostname='::1', port=8025):
+    def __init__(self, handler, size):
         self.size = size
-        super().__init__(handler, loop, hostname, port)
+        super().__init__(handler)
 
     def factory(self):
         return Server(self.handler, data_size_limit=self.size)


### PR DESCRIPTION
Removed socket opening code to rely on asyncio more complicated solution.
+ setuid test skip if it is unavailable (on Windows)
+ Windows compatible asyncio-way socket pair creation
After this tests are passed on Windows with python 3.4/3.5.