### PR TITLE
Add support for SMTP over SSL/TLS.

### DIFF
--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -9,11 +9,12 @@ from public import public
 @public
 class Controller:
     def __init__(self, handler, loop=None, hostname=None, port=8025, *,
-                 ready_timeout=1.0, enable_SMTPUTF8=True):
+                 ready_timeout=1.0, enable_SMTPUTF8=True, ssl_context=None):
         self.handler = handler
         self.hostname = '::1' if hostname is None else hostname
         self.port = port
         self.enable_SMTPUTF8 = enable_SMTPUTF8
+        self.ssl_context = ssl_context
         self.loop = asyncio.new_event_loop() if loop is None else loop
         self.server = None
         self._thread = None
@@ -30,7 +31,8 @@ class Controller:
         try:
             self.server = self.loop.run_until_complete(
                 self.loop.create_server(
-                    self.factory, host=self.hostname, port=self.port))
+                    self.factory, host=self.hostname, port=self.port,
+                    ssl=self.ssl_context))
         except Exception as error:
             self._thread_exception = error
             return

--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -21,6 +21,8 @@
 * Widen the catch of ``ConnectionResetError`` and ``CancelledError`` to also
   catch such errors from handler methods.  (Closes #110)
 * Added a manpage for the ``aiosmtpd`` command line script.  (Closes #116)
+* The ``Controller`` class now takes an optional keyword argument ``ssl_context``
+  which is passed directly to the asyncio ``create_server()`` call.
 
 1.0 (2017-05-15)
 ================

--- a/aiosmtpd/docs/controller.rst
+++ b/aiosmtpd/docs/controller.rst
@@ -161,7 +161,7 @@ The EHLO response does not include the ``SMTPUTF8`` ESMTP option.
 Controller API
 ==============
 
-.. class:: Controller(handler, loop=None, hostname=None, port=8025, *, ready_timeout=1.0, enable_SMTPUTF8=True)
+.. class:: Controller(handler, loop=None, hostname=None, port=8025, *, ready_timeout=1.0, enable_SMTPUTF8=True, ssl_context=None)
 
    *handler* is an instance of a :ref:`handler <handlers>` class.
 
@@ -181,6 +181,10 @@ Controller API
    argument to the ``SMTP`` constructor.  When True, the ESMTP ``SMTPUTF8``
    option is returned to the client in response to ``EHLO``, and UTF-8 content
    is accepted.
+
+   *ssl_context* is a ``SSLContext`` that will be used by the loops
+   server and is passed directly to :meth:`AbstractEventLoop.create_server`
+   method.
 
    .. attribute:: handler
 

--- a/aiosmtpd/tests/test_smtps.py
+++ b/aiosmtpd/tests/test_smtps.py
@@ -1,0 +1,65 @@
+"""Test SMTP over SSL/TLS."""
+import ssl
+import socket
+import unittest
+import pkg_resources
+
+from aiosmtpd.controller import Controller as BaseController
+from aiosmtpd.smtp import SMTP as SMTPProtocol
+from email.mime.text import MIMEText
+from smtplib import SMTP_SSL
+
+
+class Controller(BaseController):
+    def factory(self):
+        return SMTPProtocol(self.handler)
+
+
+class ReceivingHandler:
+    def __init__(self):
+        self.box = []
+
+    async def handle_DATA(self, server, session, envelope):
+        self.box.append(envelope)
+        return '250 OK'
+
+
+def get_server_context():
+    tls_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+    tls_context.load_cert_chain(
+            pkg_resources.resource_filename('aiosmtpd.tests.certs',
+                                            'server.crt'),
+            pkg_resources.resource_filename('aiosmtpd.tests.certs',
+                                            'server.key'))
+    return tls_context
+
+
+def get_client_context():
+    context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+    context.check_hostname = False
+    context.load_verify_locations(
+            cafile=pkg_resources.resource_filename('aiosmtpd.tests.certs',
+                                                   'server.crt'))
+    return context
+
+
+class TestSMTPS(unittest.TestCase):
+    def setUp(self):
+        self.handler = ReceivingHandler()
+        controller = Controller(self.handler, ssl_context=get_server_context())
+        controller.start()
+        self.addCleanup(controller.stop)
+        self.address = (controller.hostname, controller.port)
+
+    def test_smtps(self):
+        with SMTP_SSL(*self.address, context=get_client_context()) as client:
+            code, response = client.helo('example.com')
+            self.assertEqual(code, 250)
+            self.assertEqual(response, bytes(socket.getfqdn(), 'utf-8'))
+            client.send_message(
+                    MIMEText('hi'),
+                    'sender@example.com',
+                    'rcpt1@example.com')
+        self.assertEqual(len(self.handler.box), 1)
+        envelope = self.handler.box[0]
+        self.assertEqual(envelope.mail_from, 'sender@example.com')

--- a/aiosmtpd/tests/test_smtps.py
+++ b/aiosmtpd/tests/test_smtps.py
@@ -1,4 +1,5 @@
 """Test SMTP over SSL/TLS."""
+
 import ssl
 import socket
 import unittest
@@ -27,10 +28,8 @@ class ReceivingHandler:
 def get_server_context():
     tls_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
     tls_context.load_cert_chain(
-            pkg_resources.resource_filename('aiosmtpd.tests.certs',
-                                            'server.crt'),
-            pkg_resources.resource_filename('aiosmtpd.tests.certs',
-                                            'server.key'))
+        pkg_resources.resource_filename('aiosmtpd.tests.certs', 'server.crt'),
+        pkg_resources.resource_filename('aiosmtpd.tests.certs', 'server.key'))
     return tls_context
 
 

--- a/aiosmtpd/tests/test_smtps.py
+++ b/aiosmtpd/tests/test_smtps.py
@@ -37,8 +37,8 @@ def get_client_context():
     context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
     context.check_hostname = False
     context.load_verify_locations(
-            cafile=pkg_resources.resource_filename('aiosmtpd.tests.certs',
-                                                   'server.crt'))
+        cafile=pkg_resources.resource_filename(
+            'aiosmtpd.tests.certs', 'server.crt'))
     return context
 
 
@@ -56,9 +56,7 @@ class TestSMTPS(unittest.TestCase):
             self.assertEqual(code, 250)
             self.assertEqual(response, bytes(socket.getfqdn(), 'utf-8'))
             client.send_message(
-                    MIMEText('hi'),
-                    'sender@example.com',
-                    'rcpt1@example.com')
+                MIMEText('hi'), 'sender@example.com', 'rcpt1@example.com')
         self.assertEqual(len(self.handler.box), 1)
         envelope = self.handler.box[0]
         self.assertEqual(envelope.mail_from, 'sender@example.com')


### PR DESCRIPTION
This PR adds support for SMTP over SSL/TLS via a custom `SSLContext` supplied to a `Controller` constructor.

This however has a few nits, as the STARTTLS extension is implemented in the `SMTP` protocol class and these two options are orthogonal. It's obviously a wrong use of the library to enable STARTTLS on a `SMTP` instance as well as require SMTP over SSL/TLS via this PRs functionality, however I still think it should be somehow detected and aborted.