### PR TITLE
Hide password in logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ diffcov.html
 diffcov-*.html
 .python-version
 .pytype/
+~temp*

--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -2,6 +2,17 @@
  NEWS for aiosmtpd
 ===================
 
+1.2.4 (aiosmtpd-next)
+=====================
+
+Added
+-----
+* Optional (default-disabled) logging of ``AUTH`` interaction -- with severe warnings
+
+Fixed/Improved
+--------------
+* ``AUTH`` command line now sanitized before logging (Closes #233)
+
 
 1.2.3 (2021-01-14)
 ==================

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -60,7 +60,7 @@ __all__ = [
     "AuthMechanismType",
     "MISSING",
 ]  # Will be added to by @public
-__version__ = '1.2.3'
+__version__ = '1.2.4a1'
 __ident__ = 'Python SMTP {}'.format(__version__)
 log = logging.getLogger('mail.log')
 

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -30,7 +30,8 @@ from warnings import warn
 # region #### Custom Data Types #######################################################
 
 class _Missing:
-    pass
+    def __repr__(self):
+        return "MISSING"
 
 
 class _AuthMechAttr(NamedTuple):

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -79,7 +79,15 @@ ALLOWED_BEFORE_STARTTLS = {"NOOP", "EHLO", "STARTTLS", "QUIT"}
 
 # Auth hiding regexes
 CLIENT_AUTH_B = re.compile(
-    br"(?P<authm>\s*AUTH\s+\S+[^\S\r\n]+)(\S+)(?P<crlf>(?:\r\n)?)", re.IGNORECASE
+    # Matches "AUTH" <mechanism> <whitespace_but_not_\r_nor_\n>
+    br"(?P<authm>\s*AUTH\s+\S+[^\S\r\n]+)"
+    # Param to AUTH <mechanism>. We only need to sanitize if param is given, which
+    # for some mechanisms contain sensitive info. If no param is given, then we
+    # can skip (match fails)
+    br"(\S+)"
+    # Optional bCRLF at end. Why optional? Because we also want to sanitize the
+    # stripped line. If no bCRLF, then this group will be b""
+    br"(?P<crlf>(?:\r\n)?)", re.IGNORECASE
 )
 
 # endregion

--- a/aiosmtpd/testing/helpers.py
+++ b/aiosmtpd/testing/helpers.py
@@ -65,9 +65,8 @@ def start(plugin):
         warnings.filterwarnings('always', category=ResourceWarning)
 
 
-def assert_auth_success(testcase: TestCase, code, response):
-    testcase.assertEqual(code, 235)
-    testcase.assertEqual(response, b"2.7.0 Authentication successful")
+def assert_auth_success(testcase: TestCase, *response):
+    assert response == (235, b"2.7.0 Authentication successful")
 
 
 def assert_auth_invalid(testcase: TestCase, code, response):

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -46,7 +46,7 @@ def setUpModule():
     # and oftentimes (not always, though) leads to Error
     ModuleResources.enter_context(patch("socket.getfqdn", return_value="localhost"))
 
-    loglevel = int(os.environ.get("AIOSMTPD_TESTLOGLEVEL", "INFO"))
+    loglevel = int(os.environ.get("AIOSMTPD_TESTLOGLEVEL", logging.INFO))
     mail_logger.setLevel(loglevel)
 
     if "AIOSMTPD_TESTLOGFILE" in os.environ:

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -101,12 +101,14 @@ class PeekerHandler:
     ):
         return MISSING
 
-    async def auth_WITH_UNDERSCORE(self, server, args):
+    async def auth_WITH_UNDERSCORE(self, server: Server, args):
         """
         Be careful when using this AUTH mechanism; log_client_response is set to
         True, and this will raise some severe warnings.
         """
-        await server._auth_interact("334 challenge", log_client_response=True)
+        await server.challenge_auth(
+            "challenge", encode_to_b64=False, log_client_response=True
+        )
         return "250 OK"
 
     @auth_mechanism("with-dash")

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -262,6 +262,7 @@ class TestProtocol(unittest.TestCase):
     def setUp(self):
         self.transport = Mock()
         self.transport.write = self._write
+        self.transport.get_extra_info.return_value = "MockedPeer"
         self.responses = []
         self._old_loop = asyncio.get_event_loop()
         self.loop = asyncio.new_event_loop()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Sanitize command line before logging.

This prevents leakage of sensitive information.

## Are there changes in behavior for the user?

Only if user parses the log output.

If user _absolutely_ needs to capture the SMTP credentials, user can:

  1. Override the `auth_*` methods and/or set `log_client_response=True` on calls to `SMTP._auth_interact()` (for custom, non-built-in AUTH mechanisms), or
  2. Perform the logging within the `auth_callback` function

## Related issue number

Closes #233 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] tox testenvs have been executed in the following environments:
   - [x] Windows 10 (via PyCharm tox runner): `(ALL)`
   - [x] Windows 10 (via PSCore 7.1.0): `(ALL)`
   - [x] Windows 10 (via Cygwin): `qa,py36-{nocov,cov}`
   - [x] Ubuntu 18.04 on WSL 1.0: `(ALL)` + `pypy3-{nocov,cov,diffcov}`
   - [x] Ubuntu 18.04 on VBox: `(ALL)` + `pypy3-{nocov,cov,diffcov}`
   - [x] Ubuntu 20.04 on VBox: `(ALL)` + `pypy3-{nocov,cov,diffcov}`
   - [x] FreeBSD 12.2 [1] on VBox: `(ALL)` + `pypy3-{nocov,cov,diffcov}`
- [x] Documentation reflects the changes
- [x] Add a news fragment into the `NEWS.rst` file

[1] [12.1 is being EOL-ed](https://www.freebsd.org/security/index.html#sup). Side benefit: Since I decided to just wipe my VM and reinstall from scratch, lo and behold! Now all `pypy3` tests work! And the icing on the cake is that the whole tox suite runs much faster than before!