### PR TITLE
Add link to StackOverflow tag for aiosmtpd

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,8 +47,10 @@ As of 2016-07-14, aiosmtpd has been put under the `aio-libs
 * Report bugs at: https://github.com/aio-libs/aiosmtpd/issues
 * Git clone: https://github.com/aio-libs/aiosmtpd.git
 * Documentation: http://aiosmtpd.readthedocs.io/
+* StackOverflow: https://stackoverflow.com/questions/tagged/aiosmtpd
 
 The best way to contact the developers is through the GitHub links above.
+You can also request help by submitting a question on StackOverflow.
 
 
 Building


### PR DESCRIPTION
The aiosmtpd tag has just been created on StackOverflow and I've subscribed to notifications whenever new questions are posted in that tag. Add a link under "Project details" along with a suggestion to post questions on StackOverflow.