### PR TITLE
Don't call transport.close() in connection_lost.

### DIFF
--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -169,6 +169,11 @@ class SMTP(asyncio.StreamReaderProtocol):
     def eof_received(self):
         log.info('%r EOF received', self.session.peer)
         self._handler_coroutine.cancel()
+        if self.session.ssl is not None:
+            # If STARTTLS was issued, return False, because True has no effect
+            # on an SSL transport and raises a warning. Our superclass has no
+            # way of knowing we switched to SSL so it might return True.
+            return False
         return super().eof_received()
 
     def _client_connected_cb(self, reader, writer):


### PR DESCRIPTION
Calling `close` on a transport in a protocol `connection_lost` doesn't make sense as that will in turn call the protocols `connection_lost` again, thereby breaking the Stream Protocol state machine.

Not sure if this is the right solution to the problem, but I'm sure the call to `_writer.close` shouldn't be in `connection_lost`. ~But maybe the whole `self.transport` should be closed in the except block in `_handle_client`.~