### PR TITLE
fix tls handshake/error handling

### DIFF
--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -16,7 +16,9 @@ Fixed/Improved
 * Delay all SMTP Status Code replies during ``DATA`` phase until the phase termination (Closes #9)
 * Now catches ``Controller.factory()`` failure during ``Controller.start()`` (Closes #212)
 * :class:`SMTP` no longer edits user-supplied SSL Context (closes #191)
-
+* Implement waiting for SSL setup/handshake within STARTTLS handler to be able to catch and handle
+  (log) errors and to avoid session hanging around until timeout in such cases
+* Add session peer information to some logging output where it was missing
 
 1.2.2 (2020-11-08)
 ==================

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -432,12 +432,12 @@ class SMTP(asyncio.StreamReaderProtocol):
             except Exception as error:
                 try:
                     status = await self.handle_exception(error)
-                except Exception as error2:
+                except Exception as inner_error:
                     try:
                         log.exception('%r Exception in handle_exception()',
                                       self.session.peer)
                         status = '500 Error: ({}) {}'.format(
-                            error2.__class__.__name__, str(error2))
+                            inner_error.__class__.__name__, str(inner_error))
                     except Exception:
                         status = '500 Error: Cannot describe error'
                 finally:

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -430,6 +430,7 @@ class SMTP(asyncio.StreamReaderProtocol):
                 self._writer.close()
                 raise
             except Exception as error:
+                status = None
                 try:
                     status = await self.handle_exception(error)
                 except Exception as inner_error:

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -1524,7 +1524,7 @@ Testing
         self.addCleanup(controller.stop)
         with SMTP(controller.hostname, controller.port) as client:
             code, mesg = client.helo('example.com')
-        self.assertEqual(code, 451)
+        self.assertEqual(code, 500)
         self.assertEqual(mesg, b'Error: (ValueError) test')
         # handler.error did not change because the handler does not have a
         # handle_exception() method.
@@ -1554,7 +1554,7 @@ Testing
         self.addCleanup(controller.stop)
         with SMTP(controller.hostname, controller.port) as client:
             code, mesg = client.helo('example.com')
-        self.assertEqual(code, 451)
+        self.assertEqual(code, 500)
         self.assertEqual(mesg, b'Error: (ValueError) ErroringErrorHandler test')
         self.assertIsInstance(handler.error, ValueError)
 
@@ -1595,7 +1595,7 @@ Testing
         self.addCleanup(controller.stop)
         with SMTP(controller.hostname, controller.port) as client:
             code, mesg = client.helo('example.com')
-        self.assertEqual(code, 451)
+        self.assertEqual(code, 500)
         self.assertEqual(mesg, b'Error: Cannot describe error')
         self.assertIsInstance(handler.error, ValueError)
 

--- a/aiosmtpd/tests/test_starttls.py
+++ b/aiosmtpd/tests/test_starttls.py
@@ -183,7 +183,9 @@ class TestStartTLS(unittest.TestCase):
             self.doCleanups()
             self.assertRaises(SMTPServerDisconnected, client.quit)
 
-    def test_tls_handshake_failing(self):
+    # Suppress hairy-looking, but ultimately harmless, warning + traceback
+    @patch("logging.Logger.warning")
+    def test_tls_handshake_failing(self, mock_warning):
         class ExceptionCaptureHandler:
             error = None
 

--- a/aiosmtpd/tests/test_starttls.py
+++ b/aiosmtpd/tests/test_starttls.py
@@ -27,7 +27,6 @@ def setUpModule():
 
 def tearDownModule():
     ModuleResources.close()
-from smtplib import SMTP, SMTPServerDisconnected
 
 
 class Controller(BaseController):

--- a/aiosmtpd/tests/test_starttls.py
+++ b/aiosmtpd/tests/test_starttls.py
@@ -3,7 +3,7 @@ import unittest
 
 from aiosmtpd.controller import Controller as BaseController
 from aiosmtpd.handlers import Sink
-from aiosmtpd.smtp import Session as Sess_, SMTP as SMTPProtocol
+from aiosmtpd.smtp import Session as Sess_, SMTP as SMTPProtocol, TLSSetupException
 from aiosmtpd.testing.helpers import (
     ReceivingHandler,
     SUPPORTED_COMMANDS_TLS,
@@ -11,9 +11,8 @@ from aiosmtpd.testing.helpers import (
     get_server_context,
 )
 from contextlib import ExitStack
-from aiosmtpd.smtp import SMTP as SMTPProtocol, TLSSetupException
 from email.mime.text import MIMEText
-from smtplib import SMTP
+from smtplib import SMTP, SMTPServerDisconnected
 from unittest.mock import Mock, patch
 
 

--- a/aiosmtpd/tests/test_starttls.py
+++ b/aiosmtpd/tests/test_starttls.py
@@ -84,7 +84,9 @@ class EOFingHandler:
 
 
 class TestTLSEnding(unittest.TestCase):
-    def test_eof_received(self):
+    # Suppress scary-looking, but totally harmless, log warning
+    @patch("logging.Logger.warning")
+    def test_eof_received(self, mock_warning):
         # Adapted from 54ff1fa9 + fc65a84e of PR #202
         #
         # I don't like this. It's too intimately involved with the innards of
@@ -173,7 +175,9 @@ class TestStartTLS(unittest.TestCase):
             self.assertEqual(code, 250)
             self.assertEqual(response, SUPPORTED_COMMANDS_TLS)
 
-    def test_tls_handshake_stopcontroller(self):
+    # Suppress hairy-looking, but harmless & expected, log error
+    @patch("logging.Logger.error")
+    def test_tls_handshake_stopcontroller(self, mock_error):
         controller = TLSController(Sink())
         controller.start()
         self.addCleanup(controller.stop)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Implement waiting for SSL setup/handshake within STARTTLS handler to be able to catch and handle (log) errors and to avoid session hanging around until timeout in such cases.
Add sessions peer information to some logging output where it was missing.
## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
Better logging of TLS handshake issues and less ressource consumption on such.
## Related issue number
Closes #173
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
