### PR TITLE
Allow handle_exception to return a non-500 response

### DIFF
--- a/aiosmtpd/docs/smtp.rst
+++ b/aiosmtpd/docs/smtp.rst
@@ -187,11 +187,10 @@ return any status.  Both methods are called synchronously.
 ``handle_exception(error)``
     If implemented, this method is called when any error occurs during the
     handling of a connection (e.g. if an ``smtp_<command>()`` method raises an
-    exception).  The exception object is passed in.  This method may return
+    exception).  The exception object is passed in.  This method *must* return
     a status string, such as ``'542 Internal server error'``.  If the method
-    returns ``None``, a 500 code will be returned to the client.  If the method
-    raises an exception, the exception raised by ``handle_exception`` will be
-    logged, and a 500 code will be returned to the client.
+    returns None or raises an exception, an exception will be logged, and a 500
+    code will be returned to the client.
 
 
 .. _sessions_and_envelopes:

--- a/aiosmtpd/docs/smtp.rst
+++ b/aiosmtpd/docs/smtp.rst
@@ -187,9 +187,11 @@ return any status.  Both methods are called synchronously.
 ``handle_exception(error)``
     If implemented, this method is called when any error occurs during the
     handling of a connection (e.g. if an ``smtp_<command>()`` method raises an
-    exception).  The exception object is passed in.  Note that as part of the
-    ``SMTP`` dialog, if an exception occurs, a 500 code will be returned to
-    the client.
+    exception).  The exception object is passed in.  This method may return
+    a status string, such as ``'542 Internal server error'``.  If the method
+    returns ``None``, a 500 code will be returned to the client.  If the method
+    raises an exception, the exception raised by ``handle_exception`` will be
+    logged, and a 500 code will be returned to the client.
 
 
 .. _sessions_and_envelopes:

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -280,7 +280,7 @@ class SMTP(asyncio.StreamReaderProtocol):
                     yield from self.push(status)
                 except Exception as error:
                     try:
-                        log.exception('Exception in handle_exception')
+                        log.exception('Exception in handle_exception()')
                         status = '500 Error: ({}) {}'.format(
                             error.__class__.__name__, str(error))
                     except Exception:

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -244,9 +244,12 @@ class SMTP(asyncio.StreamReaderProtocol):
                     status = yield from self.handle_exception(error)
                     yield from self.push(status)
                 except Exception as error:
-                    log.exception('Exception in handle_exception')
-                    status = '500 Error: ({}) {}'.format(
-                        error.__class__.__name__, str(error))
+                    try:
+                        log.exception('Exception in handle_exception')
+                        status = '500 Error: ({}) {}'.format(
+                            error.__class__.__name__, str(error))
+                    except Exception:
+                        status = '500 Error: Cannot describe error'
                     yield from self.push(status)
 
     # SMTP and ESMTP commands

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -92,7 +92,7 @@ class ErroringErrorHandler:
     @asyncio.coroutine
     def handle_exception(self, error):
         self.error = error
-        raise ValueError('exception handler failed to handle exception')
+        raise ValueError('ErroringErrorHandler test')
 
 
 class ErrorSMTP(Server):
@@ -795,7 +795,8 @@ Testing
                 SMTP(controller.hostname, controller.port))
             code, response = client.helo('example.com')
         self.assertEqual(code, 500)
-        self.assertEqual(response, b'Error: (ValueError) test')
+        self.assertEqual(response,
+                         b'Error: (ValueError) ErroringErrorHandler test')
         self.assertIsInstance(handler.error, ValueError)
 
 

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -73,6 +73,7 @@ class ErroringHandler:
     @asyncio.coroutine
     def handle_exception(self, error):
         self.error = error
+        return '500 ErroringHandler handling error'
 
 
 class ErroringHandlerCustomResponse:
@@ -743,7 +744,7 @@ Testing
                 SMTP(controller.hostname, controller.port))
             code, response = client.helo('example.com')
         self.assertEqual(code, 500)
-        self.assertEqual(response, b'Error: (ValueError) test')
+        self.assertEqual(response, b'ErroringHandler handling error')
         self.assertIsInstance(handler.error, ValueError)
 
     def test_unexpected_errors_unhandled(self):

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -825,7 +825,9 @@ Testing
             client = resources.enter_context(
                 SMTP(controller.hostname, controller.port))
             code, response = client.helo('example.com')
-        # TODO
+        self.assertEqual(code, 500)
+        self.assertEqual(response, b'Error: Cannot describe error')
+        self.assertIsInstance(handler.error, ValueError)
 
 
 class TestCustomizations(unittest.TestCase):


### PR DESCRIPTION
Is 500 the right response to an internal server error (uncaught exception)? The mailing list software I'm running sends `451 Requested action aborted: error in processing` and sends an email to me when an uncaught exception handles. The idea is that the message will be retried for up to five days while I take care of the exception, and since my mailing list only ever talks to the local Postfix server that actually receives email from the Internet, I can even flush the Postfix mail queue immediately after deploying any changes in order to minimize the delay in mail forwarding. With a 5xx response, such messages would instead get lost, so in my case I would definitely run with a 4xx response.

On the other hand, if you're just running aiosmtpd without having any developers to respond immediately to delivery errors, a 5xx response is warranted since you're less likely to have the bug fixed within five days.

(I came across this when reading through the docs for the new handler hooks.)