### PR TITLE
BUGFIX: RFC4954 behavior for lone "="

### DIFF
--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -3,6 +3,16 @@
 ===================
 
 
+1.2.4 (aiosmtpd-next)
+=====================
+
+Fixed/Improved
+--------------
+* Remove special handling for lone ``=`` during AUTH;
+  it is now treated as simple Base64-encoded ``b""``.
+  This is the correct, strict interpretation of :rfc:`4954` mentions about ``=``
+
+
 1.2.3 (2021-01-14)
 ==================
 

--- a/aiosmtpd/docs/handlers.rst
+++ b/aiosmtpd/docs/handlers.rst
@@ -183,7 +183,7 @@ those methods of the handler instance will override the built-in methods.
 
   :boldital:`server` is the instance of the ``SMTP`` class invoking the AUTH hook.
   This allows the AUTH hook implementation to invoke facilities such as the
-  ``push()`` and ``_auth_interact()`` methods.
+  ``push()`` and ``challenge_auth()`` methods.
 
   :boldital:`args` is a list of string split from the string after the ``AUTH`` command.
   ``args[0]`` is always equal to ``MECHANISM``.

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -795,9 +795,6 @@ class SMTP(asyncio.StreamReaderProtocol):
     #      - 'identity' is not always username, depending on the auth mecha-
     #        nism. Might be a session key, a one-time user ID, or any kind of
     #        object, actually.
-    #      - If the client provides "=" for username during interaction, the
-    #        method MUST return b"" (empty bytes) NOT None, because None has been
-    #        used to indicate error/login failure.
     # 3. Auth credentials checking is performed in the auth_* methods because
     #    more advanced auth mechanism might not return login+password pair
     #    (see #2 above)

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -767,7 +767,10 @@ class SMTP(asyncio.StreamReaderProtocol):
 
     _334_PREFIX = re.compile(r"^334 ")
 
-    async def _auth_interact(self, server_message: str) -> Union[_Missing, bytes]:
+    async def _auth_interact(
+            self,
+            server_message: str
+    ) -> Union[_Missing, bytes]:  # pragma: nocover
         warn(
             "_auth_interact will be deprecated in version 2.0. "
             "Please use challenge_auth() instead.",

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -737,12 +737,12 @@ class SMTP(asyncio.StreamReaderProtocol):
         Send challenge during authentication. "334 " will be prefixed, so do NOT
         put "334 " at start of server_message.
 
-        :param challenge: Challenge to send to client. Must be ASCII-encodable
+        :param challenge: Challenge to send to client. If str, will be utf8-encoded.
         :param encode_to_b64: If true, then perform Base64 encoding on challenge
         :return: Response from client, or MISSING
         """
         challenge = (
-            challenge.encode("ascii") if isinstance(challenge, str) else challenge
+            challenge.encode() if isinstance(challenge, str) else challenge
         )
         assert isinstance(challenge, bytes)
         # Trailing space is MANDATORY even if server_message is empty.

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -741,14 +741,15 @@ class SMTP(asyncio.StreamReaderProtocol):
         :param encode_to_b64: If true, then perform Base64 encoding on challenge
         :return: Response from client, or MISSING
         """
-        if isinstance(challenge, str):
-            challenge = challenge.encode("ascii")
+        challenge = (
+            challenge.encode("ascii") if isinstance(challenge, str) else challenge
+        )
         assert isinstance(challenge, bytes)
-        if encode_to_b64:
-            challenge = b64encode(challenge)
         # Trailing space is MANDATORY even if server_message is empty.
         # See https://tools.ietf.org/html/rfc4954#page-4 ¶ 5
-        await self.push(b"334 " + challenge)
+        await self.push(
+            b"334 " + (b64encode(challenge) if encode_to_b64 else challenge)
+        )
         line = await self._reader.readline()
         blob: bytes = line.strip()
         # '*' handling in accordance with RFC4954

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -819,9 +819,9 @@ class SMTP(asyncio.StreamReaderProtocol):
             await self.push("501 5.5.2 Can't split auth value")
             return
         # Verify login data
+        assert login is not None
+        assert password is not None
         if self._auth_callback("PLAIN", login, password):
-            if login is None:
-                login = EMPTYBYTES
             return login
         else:
             return MISSING
@@ -837,9 +837,9 @@ class SMTP(asyncio.StreamReaderProtocol):
         if password is MISSING:
             return
 
+        assert login is not None
+        assert password is not None
         if self._auth_callback("LOGIN", login, password):
-            if login is None:  # pragma: no branch
-                login = EMPTYBYTES
             return login
         else:
             return MISSING

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -9,12 +9,13 @@ import binascii
 import collections
 import asyncio.sslproto as sslproto
 
-from base64 import b64decode
+from base64 import b64decode, b64encode
 from email._header_value_parser import get_addr_spec, get_angle_addr
 from email.errors import HeaderParseError
 from public import public
 from typing import (
     Any,
+    AnyStr,
     Awaitable,
     Callable,
     Dict,
@@ -59,7 +60,7 @@ __all__ = [
     "AuthMechanismType",
     "MISSING",
 ]  # Will be added to by @public
-__version__ = '1.2.3'
+__version__ = '1.2.4a1'
 __ident__ = 'Python SMTP {}'.format(__version__)
 log = logging.getLogger('mail.log')
 
@@ -383,10 +384,14 @@ class SMTP(asyncio.StreamReaderProtocol):
         """Reset all state variables except the greeting."""
         self._set_post_data_state()
 
-    async def push(self, status):
-        response = bytes(
-            status + '\r\n', 'utf-8' if self.enable_SMTPUTF8 else 'ascii')
-        self._writer.write(response)
+    async def push(self, status: AnyStr):
+        if isinstance(status, str):
+            response = bytes(
+                status, 'utf-8' if self.enable_SMTPUTF8 else 'ascii')
+        else:
+            response = status
+        assert isinstance(response, bytes)
+        self._writer.write(response + b"\r\n")
         log.debug("%r << %r", self.session.peer, response)
         await self._writer.drain()
 
@@ -723,18 +728,33 @@ class SMTP(asyncio.StreamReaderProtocol):
             if status is not None:  # pragma: no branch
                 await self.push(status)
 
-    async def _auth_interact(self, server_message) -> _TriStateType:
-        blob: bytes
-        await self.push(server_message)
+    async def challenge_auth(
+            self,
+            challenge: AnyStr,
+            encode_to_b64: bool = True,
+    ) -> Union[_Missing, bytes]:
+        """
+        Send challenge during authentication. "334 " will be prefixed, so do NOT
+        put "334 " at start of server_message.
+
+        :param challenge: Challenge to send to client. Must be ASCII-encodable
+        :param encode_to_b64: If true, then perform Base64 encoding on challenge
+        :return: Response from client, or MISSING
+        """
+        if isinstance(challenge, str):
+            challenge = challenge.encode("ascii")
+        assert isinstance(challenge, bytes)
+        if encode_to_b64:
+            challenge = b64encode(challenge)
+        # Trailing space is MANDATORY even if server_message is empty.
+        # See https://tools.ietf.org/html/rfc4954#page-4 ¶ 5
+        await self.push(b"334 " + challenge)
         line = await self._reader.readline()
-        blob = line.strip()
-        # '=' and '*' handling are in accordance with RFC4954
-        if blob == b"=":
-            log.debug("%r responded with '='", self.session.peer)
-            return None
+        blob: bytes = line.strip()
+        # '*' handling in accordance with RFC4954
         if blob == b"*":
-            log.warning("%r aborted with '*'", self.session.peer)
-            await self.push("501 Auth aborted")
+            log.warning("%r aborted AUTH with '*'", self.session.peer)
+            await self.push("501 5.7.0 Auth aborted")
             return MISSING
         try:
             decoded_blob = b64decode(blob, validate=True)
@@ -743,6 +763,19 @@ class SMTP(asyncio.StreamReaderProtocol):
             await self.push("501 5.5.2 Can't decode base64")
             return MISSING
         return decoded_blob
+
+    _334_PREFIX = re.compile(r"^334 ")
+
+    async def _auth_interact(self, server_message: str) -> Union[_Missing, bytes]:
+        warn(
+            "_auth_interact will be deprecated in version 2.0. "
+            "Please use challenge_auth() instead.",
+            DeprecationWarning
+        )
+        return await self.challenge_auth(
+            challenge=self._334_PREFIX.sub("", server_message),
+            encode_to_b64=False,
+        )
 
     # IMPORTANT NOTES FOR THE auth_* METHODS
     #
@@ -768,30 +801,23 @@ class SMTP(asyncio.StreamReaderProtocol):
     async def auth_PLAIN(self, _, args: List[str]):
         login_and_password: _TriStateType
         if len(args) == 1:
-            # Trailing space is MANDATORY
-            # See https://tools.ietf.org/html/rfc4954#page-4 ¶ 5
-            login_and_password = await self._auth_interact("334 ")
+            login_and_password = await self.challenge_auth("")
             if login_and_password is MISSING:
                 return
         else:
-            blob = args[1]
-            if blob == "=":
-                login_and_password = None
-            else:
-                try:
-                    login_and_password = b64decode(blob, validate=True)
-                except Exception:
-                    await self.push("501 5.5.2 Can't decode base64")
-                    return
-        # Decode login data
-        if login_and_password is None:
-            login = password = None
-        else:
             try:
-                _, login, password = login_and_password.split(b"\x00")
-            except ValueError:  # not enough args
-                await self.push("501 5.5.2 Can't split auth value")
+                login_and_password = b64decode(args[1].encode(), validate=True)
+            except Exception:
+                await self.push("501 5.5.2 Can't decode base64")
                 return
+        try:
+            # login data is "{authz_id}\x00{login_id}\x00{password}"
+            # authz_id can be null, and currently ignored
+            # See https://tools.ietf.org/html/rfc4616#page-3
+            _, login, password = login_and_password.split(b"\x00")
+        except ValueError:  # not enough args
+            await self.push("501 5.5.2 Can't split auth value")
+            return
         # Verify login data
         if self._auth_callback("PLAIN", login, password):
             if login is None:
@@ -802,14 +828,12 @@ class SMTP(asyncio.StreamReaderProtocol):
 
     async def auth_LOGIN(self, _, args: List[str]):
         login: _TriStateType
-        # 'User Name\x00'
-        login = await self._auth_interact("334 VXNlciBOYW1lAA==")
+        login = await self.challenge_auth(b"User Name\x00")
         if login is MISSING:
             return
 
         password: _TriStateType
-        # 'Password\x00'
-        password = await self._auth_interact("334 UGFzc3dvcmQA")
+        password = await self.challenge_auth(b"Password\x00")
         if password is MISSING:
             return
 

--- a/aiosmtpd/testing/helpers.py
+++ b/aiosmtpd/testing/helpers.py
@@ -65,19 +65,25 @@ def start(plugin):
         warnings.filterwarnings('always', category=ResourceWarning)
 
 
-def assert_auth_success(testcase: TestCase, code, response):
-    testcase.assertEqual(code, 235)
-    testcase.assertEqual(response, b"2.7.0 Authentication successful")
+def assert_auth_success(testcase: TestCase, *response):
+    testcase.assertEqual(
+        (235, b"2.7.0 Authentication successful"),
+        response
+    )
 
 
-def assert_auth_invalid(testcase: TestCase, code, response):
-    testcase.assertEqual(code, 535)
-    testcase.assertEqual(response, b'5.7.8 Authentication credentials invalid')
+def assert_auth_invalid(testcase: TestCase, *response):
+    testcase.assertEqual(
+        (535, b"5.7.8 Authentication credentials invalid"),
+        response
+    )
 
 
-def assert_auth_required(testcase: TestCase, code, response):
-    testcase.assertEqual(code, 530)
-    testcase.assertEqual(response, b'5.7.0 Authentication required')
+def assert_auth_required(testcase: TestCase, *response):
+    testcase.assertEqual(
+        (530, b"5.7.0 Authentication required"),
+        response
+    )
 
 
 SUPPORTED_COMMANDS_TLS: bytes = (


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

When implementing AUTH support, I misunderstood the meaning of `=` (lone equal sign) in [RFC 4954](https://tools.ietf.org/html/rfc4954).

This has been fixed to strictly comply with RFC 4954 and also [RFC 4616](https://tools.ietf.org/html/rfc4616)

This mostly impacts `AUTH PLAIN` which requires a special null-separated struct.

## Are there changes in behavior for the user?

If user (of this library, not an SMTP client) wants to test AUTH PLAIN with null login, then sending `AUTH PLAIN =` or as a response to the challenge will no longer work. This shouldn't be a problem if test is done using Standard Lib's `smtplib.SMTP`, because `smtplib.SMTP.auth_plain` already properly creates the necessary null-separated struct.

## Related issue number

None

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] tox testenvs have been executed in the following environments:
   - [x] Windows 10 (via PyCharm tox runner): `(ALL)`
   - [x] Windows 10 (via PSCore 7.1.0): `(ALL)`
   - [x] Windows 10 (via Cygwin): `qa,py36-{nocov,cov}`
   - [x] Ubuntu 18.04 on WSL 1.0: `(ALL)` + `pypy3-{nocov,cov,diffcov}`
   - [x] Ubuntu 18.04 on VBox: `(ALL)` + `pypy3-{nocov,cov,diffcov}`
   - [x] Ubuntu 20.04 on VBox: `(ALL)` + `pypy3-{nocov,cov,diffcov}`
   - [x] FreeBSD 12.1 on VBox: `(ALL)` + `pypy3-nocov`
- [x] Documentation reflects the changes
- [x] Add a news fragment into the `NEWS.rst` file
