### PR TITLE
Document Envelope.original_content in "Envelope" section

### DIFF
--- a/aiosmtpd/docs/smtp.rst
+++ b/aiosmtpd/docs/smtp.rst
@@ -259,6 +259,11 @@ Envelope
     then this attribute will contain the UTF-8 decoded string, otherwise it
     will contain the raw bytes.
 
+``original_content``
+    Defaulting to None, this attribute will contain the contents of the
+    message as provided by the ``DATA`` command.  Unlike the ``content``
+    attribute, this attribute will always contain the raw bytes.
+
 ``rcpt_tos``
     Defaulting to the empty list, this attribute will contain a list of the
     email addresses provided in the ``RCPT TO`` command.

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -46,6 +46,7 @@ class Envelope:
         self.mail_options = []
         self.smtp_utf8 = False
         self.content = None
+        self.original_content = None
         self.rcpt_tos = []
         self.rcpt_options = []
 


### PR DESCRIPTION
I just noticed that `Envelope.original_content` is not being set in `Envelope.__init__()`, nor is it documented in the section on the `Envelope` class in the docs.