### PR TITLE
Fix Controller Bug on hostname="" or IPv6 not available

### DIFF
--- a/.github/workflows/unit-testing-and-coverage.yml
+++ b/.github/workflows/unit-testing-and-coverage.yml
@@ -69,7 +69,7 @@ jobs:
       # If a matrix fail, do NOT stop other matrix, let them run to completion
       fail-fast: false
       matrix:
-        os: [ "ubuntu-18.04", "ubuntu-20.04", "macos-10.15", "windows-latest" ]
+        os: [ "macos-10.15", "ubuntu-18.04", "ubuntu-20.04", "windows-latest" ]
         python-version: [ "3.6", "3.7", "3.8", "3.9", "pypy3" ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/aiosmtpd/__init__.py
+++ b/aiosmtpd/__init__.py
@@ -1,4 +1,4 @@
 # Copyright 2014-2021 The aiosmtpd Developers
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -69,7 +69,9 @@ class Controller:
         self.port = port
         self.ssl_context = ssl_context
         self.loop = asyncio.new_event_loop() if loop is None else loop
-        self.ready_timeout = os.getenv("AIOSMTPD_CONTROLLER_TIMEOUT", ready_timeout)
+        self.ready_timeout = float(
+            os.getenv("AIOSMTPD_CONTROLLER_TIMEOUT", ready_timeout)
+        )
         if server_kwargs:
             warn(
                 "server_kwargs will be removed in version 2.0. "

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -6,7 +6,8 @@ import os
 import ssl
 import threading
 from contextlib import ExitStack
-from socket import create_connection, timeout as socket_timeout
+from socket import create_connection
+from socket import timeout as socket_timeout
 from typing import Any, Coroutine, Dict, Optional
 from warnings import warn
 
@@ -68,14 +69,13 @@ class Controller:
         self.port = port
         self.ssl_context = ssl_context
         self.loop = asyncio.new_event_loop() if loop is None else loop
-        self.ready_timeout = os.getenv(
-            'AIOSMTPD_CONTROLLER_TIMEOUT', ready_timeout)
+        self.ready_timeout = os.getenv("AIOSMTPD_CONTROLLER_TIMEOUT", ready_timeout)
         if server_kwargs:
             warn(
                 "server_kwargs will be removed in version 2.0. "
                 "Just specify the keyword arguments to forward to SMTP "
                 "as kwargs to this __init__ method.",
-                DeprecationWarning
+                DeprecationWarning,
             )
         self.SMTP_kwargs: Dict[str, Any] = server_kwargs or {}
         self.SMTP_kwargs.update(SMTP_parameters)
@@ -88,9 +88,7 @@ class Controller:
 
     def factory(self):
         """Allow subclasses to customize the handler/server creation."""
-        return SMTP(
-            self.handler, **self.SMTP_kwargs
-        )
+        return SMTP(self.handler, **self.SMTP_kwargs)
 
     def _factory_invoker(self):
         """Wraps factory() to catch exceptions during instantiation"""
@@ -119,9 +117,7 @@ class Controller:
                 ssl=self.ssl_context,
             )
             self.server_coro = srv_coro
-            srv: AsyncServer = self.loop.run_until_complete(
-                srv_coro
-            )
+            srv: AsyncServer = self.loop.run_until_complete(srv_coro)
             self.server = srv
         except Exception as error:  # pragma: on-wsl
             # Usually will enter this part only if create_server() cannot bind to the

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -29,7 +29,9 @@ def get_localhost() -> str:
         # And since it worked, it's clear that IPv6 is supported
         return "::1"
     except OSError as e:
-        if e.errno == errno.EADDRNOTAVAIL:
+        if e.errno == errno.EADDRNOTAVAIL or e.errno == 10049:
+            # 10049 is WSAEADDRNOTAVAIL .. seems to only exist on Windows
+            # So we'll not use an errno constant there.
             return "127.0.0.1"
         if e.errno == errno.ECONNREFUSED:
             return "::1"

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -146,8 +146,14 @@ class Controller:
         Context if necessary, and read some data from it to ensure that factory()
         gets invoked.
         """
+        # IMPORTANT: Windows does not need the next line; for some reasons,
+        # create_connection is happy with hostname="" on Windows, but screams murder
+        # in Linux.
+        # At this point, if self.hostname is Falsy, it most likely is "" (bind to all
+        # addresses). In such case, it should be safe to connect to localhost)
+        hostname = self.hostname or "localhost"
         with ExitStack() as stk:
-            s = stk.enter_context(create_connection((self.hostname, self.port), 1.0))
+            s = stk.enter_context(create_connection((hostname, self.port), 1.0))
             if self.ssl_context:
                 s = stk.enter_context(self.ssl_context.wrap_socket(s))
             _ = s.recv(1024)

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -22,7 +22,12 @@ AsyncServer = asyncio.base_events.Server
 
 def get_localhost() -> str:
     try:
-        create_connection(("::1", 0))
+        sock = create_connection(("::1", 0))
+        # It should be impossible... but it worked!
+        # So we need to close it
+        sock.close()
+        # And since it worked, it's clear that IPv6 is supported
+        return "::1"
     except OSError as e:
         if e.errno == errno.EADDRNOTAVAIL:
             return "127.0.0.1"

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -160,8 +160,9 @@ class Controller:
 
     def start(self):
         assert self._thread is None, "SMTP daemon already running"
-        ready_event = threading.Event()
         self._factory_invoked = threading.Event()
+
+        ready_event = threading.Event()
         self._thread = threading.Thread(target=self._run, args=(ready_event,))
         self._thread.daemon = True
         self._thread.start()
@@ -191,6 +192,7 @@ class Controller:
             raise TimeoutError("SMTP server not responding within allotted time")
         if self._thread_exception is not None:
             raise self._thread_exception
+
         # Defensive
         if self.smtpd is None:
             raise RuntimeError("Unknown Error, failed to init SMTP server")

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -6,7 +6,7 @@ import os
 import ssl
 import threading
 from contextlib import ExitStack
-from socket import create_connection
+from socket import create_connection, timeout as socket_timeout
 from typing import Any, Coroutine, Dict, Optional
 from warnings import warn
 
@@ -176,10 +176,13 @@ class Controller:
         # a connection to the server and 'exchange' some traffic.
         try:
             self._testconn()
-        except Exception:
-            # We totally don't care of exceptions experienced by _testconn,
+        except socket_timeout:
+            # We totally don't care of timeout experienced by _testconn,
             # which _will_ happen if factory() experienced problems.
             pass
+        except Exception:
+            # Raise other exceptions though
+            raise
         if not self._factory_invoked.wait(self.ready_timeout):
             raise TimeoutError("SMTP server not responding within allotted time")
         if self._thread_exception is not None:

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -218,7 +218,7 @@ class Controller:
     def _stop(self):
         self.loop.stop()
         try:
-            _all_tasks = asyncio.all_tasks
+            _all_tasks = asyncio.all_tasks  # pytype: disable=module-attr
         except AttributeError:  # pragma: py-gt-36
             _all_tasks = asyncio.Task.all_tasks
         for task in _all_tasks(self.loop):

--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -3,6 +3,15 @@
 ===================
 
 
+1.3.1 (aiosmtpd-next)
+=====================
+
+Fixed/Improved
+==============
+* ``ready_timeout`` now actually enforced, raising ``TimeoutError`` if breached
+* No longer fail with opaque "Unknown Error" if ``hostname=""`` (Fixes #244)
+
+
 1.3.0 (2021-02-09)
 ==================
 

--- a/aiosmtpd/docs/controller.rst
+++ b/aiosmtpd/docs/controller.rst
@@ -220,6 +220,8 @@ Controller API
       a float number of seconds,
       which takes precedence over the ``ready_timeout`` argument value.
 
+      If this timeout is breached, a :class:`TimeoutError` exception will be raised.
+
    .. py:attribute:: ssl_context
       :type: ssl.SSLContext
 

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -160,17 +160,15 @@ class Session:
     @property
     def login_data(self):
         """Legacy login_data, usually containing the username"""
-        warn(
+        log.warning(
             "Session.login_data is deprecated and will be removed in version 2.0",
-            DeprecationWarning
         )
         return self._login_data
 
     @login_data.setter
     def login_data(self, value):
-        warn(
+        log.warning(
             "Session.login_data is deprecated and will be removed in version 2.0",
-            DeprecationWarning
         )
         self._login_data = value
 

--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -24,7 +24,7 @@ class SlowStartController(Controller):
         super().__init__(*args, **kwargs)
 
     def _run(self, ready_event):
-        time.sleep(self.ready_timeout * 1.1)
+        time.sleep(self.ready_timeout * 1.5)
         try:
             super()._run(ready_event)
         except Exception:

--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -190,6 +190,14 @@ class TestController:
         controller = contsink(server_hostname="testhost3", server_kwargs=kwargs)
         assert controller.SMTP_kwargs["hostname"] == "testhost3"
 
+    def test_hostname_empty(self):
+        # WARNING: This test _always_ succeeds in Windows.
+        cont = Controller(Sink(), hostname="")
+        try:
+            cont.start()
+        finally:
+            cont.stop()
+
 
 class TestFactory:
     def test_normal_situation(self):

--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -199,6 +199,13 @@ class TestController:
         finally:
             cont.stop()
 
+    def test_hostname_none(self):
+        cont = Controller(Sink())
+        try:
+            cont.start()
+        finally:
+            cont.stop()
+
     def test_testconn_raises(self, mocker: MockFixture):
         mocker.patch("socket.socket.recv", side_effect=RuntimeError("MockError"))
         cont = Controller(Sink(), hostname="")

--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -241,6 +241,14 @@ class TestController:
             get_localhost()
         assert exc.value.errno == errno.EAFNOSUPPORT
 
+    def test_getlocalhost_noerr(self, mocker: MockFixture):
+        mocksock = mocker.Mock()
+        mocker.patch(
+            "aiosmtpd.controller.create_connection", return_value=mocksock
+        )
+        assert get_localhost() == "::1"
+        assert mocksock.close.called
+
 
 class TestFactory:
     def test_normal_situation(self):

--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -198,6 +198,15 @@ class TestController:
         finally:
             cont.stop()
 
+    def test_testconn_raises(self, mocker: MockFixture):
+        mocker.patch("socket.socket.recv", side_effect=RuntimeError("MockError"))
+        cont = Controller(Sink(), hostname="")
+        try:
+            with pytest.raises(RuntimeError, match="MockError"):
+                cont.start()
+        finally:
+            cont.stop()
+
 
 class TestFactory:
     def test_normal_situation(self):

--- a/release.py
+++ b/release.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -45,6 +46,19 @@ GPG_SIGNING_ID = {GPG_SIGNING_ID or 'None'}
 choice = input(f"Release aiosmtpd {version} - correct? [y/N]: ")
 if choice.lower() not in ("y", "yes"):
     sys.exit("Release aborted")
+
+newsfile = Path(".") / "aiosmtpd" / "docs" / "NEWS.rst"
+with newsfile.open("rt") as fin:
+    want = re.compile("^" + re.escape(version) + r"\s*\(\d{4}-\d\d-\d\d\)")
+    for ln in fin:
+        m = want.match(ln)
+        if not m:
+            continue
+        break
+    else:
+        print(f"ERROR: I found no datestamped entry for {version} in NEWS.rst!")
+        sys.exit(1)
+
 if not GPG_SIGNING_ID:
     choice = input("You did not specify GPG signing ID! Continue? [y/N]: ")
     if choice.lower() not in ("y", "yes"):

--- a/release.py
+++ b/release.py
@@ -46,7 +46,7 @@ choice = input(f"Release aiosmtpd {version} - correct? [y/N]: ")
 if choice.lower() not in ("y", "yes"):
     sys.exit("Release aborted")
 if not GPG_SIGNING_ID:
-    choice = input(f"You did not specify GPG signing ID! Continue? [y/N]: ")
+    choice = input("You did not specify GPG signing ID! Continue? [y/N]: ")
     if choice.lower() not in ("y", "yes"):
         sys.exit("Release aborted")
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Previously, `Controller._testconn()`, on Linux, will raise an error if `self.hostname=""`. This is due to `socket.create_connection()` not accepting `""` as hostname parameter. (Totally no problem in Windows)

In addition, `Controller.run()` wraps _all_ exceptions generated by `_testconn()` so this particular error is not seen, leading to hard times during troubleshooting.

Also, even if `hostname` not specified, `Controller` defaults to `"::1"`, which is not available on systems with IPv6 disabled.

Finally, previously `ready_timeout` is used only to wait, with no action taken if it's reached.

So, the changes:
* Now uses a smarter way to determine 'default localhost' address by attempting `::1`, and if that fails, `127.0.0.1`
* `ready_timeout` actually acts if timeout is breached
* Only swallow `socket.timeout` error but raises others

## Are there changes in behavior for the user?

User need to be aware that `ready_timeout` is no longer lip service; it is actually enforced with a possibility of raising a `TimeoutError` if violated.

Other than that, there should be no breaking behavioral changes.

## Related issue number

Fixes #244 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] tox testenvs have been executed in the following environments:
   - [x] Windows 10 (via PyCharm tox runner): `(ALL)`
   - [x] Windows 10 (via Cygwin): `qa,py-{nocov,cov}`
   - [x] Ubuntu 18.04 on WSL 1.0: `(ALL+pypy3)`
   - [x] FreeBSD 12.2 on VBox: `(ALL+pypy3)`
- [x] Documentation reflects the changes
- [x] Add a news fragment into the `NEWS.rst` file
