### PR TITLE
Improved help

### DIFF
--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -21,6 +21,10 @@
 * Widen the catch of ``ConnectionResetError`` and ``CancelledError`` to also
   catch such errors from handler methods.  (Closes #110)
 * Added a manpage for the ``aiosmtpd`` command line script.  (Closes #116)
+* Added much better support for the ``HELP``.  There's a new decorator called
+  ``@syntax()`` which you can use in derived classes to decorate ``smtp_*()``
+  methods.  These then show up in ``HELP`` responses.  This also fixes
+  ``HELP`` responses for the ``LMTP`` subclass.  (Closes #113)
 
 1.0 (2017-05-15)
 ================

--- a/aiosmtpd/docs/smtp.rst
+++ b/aiosmtpd/docs/smtp.rst
@@ -28,8 +28,9 @@ All methods implementing ``SMTP`` commands are prefixed with ``smtp_``; they
 must also be coroutines.  Here's how you could implement this use case::
 
     >>> import asyncio
-    >>> from aiosmtpd.smtp import SMTP as Server
+    >>> from aiosmtpd.smtp import SMTP as Server, syntax
     >>> class MyServer(Server):
+    ...     @syntax('PING [ignored]')
     ...     async def smtp_PING(self, arg):
     ...         await self.push('259 Pong')
 
@@ -60,6 +61,17 @@ command, we have to use the lower level interface to talk to it.
     259
     >>> message
     b'Pong'
+
+Because we prefixed the ``smtp_PING()`` method with the ``@syntax()``
+decorator, the command shows up in the ``HELP`` output.
+
+    >>> print(client.help().decode('utf-8'))
+    Supported commands: DATA EHLO HELO HELP MAIL NOOP PING QUIT RCPT RSET VRFY
+
+And we can get more detailed help on the new command.
+
+    >>> print(client.help('PING').decode('utf-8'))
+    Syntax: PING [ignored]
 
 
 Server hooks

--- a/aiosmtpd/lmtp.py
+++ b/aiosmtpd/lmtp.py
@@ -1,12 +1,14 @@
-from aiosmtpd.smtp import SMTP
+from aiosmtpd.smtp import SMTP, syntax
 from public import public
 
 
 @public
 class LMTP(SMTP):
+    @syntax('LHLO hostname')
     async def smtp_LHLO(self, arg):
         """The LMTP greeting, used instead of HELO/EHLO."""
         await super().smtp_HELO(arg)
+        self.show_smtp_greeting = False
 
     async def smtp_HELO(self, arg):
         """HELO is not a valid LMTP command."""

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -436,7 +436,7 @@ class SMTP(asyncio.StreamReaderProtocol):
             '{} Supported commands: {}'.format(code, ' '.join(commands)))
 
     @syntax('VRFY <address>')
-    def smtp_VRFY(self, arg):
+    async def smtp_VRFY(self, arg):
         if arg:
             try:
                 address, params = self._getaddr(arg)

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -421,7 +421,7 @@ class SMTP(asyncio.StreamReaderProtocol):
                 help_str = method._smtp_syntax
                 if self.session.extended_smtp and method._smtp_syntax_extended:
                     help_str += method._smtp_syntax_extended
-                yield from self.push('250 Syntax: ' + help_str)
+                    await self.push('250 Syntax: ' + help_str)
                 return
             code = 501
         commands = []
@@ -432,7 +432,7 @@ class SMTP(asyncio.StreamReaderProtocol):
             if self._syntax_available(method):
                 commands.append(name.lstrip('smtp_'))
         commands.sort()
-        yield from self.push(
+        await self.push(
             '{} Supported commands: {}'.format(code, ' '.join(commands)))
 
     @syntax('VRFY <address>')

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -51,10 +51,11 @@ def make_loop():
     return asyncio.get_event_loop()
 
 
-def syntax(text, extended=None):
+def syntax(text, extended=None, when=None):
     def decorator(f):
         f._smtp_syntax = text
         f._smtp_syntax_extended = extended
+        f._smtp_syntax_when = when
         return f
     return decorator
 
@@ -85,8 +86,6 @@ class SMTP(asyncio.StreamReaderProtocol):
         self.enable_SMTPUTF8 = enable_SMTPUTF8
         self._decode_data = decode_data
         self.command_size_limits.clear()
-        self.supported_commands = ['EHLO', 'HELO', 'MAIL', 'RCPT', 'DATA',
-                                   'RSET', 'NOOP', 'QUIT', 'VRFY']
         if hostname:
             self.hostname = hostname
         else:
@@ -95,7 +94,6 @@ class SMTP(asyncio.StreamReaderProtocol):
         if tls_context:
             # Through rfc3207 part 4.1 certificate checking is part of SMTP
             # protocol, not SSL layer.
-            self.supported_commands.append('STARTTLS')
             self.tls_context.check_hostname = False
             self.tls_context.verify_mode = ssl.CERT_NONE
         self.require_starttls = tls_context and require_starttls
@@ -406,22 +404,36 @@ class SMTP(asyncio.StreamReaderProtocol):
             result[param] = value if eq else True
         return result
 
+    def _syntax_available(self, method):
+        if not getattr(method, '_smtp_syntax', None):
+            return False
+        if method._smtp_syntax_when:
+            return bool(getattr(self, method._smtp_syntax_when))
+        return True
+
+    @asyncio.coroutine
     async def smtp_HELP(self, arg):
+        code = 250
         if arg:
             lc_arg = arg.upper()
             method = getattr(self, 'smtp_' + lc_arg, None)
-            if method and method._smtp_syntax:
+            if method and self._syntax_available(method):
                 help_str = method._smtp_syntax
                 if self.session.extended_smtp and method._smtp_syntax_extended:
                     help_str += method._smtp_syntax_extended
                 yield from self.push('250 Syntax: ' + help_str)
                 return
-            yield from self.push('501 Supported commands: {}'.format(
-                ' '.join(self.supported_commands)))
-        else:
-            yield from self.push(
-                '250 Supported commands: {}'.format(
-                    ' '.join(self.supported_commands)))
+            code = 501
+        commands = []
+        for name in dir(self):
+            if not name.startswith('smtp_'):
+                continue
+            method = getattr(self, name)
+            if self._syntax_available(method):
+                commands.append(name.lstrip('smtp_'))
+        commands.sort()
+        yield from self.push(
+            '{} Supported commands: {}'.format(code, ' '.join(commands)))
 
     @syntax('VRFY <address>')
     def smtp_VRFY(self, arg):

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -53,9 +53,9 @@ def make_loop():
 
 def syntax(text, extended=None, when=None):
     def decorator(f):
-        f._smtp_syntax = text
-        f._smtp_syntax_extended = extended
-        f._smtp_syntax_when = when
+        f.__smtp_syntax__ = text
+        f.__smtp_syntax_extended__ = extended
+        f.__smtp_syntax_when__ = when
         return f
     return decorator
 
@@ -405,10 +405,10 @@ class SMTP(asyncio.StreamReaderProtocol):
         return result
 
     def _syntax_available(self, method):
-        if not getattr(method, '_smtp_syntax', None):
+        if not getattr(method, '__smtp_syntax__', None):
             return False
-        if method._smtp_syntax_when:
-            return bool(getattr(self, method._smtp_syntax_when))
+        if method.__smtp_syntax_when__:
+            return bool(getattr(self, method.__smtp_syntax_when__))
         return True
 
     @asyncio.coroutine
@@ -418,9 +418,10 @@ class SMTP(asyncio.StreamReaderProtocol):
             lc_arg = arg.upper()
             method = getattr(self, 'smtp_' + lc_arg, None)
             if method and self._syntax_available(method):
-                help_str = method._smtp_syntax
-                if self.session.extended_smtp and method._smtp_syntax_extended:
-                    help_str += method._smtp_syntax_extended
+                help_str = method.__smtp_syntax__
+                if (self.session.extended_smtp
+                        and method.__smtp_syntax_extended__):
+                    help_str += method.__smtp_syntax_extended__
                     await self.push('250 Syntax: ' + help_str)
                 return
             code = 501

--- a/aiosmtpd/tests/test_lmtp.py
+++ b/aiosmtpd/tests/test_lmtp.py
@@ -40,3 +40,13 @@ class TestLMTP(unittest.TestCase):
             code, response = client.ehlo('example.com')
             self.assertEqual(code, 500)
             self.assertEqual(response, b'Error: command "EHLO" not recognized')
+
+    def test_help(self):
+        # https://github.com/aio-libs/aiosmtpd/issues/113
+        with SMTP(*self.address) as client:
+            # Don't get tricked by smtplib processing of the response.
+            code, response = client.docmd('HELP')
+            self.assertEqual(code, 250)
+            self.assertEqual(response,
+                             b'Supported commands: DATA HELP LHLO MAIL '
+                             b'NOOP QUIT RCPT RSET VRFY')

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -287,7 +287,7 @@ class TestSMTP(unittest.TestCase):
             code, response = client.docmd('HELP')
             self.assertEqual(code, 250)
             self.assertEqual(response,
-                             b'Supported commands: DATA EHLO HELO MAIL '
+                             b'Supported commands: DATA EHLO HELO HELP MAIL '
                              b'NOOP QUIT RCPT RSET VRFY')
 
     def test_help_helo(self):
@@ -354,7 +354,7 @@ class TestSMTP(unittest.TestCase):
         with SMTP(*self.address) as client:
             code, response = client.docmd('HELP', 'NOOP')
             self.assertEqual(code, 250)
-            self.assertEqual(response, b'Syntax: NOOP')
+            self.assertEqual(response, b'Syntax: NOOP [ignored]')
 
     def test_help_quit(self):
         with SMTP(*self.address) as client:
@@ -374,7 +374,7 @@ class TestSMTP(unittest.TestCase):
             code, response = client.docmd('HELP me!')
             self.assertEqual(code, 501)
             self.assertEqual(response,
-                             b'Supported commands: DATA EHLO HELO MAIL '
+                             b'Supported commands: DATA EHLO HELO HELP MAIL '
                              b'NOOP QUIT RCPT RSET VRFY')
 
     def test_expn(self):

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -287,8 +287,8 @@ class TestSMTP(unittest.TestCase):
             code, response = client.docmd('HELP')
             self.assertEqual(code, 250)
             self.assertEqual(response,
-                             b'Supported commands: EHLO HELO MAIL RCPT '
-                             b'DATA RSET NOOP QUIT VRFY')
+                             b'Supported commands: DATA EHLO HELO MAIL '
+                             b'NOOP QUIT RCPT RSET VRFY')
 
     def test_help_helo(self):
         with SMTP(*self.address) as client:
@@ -374,8 +374,8 @@ class TestSMTP(unittest.TestCase):
             code, response = client.docmd('HELP me!')
             self.assertEqual(code, 501)
             self.assertEqual(response,
-                             b'Supported commands: EHLO HELO MAIL RCPT '
-                             b'DATA RSET NOOP QUIT VRFY')
+                             b'Supported commands: DATA EHLO HELO MAIL '
+                             b'NOOP QUIT RCPT RSET VRFY')
 
     def test_expn(self):
         with SMTP(*self.address) as client:

--- a/aiosmtpd/tests/test_starttls.py
+++ b/aiosmtpd/tests/test_starttls.py
@@ -103,6 +103,18 @@ class TestStartTLS(unittest.TestCase):
             code, response = client.docmd('STARTTLS', 'TRUE')
             self.assertEqual(code, 501)
 
+    def test_help_after_starttls(self):
+        controller = TLSController(Sink())
+        controller.start()
+        self.addCleanup(controller.stop)
+        with SMTP(controller.hostname, controller.port) as client:
+            # Don't get tricked by smtplib processing of the response.
+            code, response = client.docmd('HELP')
+            self.assertEqual(code, 250)
+            self.assertEqual(response,
+                             b'Supported commands: DATA EHLO HELO HELP MAIL '
+                             b'NOOP QUIT RCPT RSET STARTTLS VRFY')
+
 
 class TestTLSForgetsSessionData(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Added much better support for the ``HELP``.  There's a new decorator called   ``@syntax()`` which you can use in derived classes to decorate ``smtp_*()``   methods.  These then show up in ``HELP`` responses.  This also fixes  ``HELP`` responses for the ``LMTP`` subclass.

Closes #113 

Supplants #69 

