### PR TITLE
Additional handlers (one more variant)

### DIFF
--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -148,6 +148,7 @@ class SMTP(asyncio.StreamReaderProtocol):
 
     def eof_received(self):
         self._handler_coroutine.cancel()
+        self._set_rset_state()
         return super().eof_received()
 
     def _set_post_data_state(self):
@@ -157,6 +158,8 @@ class SMTP(asyncio.StreamReaderProtocol):
 
     def _set_rset_state(self):
         """Reset all state variables except the greeting."""
+        if hasattr(self.event_handler, 'handle_RSET'):
+            self.event_handler.handle_RSET(self.session, self.envelope)
         self._set_post_data_state()
 
     @asyncio.coroutine
@@ -463,10 +466,15 @@ class SMTP(asyncio.StreamReaderProtocol):
             yield from self.push(
                 '555 MAIL FROM parameters not recognized or not implemented')
             return
-        self.envelope.mail_from = address
-        self.envelope.mail_options = mail_options
+        if hasattr(self.event_handler, 'handle_MAIL'):
+            status = yield from self.event_handler.handle_MAIL(
+                self.envelope, address, mail_options)
+        else:
+            self.envelope.mail_from = address
+            self.envelope.mail_options = mail_options
+            status = '250 OK'
         log.info('sender: %s', address)
-        yield from self.push('250 OK')
+        yield from self.push(status)
 
     @asyncio.coroutine
     def smtp_RCPT(self, arg):
@@ -501,10 +509,15 @@ class SMTP(asyncio.StreamReaderProtocol):
             yield from self.push(
                 '555 RCPT TO parameters not recognized or not implemented')
             return
-        self.envelope.rcpt_tos.append(address)
-        self.envelope.rcpt_options.append(rcpt_options)
+        if hasattr(self.event_handler, 'handle_RCPT'):
+            status = yield from self.event_handler.handle_MAIL(
+                self.envelope, address, rcpt_options)
+        else:
+            self.envelope.rcpt_tos.append(address)
+            self.envelope.rcpt_options.append(rcpt_options)
+            status = '250 OK'
         log.info('recip: %s', address)
-        yield from self.push('250 OK')
+        yield from self.push(status)
 
     @asyncio.coroutine
     def rset_hook(self):


### PR DESCRIPTION
Thats new variant of how handlers on RCPT and MAIL can be done. That is also adds right Proxy handler implementation. Its a draft so tests wouldn`t pass.

Main problem in #41 I tried to avoid was that I want to make user add custom recipient entities without any additional magic. Thats why in #41 handlers return entities, and they raised special exceptions to return custom response codes.
Here is another way: return status strings as usual, but if handler method is present it is up to method to correctly add entity on envelope.
Thats in addition to #55.