### PR TITLE
Fix typo "essentiall"

### DIFF
--- a/aiosmtpd/docs/handlers.rst
+++ b/aiosmtpd/docs/handlers.rst
@@ -33,7 +33,7 @@ The following built-in handlers can be imported from ``aiosmtpd.handlers``:
   port as positional arguments.  This class cannot be used on the command
   line.
 
-* ``Sink`` - this class just consumes and discards messages.  It's essentiall
+* ``Sink`` - this class just consumes and discards messages.  It's essentially
   the "no op" handler.  It can be used on the command line, but accepts no
   positional arguments.
 


### PR DESCRIPTION
I found a typo while proof-reading #93 -- turns out it was a typo already present in `master`.