### PR TITLE
Data command fix

### DIFF
--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -533,7 +533,8 @@ class SMTP(asyncio.StreamReaderProtocol):
         while not self._connection_closed:          # pragma: no branch
             line = yield from self._reader.readline()
             if line == b'.\r\n':
-                data[-1] = data[-1].rstrip(b'\r\n')
+                if data:
+                    data[-1] = data[-1].rstrip(b'\r\n')
                 break
             num_bytes += len(line)
             if (not size_exceeded and


### PR DESCRIPTION
Hey! I watchng on you )

RFC 5321 4.1.1.4.  DATA (DATA)
The mail data are terminated by a line containing only a period, that
is, the character sequence "<CRLF>.<CRLF>", where the first <CRLF> is
actually the terminator of the previous line

So, empty email will raise IndexError exception with your last changes.
I`m lazy ass to not adding a test for that.