### PR TITLE
Suppress possible output to the console during the test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ skip_missing_interpreters = True
 [testenv]
 commands =
     nocov: python -m nose2 -v {posargs}
-    {cov,diffcov}: python -m coverage run {[coverage]rc} -m nose2 -v
+    {cov,diffcov}: python -m coverage run {[coverage]rc} -m nose2
     {cov,diffcov}: python -m coverage combine {[coverage]rc}
     cov: python -m coverage html {[coverage]rc}
     cov: python -m coverage report -m {[coverage]rc} --fail-under=99


### PR DESCRIPTION
Also, don't be so verbose when coverage testing.