### PR TITLE
don't strip last CR-LF prior to terminating dot

### DIFF
--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -649,8 +649,6 @@ class SMTP(asyncio.StreamReaderProtocol):
                 self._writer.close()
                 raise
             if line == b'.\r\n':
-                if data:
-                    data[-1] = data[-1].rstrip(b'\r\n')
                 break
             num_bytes += len(line)
             if (not size_exceeded and

--- a/aiosmtpd/tests/test_handlers.py
+++ b/aiosmtpd/tests/test_handlers.py
@@ -425,7 +425,7 @@ Testing
             'Subject: A test',
             'X-Peer: ::1',
             '',
-            'Testing']).encode('ascii')
+            'Testing\r\n']).encode('ascii')
 
     def test_deliver_bytes(self):
         with ExitStack() as resources:

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -159,14 +159,14 @@ class TestProtocol(unittest.TestCase):
 
     def test_honors_mail_delimeters(self):
         handler = ReceivingHandler()
-        data = b'test\r\nmail\rdelimeters\nsaved'
+        data = b'test\r\nmail\rdelimeters\nsaved\r\n'
         protocol = self._get_protocol(handler)
         protocol.data_received(BCRLF.join([
             b'HELO example.org',
             b'MAIL FROM: <anne@example.com>',
             b'RCPT TO: <anne@example.com>',
             b'DATA',
-            data + b'\r\n.',
+            data + b'.',
             b'QUIT\r\n'
             ]))
         try:
@@ -902,7 +902,7 @@ Testing
             mail = CRLF.join(['Test', '.', 'mail'])
             client.sendmail('anne@example.com', ['bart@example.com'], mail)
             self.assertEqual(len(handler.box), 1)
-            self.assertEqual(handler.box[0].content, 'Test\r\n.\r\nmail')
+            self.assertEqual(handler.box[0].content, 'Test\r\n.\r\nmail\r\n')
 
     def test_unexpected_errors(self):
         handler = ErroringHandler()


### PR DESCRIPTION
Stripping the last \r\n off the DATA command results in the messages
actual size being 2 bytes shorter than the SIZE set in MAIL FROM.

RFC 1870[1]:
>   The message size is defined as the number of octets, including CR-LF
>   pairs, but not the SMTP DATA command's terminating dot or doubled
>   quoting dots, to be transmitted by the SMTP client after receiving
>   reply code 354 to the DATA command.

[1] https://tools.ietf.org/html/rfc1870#section-5