### PR TITLE
Link session and protocol

### DIFF
--- a/aiosmtpd/handlers.py
+++ b/aiosmtpd/handlers.py
@@ -66,7 +66,7 @@ class Debugging:
             print(line, file=self.stream)
 
     @asyncio.coroutine
-    def handle_DATA(self, server, session, envelope):
+    def handle_DATA(self, session, envelope):
         print('---------- MESSAGE FOLLOWS ----------', file=self.stream)
         # Yes, actually test for truthiness since it's possible for either the
         # keywords to be missing, or for their values to be empty lists.
@@ -93,7 +93,7 @@ class Proxy:
         self._port = remote_port
 
     @asyncio.coroutine
-    def handle_DATA(self, server, session, envelope):
+    def handle_DATA(self, session, envelope):
         if isinstance(envelope.content, str):
             content = envelope.original_content
         else:
@@ -155,7 +155,7 @@ class Message:
         self.message_class = message_class
 
     @asyncio.coroutine
-    def handle_DATA(self, server, session, envelope):
+    def handle_DATA(self, session, envelope):
         envelope = self.prepare_message(session, envelope)
         self.handle_message(envelope)
         return '250 OK'
@@ -186,7 +186,7 @@ class AsyncMessage(Message):
         self.loop = loop or asyncio.get_event_loop()
 
     @asyncio.coroutine
-    def handle_DATA(self, server, session, envelope):
+    def handle_DATA(self, session, envelope):
         message = self.prepare_message(session, envelope)
         yield from self.handle_message(message)
         return '250 OK'

--- a/aiosmtpd/tests/test_handlers.py
+++ b/aiosmtpd/tests/test_handlers.py
@@ -29,7 +29,7 @@ class DataHandler:
         self.original_content = None
 
     @asyncio.coroutine
-    def handle_DATA(self, server, session, envelope):
+    def handle_DATA(self, session, envelope):
         self.content = envelope.content
         self.original_content = envelope.original_content
         return '250 OK'
@@ -513,26 +513,26 @@ Testing
 
 class HELOHandler:
     @asyncio.coroutine
-    def handle_HELO(self, server, session, envelope, hostname):
+    def handle_HELO(self, session, envelope, hostname):
         return '250 geddy.example.com'
 
 
 class EHLOHandler:
     @asyncio.coroutine
-    def handle_EHLO(self, server, session, envelope, hostname):
+    def handle_EHLO(self, session, envelope, hostname):
         return '250 alex.example.com'
 
 
 class MAILHandler:
     @asyncio.coroutine
-    def handle_MAIL(self, server, session, envelope, address, options):
+    def handle_MAIL(self, session, envelope, address, options):
         envelope.mail_options.extend(options)
         return '250 Yeah, sure'
 
 
 class RCPTHandler:
     @asyncio.coroutine
-    def handle_RCPT(self, server, session, envelope, address, options):
+    def handle_RCPT(self, session, envelope, address, options):
         envelope.rcpt_options.extend(options)
         if address == 'bart@example.com':
             return '550 Rejected'
@@ -542,7 +542,7 @@ class RCPTHandler:
 
 class DATAHandler:
     @asyncio.coroutine
-    def handle_DATA(self, server, session, envelope):
+    def handle_DATA(self, session, envelope):
         return '599 Not today'
 
 

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -34,7 +34,7 @@ class ReceivingHandler:
         self.box = []
 
     @asyncio.coroutine
-    def handle_DATA(self, server, session, envelope):
+    def handle_DATA(self, session, envelope):
         self.box.append(envelope)
         return '250 OK'
 
@@ -69,7 +69,7 @@ class ErroringHandler:
     error = None
 
     @asyncio.coroutine
-    def handle_DATA(self, server, session, envelope):
+    def handle_DATA(self, session, envelope):
         return '499 Could not accept the message'
 
     @asyncio.coroutine

--- a/aiosmtpd/tests/test_starttls.py
+++ b/aiosmtpd/tests/test_starttls.py
@@ -28,7 +28,7 @@ class ReceivingHandler:
         self.box = []
 
     @asyncio.coroutine
-    def handle_DATA(self, server, session, envelope):
+    def handle_DATA(self, session, envelope):
         self.box.append(envelope)
         return '250 OK'
 
@@ -60,7 +60,7 @@ class TLSController(Controller):
 
 
 class HandshakeFailingHandler:
-    def handle_STARTTLS(self, server, session, envelope):
+    def handle_STARTTLS(self, session, envelope):
         return False
 
 


### PR DESCRIPTION
Whie #71 failed, I sill not gave up with idea to do something with long too handler method definitions. What about linking protocol and session together? They are having one lifecycle, and very similar. Protocol instance not used in handlers, and I have no idea why it may be used in handlers. But I want to have all data be accessable from handlers, so, may be good idea is hide protocol object (dont know why it is called "server") and put it on session as a field. That will make handlers definitions more compact and free from useless variables.