### PR TITLE
Install as "aiosmtpd" instead of "smtpd"

### DIFF
--- a/aiosmtpd/docs/cli.rst
+++ b/aiosmtpd/docs/cli.rst
@@ -30,10 +30,10 @@ greeting::
 Of course, you could use Python's smtplib_ module, or any other SMTP client to
 talk to the server.  Just hit control-C at the server to stop it.
 
-The entry point may also be installed as the ``smtpd`` command, so this is
+The entry point may also be installed as the ``aiosmtpd`` command, so this is
 equivalent to the above ``python3`` invocation::
 
-    $ smtpd -n
+    $ aiosmtpd -n
 
 
 Options

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ Python 3.""",
         'atpublic',
         ],
     entry_points={
-        'console_scripts': ['smtpd = aiosmtpd.main:main'],
+        'console_scripts': ['aiosmtpd = aiosmtpd.main:main'],
         },
     classifiers=[
         'License :: OSI Approved',


### PR DESCRIPTION
The $PATH/smtpd command is contested by multiple popular SMTP server implementations: Postfix installs to /usr/lib/postfix/sbin/smtpd on Ubuntu, and opensmtpd installs to /usr/sbin/smtpd. If aiosmtpd tries to install the "smtpd" command upstream, it will probably be changed by most distributions. If we pick a less contested command name, it is more likely to be available uniformly across the distributions that choose to package aiosmtpd.

I came across this while working on documentation. I think this issue would have been more important 5 years ago before pip was standardized as the way to subordinate traditional Linux package distributors, but I think aiosmtpd should still "play nice" and not require setup.py-patching on every downstream. What do you think @warsaw @kozzztik ?