### PR TITLE
Make Proxy work with decode_data=False

### DIFF
--- a/aiosmtpd/handlers.py
+++ b/aiosmtpd/handlers.py
@@ -6,6 +6,7 @@ Pass in an instance of one of these classes, or derive your own, to provide
 your own handling of messages.  Implement only the methods you care about.
 """
 
+import re
 import sys
 import asyncio
 import logging
@@ -13,13 +14,13 @@ import mailbox
 import smtplib
 
 from email import message_from_bytes, message_from_string
-from email.feedparser import NLCRE
 from public import public
 
 
-EMPTYSTRING = ''
+bEMPTYSTRING = b''
 COMMASPACE = ', '
-CRLF = '\r\n'
+bCRLF = b'\r\n'
+bNLCRE = re.compile(br'\r\n|\r|\n')
 log = logging.getLogger('mail.debug')
 
 
@@ -93,17 +94,22 @@ class Proxy:
 
     @asyncio.coroutine
     def handle_DATA(self, server, session, envelope):
+        if isinstance(envelope.content, str):
+            content = envelope.original_content
+        else:
+            content = envelope.content
         lines = envelope.content.splitlines(keepends=True)
         # Look for the last header
         i = 0
-        ending = CRLF
+        ending = bCRLF
         for line in lines:                          # pragma: nobranch
-            if NLCRE.match(line):
+            if bNLCRE.match(line):
                 ending = line
                 break
             i += 1
-        lines.insert(i, 'X-Peer: %s%s' % (session.peer[0], ending))
-        data = EMPTYSTRING.join(lines)
+        peer = session.peer[0].encode('ascii')
+        lines.insert(i, b'X-Peer: %s%s' % (peer, ending))
+        data = bEMPTYSTRING.join(lines)
         refused = self._deliver(envelope.mail_from, envelope.rcpt_tos, data)
         # TBD: what to do with refused addresses?
         log.info('we got some refusals: %s', refused)

--- a/aiosmtpd/handlers.py
+++ b/aiosmtpd/handlers.py
@@ -98,7 +98,7 @@ class Proxy:
             content = envelope.original_content
         else:
             content = envelope.content
-        lines = envelope.content.splitlines(keepends=True)
+        lines = content.splitlines(keepends=True)
         # Look for the last header
         i = 0
         ending = bCRLF

--- a/aiosmtpd/tests/test_handlers.py
+++ b/aiosmtpd/tests/test_handlers.py
@@ -432,6 +432,8 @@ Testing
                 'X-Peer: ::1',
                 '',
                 'Testing'])
+            # Proxy works with bytes
+            msg = msg.encode('ascii')
             mock().sendmail.assert_called_once_with(
                 'anne@example.com', ['bart@example.com'], msg)
             mock().quit.assert_called_once_with()


### PR DESCRIPTION
In a StackOverflow post [1] a user is trying to use Proxy to create an open proxy. However, the current implementation of Proxy requires that `decode_data=True` be set when instantiating `aiosmtpd.smtp.SMTP` which in turn requires [2] subclassing Controller as done in `UTF8Controller` in `aiosmtpd/tests/test_handlers.py`.

The Proxy handler should be usable without subclassing Controller, so it should work with `decode_data=False` (the default). This patch makes it work with either by checking the type of `envelope.content`. The module-level constants `EMPTYSTRING` and `CRLF` are only used in Proxy, so they are removed and replaced with bytes-equivalents `bEMPTYSTRING` and `bCRLF`, and `bNLCRE` is added as an analogue to `email.feedparser.NLCRE`.

[1]: https://stackoverflow.com/q/43278998/1570972
[2]: https://stackoverflow.com/a/43639097/1570972