### PR TITLE
Exclude examples from bdist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ Python 3.""",
     long_description_content_type="text/x-rst",
     url='http://aiosmtpd.readthedocs.io/',
     keywords='email',
-    packages=find_packages(),
+    packages=find_packages(exclude=['examples']),
     include_package_data=True,
     license='http://www.apache.org/licenses/LICENSE-2.0',
     install_requires=[


### PR DESCRIPTION
setup.py:
Use the exclude parameter to find_packages() to exclude 'examples' from
the bdist distribution, as the directory is otherwise installed
top-level to the site-packages directory (potentially conflicting with
other packages).

Fixes #181

<!-- Thank you for your contribution! -->

## What do these changes do?

see above

## Are there changes in behavior for the user?

see above

## Related issue number

see above

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
