### PR TITLE
add newer python version to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,24 @@ install:
   - pip install -r aiosmtpd.egg-info/requires.txt
 matrix:
   include:
-    - python: "3.5"
-      env: INTERP=py35 PYTHONASYNCIODEBUG=1
-    - python: "3.6"
-      env: INTERP=py36 PYTHONASYNCIODEBUG=1
+  - python: '3.5'
+    env: INTERP=py35 PYTHONASYNCIODEBUG=1
+  - python: '3.6'
+    env: INTERP=py36 PYTHONASYNCIODEBUG=1
+  - python: '3.7'
+    env: INTERP=py37 PYTHONASYNCIODEBUG=1
+    dist: xenial
+    sudo: required
+  - python: 3.8-dev
+    env: INTERP=py38 PYTHONASYNCIODEBUG=1
+    dist: xenial
+    sudo: required
+
+  allow_failures:
+  - python: 3.8-dev
 before_script:
   # Disable IPv6. Ref travis-ci/travis-ci#8711
   - echo 0 | sudo tee /proc/sys/net/ipv6/conf/all/disable_ipv6
 script:
   - tox -e $INTERP-nocov,$INTERP-cov,qa,docs
   - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then tox -e $INTERP-diffcov; fi'
-before_script:
-  - echo 0 | sudo tee /proc/sys/net/ipv6/conf/all/disable_ipv6


### PR DESCRIPTION
Add python 3.7 and python 3.8 (with failure allowed) to travis.