### PR TITLE
Add a timeout feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ matrix:
       env: INTERP=py35 PYTHONASYNCIODEBUG=1
     - python: "3.6"
       env: INTERP=py36 PYTHONASYNCIODEBUG=1
+before_script:
+  - echo 0 | sudo tee /proc/sys/net/ipv6/conf/all/disable_ipv6
 script:
   - tox -e $INTERP-nocov,$INTERP-cov,qa,docs
   - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then tox -e $INTERP-diffcov; fi'

--- a/aiosmtpd/docs/smtp.rst
+++ b/aiosmtpd/docs/smtp.rst
@@ -132,8 +132,8 @@ SMTP API
    depth discussion on enabling ``STARTTLS``.
 
    *timeout* is the number of seconds to wait between valid SMTP commands.
-   After this time the connection will be closed by the server.  The default 
-   es 300 seconds, as per `RFC 2821`_.
+   After this time the connection will be closed by the server.  The default
+   is 300 seconds, as per `RFC 2821`_.
 
    *loop* is the asyncio event loop to use.  If not given,
    :meth:`asyncio.new_event_loop()` is called to create the event loop.

--- a/aiosmtpd/docs/smtp.rst
+++ b/aiosmtpd/docs/smtp.rst
@@ -101,7 +101,7 @@ override to provide additional responses.
 SMTP API
 ========
 
-.. class:: SMTP(handler, *, data_size_limit=33554432, enable_SMTPUTF8=False, decode_data=False, hostname=None, ident=None, tls_context=None, require_starttls=False, loop=None)
+.. class:: SMTP(handler, *, data_size_limit=33554432, enable_SMTPUTF8=False, decode_data=False, hostname=None, ident=None, tls_context=None, require_starttls=False, timeout=300, loop=None)
 
    *handler* is an instance of a :ref:`handler <handlers>` class.
 
@@ -120,7 +120,7 @@ SMTP API
    *hostname* is the first part of the string returned in the ``220`` greeting
    response given to clients when they first connect to the server.  If not given,
    the system's fully-qualified domain name is used.
-   
+
    *ident* is the second part of the string returned in the ``220`` greeting
    response that identifies the software name and version of the SMTP server
    to the client. If not given, a default Python SMTP ident is used.
@@ -130,6 +130,10 @@ SMTP API
    server. For this option to be available, *tls_context* must be supplied,
    and *require_starttls* should be ``True``.  See :ref:`tls` for a more in
    depth discussion on enabling ``STARTTLS``.
+
+   *timeout* is the number of seconds to wait between valid SMTP commands.
+   After this time the connection will be closed by the server.  The default 
+   es 300 seconds, as per `RFC 2821`_.
 
    *loop* is the asyncio event loop to use.  If not given,
    :meth:`asyncio.new_event_loop()` is called to create the event loop.
@@ -253,8 +257,8 @@ advertised, and the ``STARTTLS`` command will not be accepted.
 *require_starttls* is meaningless in this case, and should be set to
 ``False``.
 
-
 .. _StreamReaderProtocol: https://docs.python.org/3/library/asyncio-stream.html#streamreaderprotocol
 .. _`RFC 3207`: http://www.faqs.org/rfcs/rfc3207.html
+.. _`RFC 2821`: https://www.ietf.org/rfc/rfc2821.txt
 .. _`asyncio transport`: https://docs.python.org/3/library/asyncio-protocol.html#asyncio-transport
 .. _ssl: https://docs.python.org/3/library/ssl.html

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -75,6 +75,7 @@ class SMTP(asyncio.StreamReaderProtocol):
                  ident=None,
                  tls_context=None,
                  require_starttls=False,
+                 timeout=300,
                  loop=None):
         self.__ident__ = ident or __ident__
         self.loop = loop if loop else make_loop()
@@ -98,6 +99,8 @@ class SMTP(asyncio.StreamReaderProtocol):
             self.tls_context.check_hostname = False
             self.tls_context.verify_mode = ssl.CERT_NONE
         self.require_starttls = tls_context and require_starttls
+        self._timeout_duration = timeout
+        self._timeout_handle = None
         self._tls_handshake_okay = True
         self._tls_protocol = None
         self._original_transport = None
@@ -131,6 +134,7 @@ class SMTP(asyncio.StreamReaderProtocol):
         self._set_rset_state()
         self.session = self._create_session()
         self.session.peer = transport.get_extra_info('peername')
+        self._reset_timeout()
         seen_starttls = (self._original_transport is not None)
         if self.transport is not None and seen_starttls:
             # It is STARTTLS connection over normal connection.
@@ -156,6 +160,7 @@ class SMTP(asyncio.StreamReaderProtocol):
 
     def connection_lost(self, error):
         log.info('%r connection lost', self.session.peer)
+        self._timeout_handle.cancel()
         # If STARTTLS was issued, then our transport is the SSL protocol
         # transport, and we need to close the original transport explicitly,
         # otherwise an unexpected eof_received() will be called *after* the
@@ -181,6 +186,21 @@ class SMTP(asyncio.StreamReaderProtocol):
             # above.
             return False
         return super().eof_received()
+
+    def _reset_timeout(self):
+        if self._timeout_handle:
+            self._timeout_handle.cancel()
+
+        self._timeout_handle = self.loop.call_later(
+                self._timeout_duration, self._timeout_cb)
+
+    def _timeout_cb(self):
+        log.info('%r connection timeout', self.session.peer)
+
+        # Calling close() on the transport will trigger connection_lost(),
+        # which gracefully closes the SSL transport if required and cleans
+        # up state.
+        self.transport.close()
 
     def _client_connected_cb(self, reader, writer):
         # This is redundant since we subclass StreamReaderProtocol, but I like
@@ -279,6 +299,9 @@ class SMTP(asyncio.StreamReaderProtocol):
                     await self.push(
                         '500 Error: command "%s" not recognized' % command)
                     continue
+
+                # Received a valid command, reset the timer.
+                self._reset_timeout()
                 await method(arg)
             except asyncio.CancelledError:
                 # The connection got reset during the DATA command.

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -188,7 +188,7 @@ class SMTP(asyncio.StreamReaderProtocol):
         return super().eof_received()
 
     def _reset_timeout(self):
-        if self._timeout_handle:
+        if self._timeout_handle is not None:
             self._timeout_handle.cancel()
 
         self._timeout_handle = self.loop.call_later(

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -30,7 +30,7 @@ class NoDecodeController(Controller):
 
 class TimeoutController(Controller):
     def factory(self):
-        return Server(self.handler, timeout=1)
+        return Server(self.handler, timeout=0.1)
 
 
 class ReceivingHandler:
@@ -1173,5 +1173,5 @@ class TestTimeout(unittest.TestCase):
     def test_timeout(self):
         with SMTP(*self.address) as client:
             code, response = client.ehlo('example.com')
-            time.sleep(2)
+            time.sleep(0.3)
             self.assertRaises(SMTPServerDisconnected, client.getreply)


### PR DESCRIPTION
Client will now be disconnected after a set period of time, which can be
adjusted.  This prevents one form of resource exhaustion when badly
behaving clients connect and never send any data.

This partially fixes issue #145 