### PR TITLE
Release helpers

### DIFF
--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -11,7 +11,7 @@ from public import public
 from warnings import warn
 
 
-__version__ = '1.2+'
+__version__ = '1.2.2'
 __ident__ = 'Python SMTP {}'.format(__version__)
 log = logging.getLogger('mail.log')
 

--- a/release.py
+++ b/release.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+import sys
+
+import aiosmtpd.smtp as smtpd
+
+version = smtpd.__version__
+
+choice = input(f'Release aiosmtpd {version} - correct? [y/N]: ')
+if choice.lower() not in ('y', 'yes'):
+    sys.exit('Release aborted')
+else:
+    # We're probably already in the right place
+    os.chdir(os.path.dirname(os.path.abspath(__file__)))
+    # Let's use *this* python to build, please
+    subprocess.run([sys.executable, "setup.py", "sdist"])
+    # Assuming twine is installed. And that we're only building .tar.gz
+    subprocess.run(["twine", "check", f"dist/aiosmtpd-{version}.tar.gz"])
+    # You should have an aiosmtpd bit setup in your ~/.pypirc - for twine
+    subprocess.run(["twine", "upload", "--config-file", "~/.pypirc", "-r", "aiosmtpd", "dist/aiosmptd-{version}.tar.gz"])
+    # Only tag when we've actually built and uploaded. If something goes wrong
+    # we may need the tag somewhere else!
+    # The annotation information should come from the changelog
+    subprocess.run(["git", "tag", "-a", version])
+    # And now push the tag, of course.
+    subprocess.run(["git", "push", "upstream", "--tags"])

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
 This is a server for SMTP and related protocols, similar in utility to the
 standard library's smtpd.py module, but rewritten to be based on asyncio for
 Python 3.""",
+    long_description_content_type="text/x-rst",
     url='http://aiosmtpd.readthedocs.io/',
     keywords='email',
     packages=find_packages(),


### PR DESCRIPTION
This adds a release helper script - basically what I use to upload releases to pypi myself. I don't have any emotional investment in the configuration of this script - it's just me trying to improve that bus factor. If there are improvements then they are very welcome!

Anyway, the idea is that you should be able to create a pypi token and setup a `~/.pypirc`, install necessary packages (e.g. twine), and then you'd be able to run this script any time you needed to release!

In the process of setting up this script, the twine check informed me of the missing field, so I went ahead and fixed that.