### PR TITLE
Use MagicMock to make sure create_server doesn't use AsyncMock on Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ matrix:
     - python: "3.7"
       env: INTERP=py37 PYTHONASYNCIODEBUG=1
       dist: xenial
+    - python: "3.8"
+      env: INTERP=py38 PYTHONASYNCIODEBUG=1
+      dist: xenial
 before_script:
   # Disable IPv6. Ref travis-ci/travis-ci#8711
   - echo 0 | sudo tee /proc/sys/net/ipv6/conf/all/disable_ipv6

--- a/aiosmtpd/tests/test_main.py
+++ b/aiosmtpd/tests/test_main.py
@@ -10,7 +10,7 @@ from aiosmtpd.smtp import SMTP, __version__
 from contextlib import ExitStack
 from functools import partial
 from io import StringIO
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 try:
     import pwd
@@ -150,7 +150,7 @@ class TestLoop(unittest.TestCase):
         pfunc = partial(patch.object, self.loop)
         resources = ExitStack()
         self.addCleanup(resources.close)
-        self.create_server = resources.enter_context(pfunc('create_server'))
+        self.create_server = resources.enter_context(pfunc('create_server', MagicMock()))
         self.run_until_complete = resources.enter_context(
             pfunc('run_until_complete'))
         self.add_signal_handler = resources.enter_context(

--- a/aiosmtpd/tests/test_main.py
+++ b/aiosmtpd/tests/test_main.py
@@ -10,7 +10,7 @@ from aiosmtpd.smtp import SMTP, __version__
 from contextlib import ExitStack
 from functools import partial
 from io import StringIO
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 try:
     import pwd
@@ -150,7 +150,8 @@ class TestLoop(unittest.TestCase):
         pfunc = partial(patch.object, self.loop)
         resources = ExitStack()
         self.addCleanup(resources.close)
-        self.create_server = resources.enter_context(pfunc('create_server', MagicMock()))
+        self.create_server = resources.enter_context(
+            pfunc('create_server', MagicMock()))
         self.run_until_complete = resources.enter_context(
             pfunc('run_until_complete'))
         self.add_signal_handler = resources.enter_context(

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py35,py36,py37}-{cov,nocov,diffcov},qa,docs
+envlist = {py35,py36,py37,py38}-{cov,nocov,diffcov},qa,docs
 skip_missing_interpreters = True
 
 [testenv]
@@ -26,6 +26,7 @@ setenv =
     py35: INTERP=py35
     py36: INTERP=py36
     py37: INTERP=py37
+    py38: INTERP=py38
     PLATFORM={env:PLATFORM:linux}
 passenv =
     PYTHON*


### PR DESCRIPTION
## What do these changes do?

On Python 3.8 mocking async functions return an AsyncMock which used to be a MagicMock. Restore the older behavior to fix the tests in 3.8

## Are there changes in behavior for the user?

No, this change is tests only.

## Related issue number

#167 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder

I am not sure these changes need to be added to CHANGES or docs. The project also needs to be updated to test on 3.8. If someone can help or suggest changes for travis and tox config it would be helpful. Thanks.
