### PR TITLE
Generic hook mechanism

### DIFF
--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -4,8 +4,11 @@
 
 1.0a5 (201X-XX-XX)
 ==================
-* Deprecate handler `process_message()` methods.  Use the new asynchronous
-  `handle_DATA()` methods, which take a session and an envelope object.
+* A new handler hook API has been added which provides more flexibility but
+  requires more responsibility (e.g. hooks must return a string status).
+  Deprecate ``SMTP.ehlo_hook()`` and ``SMTP.rset_hook()``.
+* Deprecate handler ``process_message()`` methods.  Use the new asynchronous
+  ``handle_DATA()`` methods, which take a session and an envelope object.
 * Added the ``STARTTLS`` extension.  Given by Konstantin Volkov.
 * Minor changes to the way the ``Debugging`` handler prints ``mail_options``
   and ``rcpt_options`` (although the latter is still not support in ``SMTP``).

--- a/aiosmtpd/docs/smtp.rst
+++ b/aiosmtpd/docs/smtp.rst
@@ -162,9 +162,18 @@ The following hooks are currently defined:
     Called during ``RSET``.
 
 ``handle_DATA(session, envelope)``
-    Called during ``DATA`` after the entire message ("SMTP content" as
-    described in RFC 5321) has been received.  Hooks can inspect or change the
-    converted data by looking at ``envelope.content``.
+    Called during ``DATA`` after the entire message (`"SMTP content"
+    <https://tools.ietf.org/html/rfc5321#section-2.3.9>`_ as described in
+    RFC 5321) has been received.  The content is available on the ``envelope``
+    object, but the values are dependent on whether the ``SMTP`` class was
+    instantiated with ``decode_data=False`` (the default) or
+    ``decode_data=True``.  In the former case, both ``envelope.content`` and
+    ``envelope.original_content`` will be the content bytes (normalized
+    according to the transparency rules in `RFC 5321, $4.5.2
+    <https://tools.ietf.org/html/rfc5321#section-4.5.2>`_).  In the latter
+    case, ``envelope.original_content`` will be the normalized bytes, but
+    ``envelope.content`` will be the UTF-8 decoded string of the original
+    content.
 
 In addition to the SMTP command hooks, the following hooks can also be
 implemented by handlers.  They have a different signature and don't need to

--- a/aiosmtpd/docs/smtp.rst
+++ b/aiosmtpd/docs/smtp.rst
@@ -81,6 +81,9 @@ incremented.
 Server hooks
 ============
 
+.. warning:: These methods are deprecated.  :ref:`handler hooks <hooks>`
+             instead.
+
 The ``SMTP`` server class also implements some hooks which your subclass can
 override to provide additional responses.
 
@@ -104,9 +107,68 @@ override to provide additional responses.
 Handler hooks
 =============
 
-Handlers can implement a few hooks that get called during the ``SMTP`` dialog,
-or in exceptional cases.  More hooks may be added in the future, but for now
-the following handler hooks are defined:
+Handlers can implement a hooks that get called during the ``SMTP`` dialog, or
+in exceptional cases.  These *handler hooks* are all called asynchronously and
+they *must* return a status string, since the default statuses are *not*
+returned when a hook is defined.  Individual handlers may have additional
+responsibilities to replace default behavior, as described below.
+
+All handler hooks take at least three arguments, the ``SMTP`` server instance,
+:ref:`a session instance, and an envelope instance <sessions_and_envelopes>`.
+Some methods take additional arguments.
+
+The following hooks are currently defined:
+
+``handle_HELO(server, session, envelope, hostname)``
+    Called during ``HELO``, the ``hostname`` argument is the host name given
+    by the client in the ``HELO`` command.  If implemented, this hook must
+    also set the ``session.host_name`` attribute.
+
+``handle_EHLO(server, session, envelope, hostname)``
+    Called during ``EHLO``, the ``hostname`` argument is the host name given
+    by the client in the ``EHLO`` command.  If implemented, this hook must
+    also set the ``session.host_name`` attribute.  This hook may push
+    additional ``250-<command>`` responses to the client by yielding from
+    ``server.push(status)``.
+
+``handle_NOOP(server, session, envelope)``
+    Called during ``NOOP``.
+
+``handle_QUIT(server, session, envelope)``
+    Called during ``QUIT``.
+
+``handle_VRFY(server, session, envelope, address)``
+    Called during ``VRFY``, the ``address`` argument is the parsed email
+    address given by the client in the ``VRFY`` command.
+
+``handle_MAIL(server, session, envelope, address, mail_options)``
+    Called during ``MAIL FROM``, the ``address`` argument is the parsed email
+    address given by the client in the ``MAIL FROM`` command, and
+    ``mail_options`` are any additional ESMTP mail options providing by the
+    client.  If implemented, this hook must also set the
+    ``envelope.mail_from`` attribute and it may extend
+    ``envelope.mail_options`` (which is always a Python list).
+
+``handle_RCPT(server, session, envelope, address, rcpt_options)``
+    Called during ``RCPT TO``, the ``address`` argument is the parsed email
+    address given by the client in the ``RCPT TO`` command, and
+    ``rcpt_options`` are any additional ESMTP recipient options providing by
+    the client.  If implemented, this hook should append the address to
+    ``envelope.rcpt_tos`` and may extend ``envelope.rcpt_options`` (both of
+    which are always Python lists).
+
+``handle_RSET(server, session, envelope)``
+    Called during ``RSET``.
+
+``handle_DATA(session, envelope)``
+    Called during ``DATA`` after most processing of the data has occurred.
+    Hooks can inspect the converted 
+
+    This method is called on the handler so that
+    it can process the incoming ``DATA`` bytes.  The ``session`` and
+    ``envelope`` arguments are described below.  It returns the status string
+    to pass back to the client.  If status is not given (e.g. it is None),
+    then the string ``"250 OK"`` is used as the status.
 
 ``handle_tls_handshake(session)``
     (*optional*, *synchronous*) If implemented, and if SSL is supported, this
@@ -122,13 +184,9 @@ the following handler hooks are defined:
     passed in.  Note that as part of the ``SMTP`` dialog, if an exception
     occurs, a 500 code will be returned to the client.
 
-``handle_DATA(session, envelope)``
-    (*required*, *asynchronous*) This method is called on the handler so that
-    it can process the incoming ``DATA`` bytes.  The ``session`` and
-    ``envelope`` arguments are described below.  It returns the status string
-    to pass back to the client.  If status is not given (e.g. it is None),
-    then the string ``"250 OK"`` is used as the status.
 
+
+.. _sessions_and_envelopes:
 
 Sessions and envelopes
 ======================

--- a/aiosmtpd/docs/smtp.rst
+++ b/aiosmtpd/docs/smtp.rst
@@ -162,28 +162,24 @@ The following hooks are currently defined:
 
 ``handle_DATA(session, envelope)``
     Called during ``DATA`` after most processing of the data has occurred.
-    Hooks can inspect the converted 
+    Hooks can inspect or change the converted data by looking at
+    ``envelope.content``.
 
-    This method is called on the handler so that
-    it can process the incoming ``DATA`` bytes.  The ``session`` and
-    ``envelope`` arguments are described below.  It returns the status string
-    to pass back to the client.  If status is not given (e.g. it is None),
-    then the string ``"250 OK"`` is used as the status.
+In addition to the SMTP command hooks, the following hooks can also be
+implemented by handlers.  They have a different signature and don't need to
+return any status.  Both methods are called synchronously.
 
 ``handle_tls_handshake(session)``
-    (*optional*, *synchronous*) If implemented, and if SSL is supported, this
-    handler method gets called during the TLS handshake phase of
-    ``connection_made()``.  It should return a boolean which specifies whether
-    the handshake failed or not.  ``session`` is an instance of the Session_
-    object.
+    If implemented, and if SSL is supported, this handler method gets called
+    during the TLS handshake phase of ``connection_made()``.  It should return
+    a boolean which specifies whether the handshake failed or not.
 
 ``handle_exception(error)``
-    (*optional*, *synchronous*) If implemented, this method is called when any
-    error occurs during the handling of a connection (e.g. if an
-    ``smtp_COMMAND()`` command raises an exception).  The exception object is
-    passed in.  Note that as part of the ``SMTP`` dialog, if an exception
-    occurs, a 500 code will be returned to the client.
-
+    If implemented, this method is called when any error occurs during the
+    handling of a connection (e.g. if an ``smtp_<command>()`` method raises an
+    exception).  The exception object is passed in.  Note that as part of the
+    ``SMTP`` dialog, if an exception occurs, a 500 code will be returned to
+    the client.
 
 
 .. _sessions_and_envelopes:

--- a/aiosmtpd/docs/smtp.rst
+++ b/aiosmtpd/docs/smtp.rst
@@ -107,11 +107,12 @@ override to provide additional responses.
 Handler hooks
 =============
 
-Handlers can implement a hooks that get called during the ``SMTP`` dialog, or
-in exceptional cases.  These *handler hooks* are all called asynchronously and
-they *must* return a status string, since the default statuses are *not*
-returned when a hook is defined.  Individual handlers may have additional
-responsibilities to replace default behavior, as described below.
+Handlers can implement hooks that get called during the SMTP dialog, or in
+exceptional cases.  These *handler hooks* are all called asynchronously and
+they *must* return a status string, such as ``'250 OK'``.  All handler hooks
+are optional and certain default behaviors are carried out by the ``SMTP``
+class when a hook is omitted, but when handler hooks are defined, they may
+have additional responsibilities, as described below.
 
 All handler hooks take at least three arguments, the ``SMTP`` server instance,
 :ref:`a session instance, and an envelope instance <sessions_and_envelopes>`.
@@ -120,16 +121,16 @@ Some methods take additional arguments.
 The following hooks are currently defined:
 
 ``handle_HELO(server, session, envelope, hostname)``
-    Called during ``HELO``, the ``hostname`` argument is the host name given
+    Called during ``HELO``.  The ``hostname`` argument is the host name given
     by the client in the ``HELO`` command.  If implemented, this hook must
     also set the ``session.host_name`` attribute.
 
 ``handle_EHLO(server, session, envelope, hostname)``
-    Called during ``EHLO``, the ``hostname`` argument is the host name given
+    Called during ``EHLO``.  The ``hostname`` argument is the host name given
     by the client in the ``EHLO`` command.  If implemented, this hook must
     also set the ``session.host_name`` attribute.  This hook may push
     additional ``250-<command>`` responses to the client by yielding from
-    ``server.push(status)``.
+    ``server.push(status)`` before returning ``250 OK`` as the final response.
 
 ``handle_NOOP(server, session, envelope)``
     Called during ``NOOP``.
@@ -138,11 +139,11 @@ The following hooks are currently defined:
     Called during ``QUIT``.
 
 ``handle_VRFY(server, session, envelope, address)``
-    Called during ``VRFY``, the ``address`` argument is the parsed email
+    Called during ``VRFY``.  The ``address`` argument is the parsed email
     address given by the client in the ``VRFY`` command.
 
 ``handle_MAIL(server, session, envelope, address, mail_options)``
-    Called during ``MAIL FROM``, the ``address`` argument is the parsed email
+    Called during ``MAIL FROM``.  The ``address`` argument is the parsed email
     address given by the client in the ``MAIL FROM`` command, and
     ``mail_options`` are any additional ESMTP mail options providing by the
     client.  If implemented, this hook must also set the
@@ -150,7 +151,7 @@ The following hooks are currently defined:
     ``envelope.mail_options`` (which is always a Python list).
 
 ``handle_RCPT(server, session, envelope, address, rcpt_options)``
-    Called during ``RCPT TO``, the ``address`` argument is the parsed email
+    Called during ``RCPT TO``.  The ``address`` argument is the parsed email
     address given by the client in the ``RCPT TO`` command, and
     ``rcpt_options`` are any additional ESMTP recipient options providing by
     the client.  If implemented, this hook should append the address to
@@ -161,9 +162,9 @@ The following hooks are currently defined:
     Called during ``RSET``.
 
 ``handle_DATA(session, envelope)``
-    Called during ``DATA`` after most processing of the data has occurred.
-    Hooks can inspect or change the converted data by looking at
-    ``envelope.content``.
+    Called during ``DATA`` after the entire message ("SMTP content" as
+    described in RFC 5321) has been received.  Hooks can inspect or change the
+    converted data by looking at ``envelope.content``.
 
 In addition to the SMTP command hooks, the following hooks can also be
 implemented by handlers.  They have a different signature and don't need to

--- a/aiosmtpd/handlers.py
+++ b/aiosmtpd/handlers.py
@@ -65,7 +65,7 @@ class Debugging:
             print(line, file=self.stream)
 
     @asyncio.coroutine
-    def handle_DATA(self, session, envelope):
+    def handle_DATA(self, server, session, envelope):
         print('---------- MESSAGE FOLLOWS ----------', file=self.stream)
         # Yes, actually test for truthiness since it's possible for either the
         # keywords to be missing, or for their values to be empty lists.
@@ -91,7 +91,7 @@ class Proxy:
         self._port = remote_port
 
     @asyncio.coroutine
-    def handle_DATA(self, session, envelope):
+    def handle_DATA(self, server, session, envelope):
         lines = envelope.content.splitlines(keepends=True)
         # Look for the last header
         i = 0
@@ -139,10 +139,6 @@ class Sink:
             parser.error('Sink handler does not accept arguments')
         return cls()
 
-    @asyncio.coroutine
-    def handle_DATA(self, session, envelope):
-        pass                                        # pragma: nocover
-
 
 @public
 class Message:
@@ -150,9 +146,10 @@ class Message:
         self.message_class = message_class
 
     @asyncio.coroutine
-    def handle_DATA(self, session, envelope):
+    def handle_DATA(self, server, session, envelope):
         envelope = self.prepare_message(session, envelope)
         self.handle_message(envelope)
+        return '250 OK'
 
     def prepare_message(self, session, envelope):
         # If the server was created with decode_data True, then data will be a
@@ -180,7 +177,7 @@ class AsyncMessage(Message):
         self.loop = loop or asyncio.get_event_loop()
 
     @asyncio.coroutine
-    def handle_DATA(self, session, envelope):
+    def handle_DATA(self, server, session, envelope):
         message = self.prepare_message(session, envelope)
         yield from self.handle_message(message)
 

--- a/aiosmtpd/handlers.py
+++ b/aiosmtpd/handlers.py
@@ -82,6 +82,7 @@ class Debugging:
             print(file=self.stream)
         self._print_message_content(session.peer, envelope.content)
         print('------------ END MESSAGE ------------', file=self.stream)
+        return '250 OK'
 
 
 @public
@@ -106,6 +107,7 @@ class Proxy:
         refused = self._deliver(envelope.mail_from, envelope.rcpt_tos, data)
         # TBD: what to do with refused addresses?
         log.info('we got some refusals: %s', refused)
+        return '250 OK'
 
     def _deliver(self, mail_from, rcpt_tos, data):
         refused = {}
@@ -180,6 +182,7 @@ class AsyncMessage(Message):
     def handle_DATA(self, server, session, envelope):
         message = self.prepare_message(session, envelope)
         yield from self.handle_message(message)
+        return '250 OK'
 
     @asyncio.coroutine
     def handle_message(self, message):

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -575,10 +575,11 @@ class SMTP(asyncio.StreamReaderProtocol):
             text = data[i]
             if text and text[:1] == b'.':
                 data[i] = text[1:]
-        received_data = EMPTYBYTES.join(data)
+        content = original_content = EMPTYBYTES.join(data)
         if self._decode_data:
-            received_data = received_data.decode('utf-8')
-        self.envelope.content = received_data
+            content = original_content.decode('utf-8')
+        self.envelope.content = content
+        self.envelope.original_content = original_content
         # Call the new API first if it's implemented.
         if hasattr(self.event_handler, 'handle_DATA'):
             status = yield from self._call_handler_hook('DATA')

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -255,7 +255,6 @@ class SMTP(asyncio.StreamReaderProtocol):
         yield from self.push(status)
 
     @asyncio.coroutine
-    @asyncio.coroutine
     def smtp_EHLO(self, hostname):
         if not hostname:
             yield from self.push('501 Syntax: EHLO hostname')

--- a/aiosmtpd/tests/test_handlers.py
+++ b/aiosmtpd/tests/test_handlers.py
@@ -506,6 +506,7 @@ class RCPTHandler:
         envelope.rcpt_options.extend(options)
         if address == 'bart@example.com':
             return '550 Rejected'
+        envelope.rcpt_tos.append(address)
         return '250 OK'
 
 

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -681,9 +681,9 @@ Subject: A test
 
 Testing
 """)
-                self.assertEqual(cm.exception.code, 499)
-                self.assertEqual(cm.exception.response,
-                                 b'Could not accept the message')
+            self.assertEqual(cm.exception.smtp_code, 499)
+            self.assertEqual(cm.exception.smtp_error,
+                             b'Could not accept the message')
 
     def test_too_long_message_body(self):
         controller = SizedController(Sink(), size=100)
@@ -748,7 +748,7 @@ Testing
 
 class TestCustomizations(unittest.TestCase):
     def test_custom_hostname(self):
-        controller = CustomHostnameController(Sink)
+        controller = CustomHostnameController(Sink())
         controller.start()
         self.addCleanup(controller.stop)
         with SMTP(controller.hostname, controller.port) as client:
@@ -757,7 +757,7 @@ class TestCustomizations(unittest.TestCase):
             self.assertEqual(response, bytes('custom.localhost', 'utf-8'))
 
     def test_custom_greeting(self):
-        controller = CustomIdentController(Sink)
+        controller = CustomIdentController(Sink())
         controller.start()
         self.addCleanup(controller.stop)
         with SMTP() as client:
@@ -767,7 +767,7 @@ class TestCustomizations(unittest.TestCase):
             self.assertEqual(msg[-22:], b'Identifying SMTP v2112')
 
     def test_default_greeting(self):
-        controller = Controller(Sink)
+        controller = Controller(Sink())
         controller.start()
         self.addCleanup(controller.stop)
         with SMTP() as client:
@@ -777,7 +777,7 @@ class TestCustomizations(unittest.TestCase):
             self.assertEqual(msg[-len(GREETING):], bytes(GREETING, 'utf-8'))
 
     def test_mail_invalid_body_param(self):
-        controller = NoDecodeController(Sink)
+        controller = NoDecodeController(Sink())
         controller.start()
         self.addCleanup(controller.stop)
         with SMTP() as client:

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -34,6 +34,7 @@ class ReceivingHandler:
     @asyncio.coroutine
     def handle_DATA(self, server, session, envelope):
         self.box.append(envelope.content)
+        return '250 OK'
 
 
 class SizedController(Controller):

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -32,7 +32,7 @@ class ReceivingHandler:
         self.box = []
 
     @asyncio.coroutine
-    def handle_DATA(self, session, envelope):
+    def handle_DATA(self, server, session, envelope):
         self.box.append(envelope.content)
 
 
@@ -66,7 +66,7 @@ class ErroringHandler:
     error = None
 
     @asyncio.coroutine
-    def handle_DATA(self, session, envelope):
+    def handle_DATA(self, server, session, envelope):
         return '499 Could not accept the message'
 
     @asyncio.coroutine


### PR DESCRIPTION
As an alternative to #41 here's my rough idea for a generic hook mechanism.  This is a WIP with the intention of sparking discussion.  If this is acceptable, it still needs fleshing out (more hooks), NEWS, and documentation.

I tried to make this even more generic by building the calling of handler hooks into `_handle_client()` but that had several problems.  The most complicated is that it would not allow hooks to set different statuses without changing the API of existing `SMTP.smtp_*()` methods.  Well, with avoiding exceptions for error statuses, which is one of my main motivations for this over #41 

This branch maintains API compatibility while providing a generic hook API, similar to what was previously implemented in `handle_DATA()`.  I'm hoping this will solve @Mortal issue in #47 and will be acceptable to @kozzztik as an alternative to #41 

Feedback welcome!