### PR TITLE
Add Appveyor config for testing on Windows

### DIFF
--- a/aiosmtpd/main.py
+++ b/aiosmtpd/main.py
@@ -102,7 +102,7 @@ def parseargs(args=None):
 def main(args=None):
     parser, args = parseargs(args=args)
 
-    if args.setuid:
+    if args.setuid:  # pragma: nomswin
         if pwd is None:
             print('Cannot import module "pwd"; try running with -n option.',
                   file=sys.stderr)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,29 @@
+environment:
+  PYTHONASYNCIODEBUG: "1"
+
+  matrix:
+
+    # For Python versions available on Appveyor, see
+    # http://www.appveyor.com/docs/installed-software#python
+
+    - PYTHON: "C:\\Python34"
+      INTERP: "py34"
+    - PYTHON: "C:\\Python35"
+      INTERP: "py35"
+    - PYTHON: "C:\\Python34-x64"
+      INTERP: "py34"
+      DISTUTILS_USE_SDK: "1"
+    - PYTHON: "C:\\Python35-x64"
+      INTERP: "py35"
+    - PYTHON: "C:\\Python36-x64"
+      INTERP: "py36"
+
+install:
+  - "%PYTHON%\\python.exe -m pip install tox"
+  - "%PYTHON%\\python.exe setup.py egg_info"
+  - "%PYTHON%\\python.exe -m pip install -r aiosmtpd.egg-info/requires.txt"
+
+build: off
+
+test_script:
+  - "%PYTHON%\\python.exe -m tox -e %INTERP%-nocov,%INTERP%-cov,qa,docs"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 environment:
   PYTHONASYNCIODEBUG: "1"
+  PLATFORM: "mswin"
 
   matrix:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,4 +26,4 @@ install:
 build: off
 
 test_script:
-  - "%PYTHON%\\python.exe -m tox -e %INTERP%-nocov,%INTERP%-cov,qa,docs"
+  - "%PYTHON%\\python.exe -m tox -e %INTERP%-nocov,%INTERP%-cov"

--- a/py34mswin-coverage.ini
+++ b/py34mswin-coverage.ini
@@ -1,0 +1,20 @@
+[run]
+branch = true
+parallel = true
+omit =
+     setup*
+     aiosmtpd/testing/*
+     aiosmtpd/tests/*
+    .tox/*/lib/python3.*/site-packages/*
+
+[paths]
+source =
+    aiosmtpd
+    .tox/*/lib/python*/site-packages/aiosmtpd
+
+[report]
+exclude_lines =
+    pragma: nocover
+    pragma: nossl
+    pragma: nopy34
+    pragma: nomswin

--- a/py35mswin-coverage.ini
+++ b/py35mswin-coverage.ini
@@ -1,0 +1,18 @@
+[run]
+branch = true
+parallel = true
+omit =
+     setup*
+     aiosmtpd/testing/*
+     aiosmtpd/tests/*
+    .tox/*/lib/python3.*/site-packages/*
+
+[paths]
+source =
+    aiosmtpd
+    .tox/*/lib/python*/site-packages/aiosmtpd
+
+[report]
+exclude_lines =
+    pragma: nocover
+    pragma: nomswin

--- a/py36mswin-coverage.ini
+++ b/py36mswin-coverage.ini
@@ -1,0 +1,18 @@
+[run]
+branch = true
+parallel = true
+omit =
+     setup*
+     aiosmtpd/testing/*
+     aiosmtpd/tests/*
+    .tox/*/lib/python3.*/site-packages/*
+
+[paths]
+source =
+    aiosmtpd
+    .tox/*/lib/python*/site-packages/aiosmtpd
+
+[report]
+exclude_lines =
+    pragma: nocover
+    pragma: nomswin

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ passenv =
     PYTHON*
 
 [coverage]
-rcfile = {toxinidir}/{env:INTERP:py35}-coverage.ini
+rcfile = {toxinidir}/{env:INTERP:py35}{env:PLATFORM:}-coverage.ini
 rc = --rcfile={[coverage]rcfile}
 
 [testenv:qa]


### PR DESCRIPTION
This PR adds an Appveyor config. When aio-libs/aiosmtpd is created on https://ci.appveyor.com (by the FLUFL), the config will be automatically picked up and tests will start running whenever master is updated.

Currently coverage [fails](https://ci.appveyor.com/project/Mortal/aiosmtpd/build/1.0.6/job/400lst9pqg2bbky7#L615) because this if-branch is always taken in tests:

```python
def eof_received(self):
    log.info('%r EOF received', self.session.peer)
    self._handler_coroutine.cancel()
    if self.transport is not None:                        # pragma: nopy34
        return super().eof_received()
```

I can't figure out how to make a test where `eof_received()` is called when `self.transport` is None, but it seems that this is exercised when testing on Linux by the tests in TestStartTLS (discovered by adding `raise Exception()` at the end of eof_received()).