### PR TITLE
Move __version__ to __init__.py

### DIFF
--- a/aiosmtpd/__init__.py
+++ b/aiosmtpd/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2014-2021 The aiosmtpd Developers
+# SPDX-License-Identifier: Apache-2.0
+
+__version__ = "1.3.0a4"

--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -19,6 +19,11 @@ Fixed/Improved
 * ``authenticator`` system improves on ``auth_callback`` by enabling the called function
   to see the SMTP Session and other info.
   (``auth_callback`` will be deprecated in 2.0)
+* ``__version__`` is now an attribute in ``__init__.py``,
+  and can be imported from the 'plain' ``aiosmtpd`` module.
+  (It gets reimported to ``aiosmtpd.smtp``,
+  so programs relying on ``aiosmtpd.smtp.__version__`` should still work.)
+  (Closes #241)
 
 
 1.2.4 (2021-01-24)

--- a/aiosmtpd/docs/conf.py
+++ b/aiosmtpd/docs/conf.py
@@ -12,19 +12,16 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
-import re
 import datetime
-
+import re
+import sys
 from pathlib import Path
 
 from aiosmtpd import __version__
 
 try:
     # noinspection PyPackageRequirements
-    from colorama import (  # pytype: disable=import-error
-        init as colorama_init,
-    )
+    from colorama import init as colorama_init  # pytype: disable=import-error
 
     colorama_init()
 except ImportError:

--- a/aiosmtpd/docs/conf.py
+++ b/aiosmtpd/docs/conf.py
@@ -18,6 +18,8 @@ import datetime
 
 from pathlib import Path
 
+from aiosmtpd import __version__
+
 try:
     # noinspection PyPackageRequirements
     from colorama import (  # pytype: disable=import-error
@@ -77,15 +79,6 @@ copyright = f"2015-{datetime.datetime.now().year}, {author}"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-__version__ = None
-with open("../smtp.py") as fp:
-    for line in fp:
-        m = RE__VERSION.match(line.strip())
-        if m:
-            __version__ = m.group("ver")
-            break
-if __version__ is None:
-    raise RuntimeError("No __version__ found in aiosmtpd/smtp.py!")
 release = __version__
 version = __version__
 

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -13,6 +13,7 @@ import binascii
 import collections
 import asyncio.sslproto as sslproto
 
+from aiosmtpd import __version__
 from base64 import b64decode, b64encode
 from email._header_value_parser import get_addr_spec, get_angle_addr
 from email.errors import HeaderParseError
@@ -66,8 +67,8 @@ __all__ = [
     "AuthCallbackType",
     "AuthMechanismType",
     "MISSING",
+    "__version__",
 ]  # Will be added to by @public
-__version__ = '1.3.0a3'
 __ident__ = 'Python SMTP {}'.format(__version__)
 log = logging.getLogger('mail.log')
 

--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -8,9 +8,10 @@ import os
 import socket
 import unittest
 
+from aiosmtpd import __version__ as init_version
 from aiosmtpd.controller import asyncio, Controller, _FakeServer
 from aiosmtpd.handlers import Sink
-from aiosmtpd.smtp import SMTP as Server
+from aiosmtpd.smtp import SMTP as Server, __version__ as smtp_version
 from contextlib import ExitStack
 from functools import wraps
 from smtplib import SMTP
@@ -203,3 +204,9 @@ class TestFactory(unittest.TestCase):
             self.assertIsNone(cont._thread_exception)
             excm = str(cm.exception)
             self.assertEqual("Unknown Error, failed to init SMTP server", excm)
+
+
+class TestCompat(unittest.TestCase):
+
+    def test_version(self):
+        assert smtp_version is init_version

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aiosmtpd
-version = attr: aiosmtpd.smtp.__version__
+version = attr: aiosmtpd.__version__
 description = aiosmtpd - asyncio based SMTP server
 long_description =
     This is a server for SMTP and related protocols, similar in utility to the


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Move the `__version__` attribute from `smtp.py` to `__init__.py`

Benefits:

* Semantically more correct -- version applies to _all_ aiosmtpd package, not just smtp.py
* Prevent breakage when installing using `setuptools<46.4.0` (see [this PR](https://github.com/pypa/setuptools/pull/1753) which resulted in [this change for 46.4.0](https://setuptools.readthedocs.io/en/latest/history.html#v46-4-0)

## Are there changes in behavior for the user?

Only if user actively searches for `__version__` in the source code of `smtp.py` (via regex, startswith, or AST) instead of importing that attribute from `smtp.py`

User that do `from aiosmtpd.smtp import __version__` will NOT be affected, though it will be better if the import is done `from aiosmtpd` instead.

## Related issue number

Fixes #241 (partially? Not sure if encoding error in the output posted in that issue is related to this...)

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] tox testenvs have been executed in the following environments:
  - [x] Windows 10 (via PyCharm tox runner): `(ALL)`
  - [x] Windows 10 (via PSCore 7.1.1): `(ALL)`
  - [x] Windows 10 (via Cygwin): `qa,py36-{nocov,cov}`
  - [x] Ubuntu 18.04 on WSL 1.0: `(ALL)` + `pypy3-{nocov,cov,diffcov}`
  - [x] FreeBSD 12.2 on VBox: `(ALL)` + `pypy3-{nocov,cov,diffcov}`
  - [x] OpenSUSE Leap 15.2 on VBox: `(ALL)` + `pypy3-{nocov,cov,diffcov}`
- [x] Documentation reflects the changes
- [x] Add a news fragment into the `NEWS.rst` file

**_PR Note is undergoing editing; will undraft when editing done._**
