### PR TITLE
handle_HELO/EHLO documentation (+two other doc fixes)

### DIFF
--- a/aiosmtpd/docs/handlers.rst
+++ b/aiosmtpd/docs/handlers.rst
@@ -41,7 +41,8 @@ The following hooks are currently defined:
 ``handle_HELO(server, session, envelope, hostname)``
     Called during ``HELO``.  The ``hostname`` argument is the host name given
     by the client in the ``HELO`` command.  If implemented, this hook must
-    also set the ``session.host_name`` attribute.
+    also set the ``session.host_name`` attribute before returning
+    ``'250 {}'.format(server.hostname)`` as the status.
 
 ``handle_EHLO(server, session, envelope, hostname)``
     Called during ``EHLO``.  The ``hostname`` argument is the host name given

--- a/aiosmtpd/docs/handlers.rst
+++ b/aiosmtpd/docs/handlers.rst
@@ -49,7 +49,8 @@ The following hooks are currently defined:
     by the client in the ``EHLO`` command.  If implemented, this hook must
     also set the ``session.host_name`` attribute.  This hook may push
     additional ``250-<command>`` responses to the client by yielding from
-    ``server.push(status)`` before returning ``250 OK`` as the final response.
+    ``server.push(status)`` before returning ``250 HELP`` as the final
+    response.
 
 ``handle_NOOP(server, session, envelope)``
     Called during ``NOOP``.

--- a/aiosmtpd/docs/smtp.rst
+++ b/aiosmtpd/docs/smtp.rst
@@ -7,7 +7,7 @@
 At the heart of this module is the ``SMTP`` class.  This class implements the
 `RFC 5321 <http://www.faqs.org/rfcs/rfc5321.html>`_ Simple Mail Transport
 Protocol.  Often you won't run an ``SMTP`` instance directly, but instead will
-use a :ref:`controller <controller>` instance to run the server in a subthead.
+use a :ref:`controller <controller>` instance to run the server in a subthread.
 
     >>> from aiosmtpd.controller import Controller
 

--- a/aiosmtpd/docs/smtp.rst
+++ b/aiosmtpd/docs/smtp.rst
@@ -178,8 +178,8 @@ SMTP API
       The method that subclasses and handlers should use to return statuses to
       SMTP clients.  This is a coroutine.  *status* can be a bytes object, but
       for convenience it is more likely to be a string.  If it's a string, it
-      must be ASCII, unless *enable_SMTPUTF8* is True in which case it must be
-      UTF-8.
+      must be ASCII, unless *enable_SMTPUTF8* is True in which case it will be
+      encoded as UTF-8.
 
    .. method:: smtp_<COMMAND>(arg)
 


### PR DESCRIPTION
* It currently sounds like handle_HELO() should return "250 OK". However, it should return the host name. I'm not entirely sure if this is actually required by RFC 5321, but I suggest documenting that it is required by the aiosmtpd handler.

* handle_EHLO() documentation specifies "250 OK" as the return code, however, as I understand it must return "250 HELP".

* SMTP.push() documentation specifies that a string must be UTF-8, but that is nonsense -- it is more correct to say that the string will be encoded as UTF-8.

* Fix a typo in the intro of smtp.rst ("subthead").

[RFC 5321 §4.1.1.1 EHLO and HELO](https://tools.ietf.org/html/rfc5321#section-4.1.1.1): "These commands, and a "250 OK" reply to one of them, confirm that both the SMTP client and the SMTP server are in the initial state, [...]"

However, the grammar for the HELO/EHLO response (ehlo-ok-rsp) specifies that the first token must be syntactically a "Domain". I guess the string "OK" technically passes the grammar for a domain, but I can't figure out if the RFC wants to say that the server must reply with its hostname in response to HELO/EHLO, or if it is optional. Is "a "250 OK" reply" a typo in the RFC that meant to say "a 250 reply"?