### PR TITLE
Connect session and envelope.

### DIFF
--- a/aiosmtpd/docs/smtp.rst
+++ b/aiosmtpd/docs/smtp.rst
@@ -120,29 +120,29 @@ Some methods take additional arguments.
 
 The following hooks are currently defined:
 
-``handle_HELO(server, session, envelope, hostname)``
+``handle_HELO(server, envelope, hostname)``
     Called during ``HELO``.  The ``hostname`` argument is the host name given
     by the client in the ``HELO`` command.  If implemented, this hook must
-    also set the ``session.host_name`` attribute.
+    also set the ``envelope.session.host_name`` attribute.
 
-``handle_EHLO(server, session, envelope, hostname)``
+``handle_EHLO(server, envelope, hostname)``
     Called during ``EHLO``.  The ``hostname`` argument is the host name given
     by the client in the ``EHLO`` command.  If implemented, this hook must
-    also set the ``session.host_name`` attribute.  This hook may push
+    also set the ``envelope.session.host_name`` attribute.  This hook may push
     additional ``250-<command>`` responses to the client by yielding from
     ``server.push(status)`` before returning ``250 OK`` as the final response.
 
-``handle_NOOP(server, session, envelope)``
+``handle_NOOP(server, envelope)``
     Called during ``NOOP``.
 
-``handle_QUIT(server, session, envelope)``
+``handle_QUIT(server, envelope)``
     Called during ``QUIT``.
 
-``handle_VRFY(server, session, envelope, address)``
+``handle_VRFY(server, envelope, address)``
     Called during ``VRFY``.  The ``address`` argument is the parsed email
     address given by the client in the ``VRFY`` command.
 
-``handle_MAIL(server, session, envelope, address, mail_options)``
+``handle_MAIL(server, envelope, address, mail_options)``
     Called during ``MAIL FROM``.  The ``address`` argument is the parsed email
     address given by the client in the ``MAIL FROM`` command, and
     ``mail_options`` are any additional ESMTP mail options providing by the
@@ -150,7 +150,7 @@ The following hooks are currently defined:
     ``envelope.mail_from`` attribute and it may extend
     ``envelope.mail_options`` (which is always a Python list).
 
-``handle_RCPT(server, session, envelope, address, rcpt_options)``
+``handle_RCPT(server, envelope, address, rcpt_options)``
     Called during ``RCPT TO``.  The ``address`` argument is the parsed email
     address given by the client in the ``RCPT TO`` command, and
     ``rcpt_options`` are any additional ESMTP recipient options providing by
@@ -158,10 +158,10 @@ The following hooks are currently defined:
     ``envelope.rcpt_tos`` and may extend ``envelope.rcpt_options`` (both of
     which are always Python lists).
 
-``handle_RSET(server, session, envelope)``
+``handle_RSET(server, envelope)``
     Called during ``RSET``.
 
-``handle_DATA(server, session, envelope)``
+``handle_DATA(server, envelope)``
     Called during ``DATA`` after the entire message (`"SMTP content"
     <https://tools.ietf.org/html/rfc5321#section-2.3.9>`_ as described in
     RFC 5321) has been received.  The content is available on the ``envelope``
@@ -179,7 +179,7 @@ In addition to the SMTP command hooks, the following hooks can also be
 implemented by handlers.  These have a different APIs, and are called
 synchronously.
 
-``handle_STARTTLS(server, session, envelope)``
+``handle_STARTTLS(server, session)``
     If implemented, and if SSL is supported, this method gets called
     during the TLS handshake phase of ``connection_made()``.  It should return
     True if the handshake succeeded, and False otherwise.
@@ -266,6 +266,9 @@ Envelope
     Defaulting to the empty list, this attribute will contain the list of any
     recipient options provided by the client, such as those passed in by `the
     smtplib client`_.
+
+``session``
+    Link to Session instance.
 
 
 .. _peername: https://docs.python.org/3/library/asyncio-protocol.html?highlight=peername#asyncio.BaseTransport.get_extra_info

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -37,7 +37,6 @@ class Session:
         self.host_name = None
         self.extended_smtp = False
         self.loop = loop
-        self.envelope = None
         self.protocol = protocol
 
 
@@ -179,7 +178,6 @@ class SMTP(asyncio.StreamReaderProtocol):
     def _set_post_data_state(self):
         """Reset state variables to their post-DATA state."""
         self.envelope = self._create_envelope()
-        self.session.envelope = self.envelope
         self.require_SMTPUTF8 = False
 
     def _set_rset_state(self):

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -132,11 +132,11 @@ class SMTP(asyncio.StreamReaderProtocol):
     def connection_made(self, transport):
         # Reset state due to rfc3207 part 4.2.
         self.session = self._create_session()
+        self._set_rset_state()
         self.session.peer = transport.get_extra_info('peername')
         is_instance = (_has_ssl and
                        isinstance(transport, sslproto._SSLProtocolTransport))
         if self.transport is not None and is_instance:   # pragma: nossl
-            self._set_rset_state()
             # It is STARTTLS connection over normal connection.
             self._reader._transport = transport
             self._writer._transport = transport
@@ -199,7 +199,6 @@ class SMTP(asyncio.StreamReaderProtocol):
 
     @asyncio.coroutine
     def _handle_client(self):
-        self._set_rset_state()
         log.info('%r handling connection', self.session.peer)
         yield from self.push(
             '220 {} {}'.format(self.hostname, self.__ident__))

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -134,10 +134,10 @@ class SMTP(asyncio.StreamReaderProtocol):
         # Reset state due to rfc3207 part 4.2.
         self.session = self._create_session()
         self.session.peer = transport.get_extra_info('peername')
-        self._set_rset_state()
         is_instance = (_has_ssl and
                        isinstance(transport, sslproto._SSLProtocolTransport))
         if self.transport is not None and is_instance:   # pragma: nossl
+            self._set_rset_state()
             # It is STARTTLS connection over normal connection.
             self._reader._transport = transport
             self._writer._transport = transport
@@ -201,6 +201,7 @@ class SMTP(asyncio.StreamReaderProtocol):
 
     @asyncio.coroutine
     def _handle_client(self):
+        self._set_rset_state()
         log.info('%r handling connection', self.session.peer)
         yield from self.push(
             '220 {} {}'.format(self.hostname, self.__ident__))

--- a/aiosmtpd/tests/test_handlers.py
+++ b/aiosmtpd/tests/test_handlers.py
@@ -157,7 +157,7 @@ class DataHandler:
         self.original_content = None
 
     @asyncio.coroutine
-    def handle_DATA(self, server, session, envelope):
+    def handle_DATA(self, envelope):
         self.content = envelope.content
         self.original_content = envelope.original_content
         return '250 OK'
@@ -477,26 +477,26 @@ Testing
 
 class HELOHandler:
     @asyncio.coroutine
-    def handle_HELO(self, server, session, envelope, hostname):
+    def handle_HELO(self, envelope, hostname):
         return '250 geddy.example.com'
 
 
 class EHLOHandler:
     @asyncio.coroutine
-    def handle_EHLO(self, server, session, envelope, hostname):
+    def handle_EHLO(self, envelope, hostname):
         return '250 alex.example.com'
 
 
 class MAILHandler:
     @asyncio.coroutine
-    def handle_MAIL(self, server, session, envelope, address, options):
+    def handle_MAIL(self, envelope, address, options):
         envelope.mail_options.extend(options)
         return '250 Yeah, sure'
 
 
 class RCPTHandler:
     @asyncio.coroutine
-    def handle_RCPT(self, server, session, envelope, address, options):
+    def handle_RCPT(self, envelope, address, options):
         envelope.rcpt_options.extend(options)
         if address == 'bart@example.com':
             return '550 Rejected'
@@ -506,7 +506,7 @@ class RCPTHandler:
 
 class DATAHandler:
     @asyncio.coroutine
-    def handle_DATA(self, server, session, envelope):
+    def handle_DATA(self, envelope):
         return '599 Not today'
 
 

--- a/aiosmtpd/tests/test_handlers.py
+++ b/aiosmtpd/tests/test_handlers.py
@@ -29,7 +29,7 @@ class DataHandler:
         self.original_content = None
 
     @asyncio.coroutine
-    def handle_DATA(self, server, session, envelope):
+    def handle_DATA(self, envelope):
         self.content = envelope.content
         self.original_content = envelope.original_content
         return '250 OK'

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -32,7 +32,7 @@ class ReceivingHandler:
         self.box = []
 
     @asyncio.coroutine
-    def handle_DATA(self, server, session, envelope):
+    def handle_DATA(self, envelope):
         self.box.append(envelope.content)
         return '250 OK'
 
@@ -67,7 +67,7 @@ class ErroringHandler:
     error = None
 
     @asyncio.coroutine
-    def handle_DATA(self, server, session, envelope):
+    def handle_DATA(self, envelope):
         return '499 Could not accept the message'
 
     @asyncio.coroutine

--- a/aiosmtpd/tests/test_starttls.py
+++ b/aiosmtpd/tests/test_starttls.py
@@ -28,7 +28,7 @@ class ReceivingHandler:
         self.box = []
 
     @asyncio.coroutine
-    def handle_DATA(self, server, session, envelope):
+    def handle_DATA(self, envelope):
         self.box.append(envelope)
         return '250 OK'
 
@@ -60,7 +60,7 @@ class TLSController(Controller):
 
 
 class HandshakeFailingHandler:
-    def handle_STARTTLS(self, server, session, envelope):
+    def handle_STARTTLS(self, session):
         return False
 
 


### PR DESCRIPTION
We can avoid using many parameters for calls by connecting Envelope and Session together, and Session with protocol.
Also, sure, that STARTTLS handler needs only session info (anyway, envelope and protocol still avaliable through session).