### PR TITLE
Add test for changing SMTP.command_size_limit

### DIFF
--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -40,6 +40,12 @@ class TestServer(unittest.TestCase):
         server.command_size_limits['DATA'] = 1024
         self.assertEqual(server.max_command_size_limit, 1024)
 
+    def test_special_command_size_limit(self):
+        server = Server(Sink())
+        server.command_size_limit = 1024
+        self.assertEqual(server.max_command_size_limit, 1024)
+        self.assertEqual(server.command_size_limits['DATA'], 1024)
+
     def test_socket_error(self):
         # Testing starting a server with a port already in use
         s1 = UTF8Controller(Sink(), port=8025)


### PR DESCRIPTION
What is the intended semantics of SMTP.command_size_limit? Is the user supposed to be allowed to change it? Changing it does not actually change the size limit of any particular command since command_size_limits is a defaultdict with fixed default value 512 -- which the failing test in this PR demonstrates. This is a [relic from smtpd](https://github.com/aio-libs/aiosmtpd/commit/27468a20ff21aea95b27cc9c807e678c5fc1bfee#diff-6353db7a2e2e6a598843477863128a6cR121), and since smtpd doesn't document command_size_limit at all, this might be considered a private API.