### PR TITLE
Fix logging error

### DIFF
--- a/aiosmtpd/handlers.py
+++ b/aiosmtpd/handlers.py
@@ -129,7 +129,7 @@ class Proxy:
             log.info('got SMTPRecipientsRefused')
             refused = e.recipients
         except (OSError, smtplib.SMTPException) as e:
-            log.exception('got', e.__class__)
+            log.exception('got %s', e.__class__)
             # All recipients were refused.  If the exception had an associated
             # error code, use it.  Otherwise, fake it with a non-triggering
             # exception code.


### PR DESCRIPTION
Proxy has an incorrect call to `log.error`, and I ran into this error when testing an example that uses Proxy. I remember viewing another aiosmtpd PR that fixes this issue, but I guess that other PR has been deferred post-1.0.