### PR TITLE
Rename STARTTLS handling method

### DIFF
--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -14,7 +14,7 @@
 * Controller objects now have an optional timeout argument used to wait for
   the server to become ready.  This can also be overridden with the
   environment variable ``AIOSMTPD_CONTROLLER_TIMEOUT``. (Closes #35)
-* Handlers can define a ``handle_tls_handshake()`` method, which takes a
+* Handlers can define a ``handle_STARTTLS()`` method, which takes a
   session object, and is called if SSL is enabled during the making of the
   connection.  (Closes #48)
 * Better Python 3.4 compatibility.

--- a/aiosmtpd/docs/smtp.rst
+++ b/aiosmtpd/docs/smtp.rst
@@ -108,7 +108,7 @@ Handlers can implement a few hooks that get called during the ``SMTP`` dialog,
 or in exceptional cases.  More hooks may be added in the future, but for now
 the following handler hooks are defined:
 
-``handle_tls_handshake(session)``
+``handle_STARTTLS(session)``
     (*optional*, *synchronous*) If implemented, and if SSL is supported, this
     handler method gets called during the TLS handshake phase of
     ``connection_made()``.  It should return a boolean which specifies whether

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -124,8 +124,8 @@ class SMTP(asyncio.StreamReaderProtocol):
             # Do SSL certificate checking as rfc3207 part 4.1 says.
             # Why _extra is protected attribute?
             self.session.ssl = self._tls_protocol._extra
-            if hasattr(self.event_handler, 'handle_tls_handshake'):
-                auth = self.event_handler.handle_tls_handshake(self.session)
+            if hasattr(self.event_handler, 'handle_STARTTLS'):
+                auth = self.event_handler.handle_STARTTLS(self.session)
                 self._tls_handshake_failed = not auth
             else:
                 self._tls_handshake_failed = False

--- a/aiosmtpd/tests/test_starttls.py
+++ b/aiosmtpd/tests/test_starttls.py
@@ -1,4 +1,3 @@
-import asyncio
 import unittest
 import pkg_resources
 

--- a/aiosmtpd/tests/test_starttls.py
+++ b/aiosmtpd/tests/test_starttls.py
@@ -24,13 +24,11 @@ class Controller(BaseController):
 
 
 class ReceivingHandler:
-    box = None
+    def __init__(self):
+        self.box = []
 
-    @asyncio.coroutine
-    def process_message(self, *args, **kws):
-        if not self.box:
-            self.box = []
-        self.box.append(args)
+    def handle_DATA(self, session, envelope):
+        self.box.append(envelope)
 
 
 def get_tls_context():
@@ -61,7 +59,7 @@ class TLSController(Controller):
 
 class HandshakeFailingHandler:
     @staticmethod
-    def handle_tls_handshake(session):
+    def handle_STARTTLS(session):
         return False
 
 

--- a/aiosmtpd/tests/test_starttls.py
+++ b/aiosmtpd/tests/test_starttls.py
@@ -1,3 +1,4 @@
+import asyncio
 import unittest
 import pkg_resources
 
@@ -26,6 +27,7 @@ class ReceivingHandler:
     def __init__(self):
         self.box = []
 
+    @asyncio.coroutine
     def handle_DATA(self, session, envelope):
         self.box.append(envelope)
 


### PR DESCRIPTION
After handle_DATA method, may be its better to rename handle_tls_handshake too?