### PR TITLE
Handle lost connections and EOF during readlines

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,14 @@ Individual tests can be run like this::
 
 where *<pattern>* is a Python regular expression matching a test name.
 
+You can also add the ``-E`` option to boost debugging output, e.g.::
+
+    $ tox -e py35-nocov -- -E
+
+and these options can be combined::
+
+    $ tox -e py35-nocov -- -P test_connection_reset_during_DATA -E
+
 
 Contents
 ========

--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -5,6 +5,10 @@
 1.0a6 (20XX-XX-XX)
 ==================
 * The connection peer is displayed in all INFO level logging.
+* When running the test suite, you can include a ``-E`` option after the
+  ``--`` separator to boost the debugging output.
+* The main SMTP readline loops are now more robust against connection resets
+  and mid-read EOFs.  (Closes #62)
 
 1.0a5 (2017-04-06)
 ==================

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -173,7 +173,7 @@ class SMTP(asyncio.StreamReaderProtocol):
     def eof_received(self):
         log.info('%r EOF received', self.session.peer)
         self._handler_coroutine.cancel()
-        if not self._connection_closed:
+        if not self._connection_closed:             # pragma: nopy34
             return super().eof_received()
 
     def _set_post_data_state(self):

--- a/aiosmtpd/testing/helpers.py
+++ b/aiosmtpd/testing/helpers.py
@@ -1,6 +1,38 @@
 """Testing helpers."""
 
+import sys
+import socket
+import struct
+import asyncio
+import logging
+import warnings
+
 from contextlib import ExitStack
+from unittest.mock import patch
+
+
+def reset_connection(client):
+    # Close the connection with a TCP RST instead of a TCP FIN.  client must
+    # be a smtplib.SMTP instance.
+    #
+    # https://stackoverflow.com/a/6440364/1570972
+    #
+    # socket(7) SO_LINGER option.
+    #
+    # struct linger {
+    #   int l_onoff;    /* linger active */
+    #   int l_linger;   /* how many seconds to linger for */
+    # };
+    #
+    # Is this correct for Windows/Cygwin and macOS?
+    struct_format = 'hh' if sys.platform == 'win32' else 'ii'
+    l_onoff = 1
+    l_linger = 0
+    client.sock.setsockopt(
+        socket.SOL_SOCKET,
+        socket.SO_LINGER,
+        struct.pack(struct_format, l_onoff, l_linger))
+    client.close()
 
 
 # For integration with flufl.testing.
@@ -11,3 +43,18 @@ def setup(testobj):
 
 def teardown(testobj):
     testobj.globs['resources'].close()
+
+
+def make_debug_loop():
+    loop = asyncio.get_event_loop()
+    loop.set_debug(True)
+    return loop
+
+
+def start(plugin):
+    if plugin.stderr:
+        # Turn on lots of debugging.
+        patch('aiosmtpd.smtp.make_loop', make_debug_loop).start()
+        logging.getLogger('asyncio').setLevel(logging.DEBUG)
+        logging.getLogger('mail.log').setLevel(logging.DEBUG)
+        warnings.filterwarnings('always', category=ResourceWarning)

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -830,33 +830,6 @@ class TestClientCrash(unittest.TestCase):
             # server just hung.
             self.assertRaises(SMTPServerDisconnected, client.noop)
 
-    def test_connection_EOF_during_DATA(self):
-        with SMTP(*self.address) as client:
-            client.helo('example.com')
-            client.docmd('MAIL FROM: <anne@example.com>')
-            client.docmd('RCPT TO: <bart@example.com>')
-            client.docmd('DATA')
-            # Start sending the DATA but send an EOF before that completes,
-            # i.e. before the .\r\n
-            client.send(b'From: <anne@example.com>\0x4')
-            reset_connection(client)
-            # The connection should be disconnected, so trying to do another
-            # command from here will give us an exception.  In GH#62, the
-            # server just hung.
-            self.assertRaises(SMTPServerDisconnected, client.noop)
-
-    def test_connection_EOF_during_command(self):
-        with SMTP(*self.address) as client:
-            client.helo('example.com')
-            # Send part of the command, but do not include the CRLF.  Then
-            # reset the connection in the middle of the command.
-            client.send(b'MAIL FROM: <anne\x04')
-            reset_connection(client)
-            # The connection should be disconnected, so trying to do another
-            # command from here will give us an exception.  In GH#62, the
-            # server just hung.
-            self.assertRaises(SMTPServerDisconnected, client.noop)
-
     def test_close_in_command(self):
         with SMTP(*self.address) as client:
             # Don't include the CRLF.

--- a/py34-coverage.ini
+++ b/py34-coverage.ini
@@ -16,3 +16,4 @@ source =
 exclude_lines =
     pragma: nocover
     pragma: nossl
+    pragma: nopy34

--- a/unittest.cfg
+++ b/unittest.cfg
@@ -10,3 +10,4 @@ always-on = True
 package = aiosmtpd
 setup = aiosmtpd.testing.helpers.setup
 teardown = aiosmtpd.testing.helpers.teardown
+start_run = aiosmtpd.testing.helpers.start


### PR DESCRIPTION
Test cases for connection problems during readline()

Also, add some much improved debugging options for when the test suite is run
with the -E option.

Update the documentation.

Closes #61 