### PR TITLE
Fix ipv6 detection

### DIFF
--- a/DESCRIPTION.rst
+++ b/DESCRIPTION.rst
@@ -1,0 +1,51 @@
+######################################
+ aiosmtpd - asyncio based SMTP server
+######################################
+
+| |github license| |GA badge| |codecov| |LGTM.com| |readthedocs| |PyPI|
+|
+
+.. |github license| image:: https://img.shields.io/github/license/aio-libs/aiosmtpd
+   :target: https://github.com/aio-libs/aiosmtpd/blob/master/LICENSE
+   :alt: Project License on GitHub
+.. .. For |GA badge|, don't forget to check actual workflow name in unit-testing-and-coverage.yml
+.. |GA badge| image:: https://github.com/aio-libs/aiosmtpd/workflows/aiosmtpd%20CI/badge.svg
+   :target: https://github.com/aio-libs/aiosmtpd/actions
+   :alt: GitHub Actions status
+.. |codecov| image:: https://codecov.io/github/aio-libs/aiosmtpd/coverage.svg?branch=master
+   :target: https://codecov.io/github/aio-libs/aiosmtpd?branch=master
+   :alt: Code Coverage
+.. |LGTM.com| image:: https://img.shields.io/lgtm/grade/python/github/aio-libs/aiosmtpd.svg?logo=lgtm&logoWidth=18
+   :target: https://lgtm.com/projects/g/aio-libs/aiosmtpd/context:python
+   :alt: Semmle/LGTM.com quality
+.. |readthedocs| image:: https://readthedocs.org/projects/aiosmtpd/badge/?version=latest
+   :target: https://aiosmtpd.readthedocs.io/en/latest/?badge=latest
+   :alt: Documentation Status
+.. |PyPI| image:: https://badge.fury.io/py/aiosmtpd.svg
+   :target: https://badge.fury.io/py/aiosmtpd
+   :alt: PyPI Package
+.. .. Do NOT include the Discourse badge!
+
+This is a server for SMTP and related protocols, similar in utility to the
+standard library's ``smtpd.py module``, but rewritten to be based on ``asyncio`` for
+Python 3.6+.
+
+Please visit the `Project Homepage`_ for more information.
+
+.. _`Project Homepage`: https://aiosmtpd.readthedocs.io/
+
+
+Signing Keys
+============
+
+Starting version 1.3.1,
+files provided through PyPI or `GitHub Releases`_
+will be signed using one of the following GPG Keys:
+
++-------------------------+----------------+------------------------------+
+| GPG Key ID              | Owner          | Email                        |
++=========================+================+==============================+
+| ``5D60 CE28 9CD7 C258`` | Pandu E POLUAN | pepoluan at gmail period com |
++-------------------------+----------------+------------------------------+
+
+.. _`GitHub Releases`: https://github.com/aio-libs/aiosmtpd/releases

--- a/README.rst
+++ b/README.rst
@@ -9,10 +9,10 @@
 .. |github license| image:: https://img.shields.io/github/license/aio-libs/aiosmtpd
    :target: https://github.com/aio-libs/aiosmtpd/blob/master/LICENSE
    :alt: Project License on GitHub
+.. .. Fpr |GA badge|, don't forget to check actual workflow name in unit-testing-and-coverage.yml
 .. |GA badge| image:: https://github.com/aio-libs/aiosmtpd/workflows/aiosmtpd%20CI/badge.svg
    :target: https://github.com/aio-libs/aiosmtpd/actions
    :alt: GitHub Actions status
-.. .. Don't forget to check actual workflow name in unit-testing-and-coverage.yml
 .. |codecov| image:: https://codecov.io/github/aio-libs/aiosmtpd/coverage.svg?branch=master
    :target: https://codecov.io/github/aio-libs/aiosmtpd?branch=master
    :alt: Code Coverage
@@ -29,7 +29,7 @@
 .. .. The |Discourse| badge MUST NOT be included in setup.cfg
 .. |Discourse| image:: https://img.shields.io/discourse/status?server=https%3A%2F%2Faio-libs.discourse.group%2F&style=social
    :target: https://aio-libs.discourse.group/
-   :alt: Discourse status
+   :alt: Discourse
 
 The Python standard library includes a basic |SMTP|_ server in the |smtpd|_ module,
 based on the old asynchronous libraries |asyncore|_ and |asynchat|_.

--- a/README.rst
+++ b/README.rst
@@ -201,8 +201,19 @@ have been configured and tested:
 
 * ``docs``
 
-  Builds HTML documentation using Sphinx. A `pytest doctest`_ will run prior to
-  actual building of the documentation.
+  Builds **HTML documentation** using Sphinx.
+  A `pytest doctest`_ will run prior to actual building of the documentation.
+
+* ``static``
+
+  Performs a **static type checking** using ``pytype``.
+  Please ensure that `all its dependencies`_ have been installed before
+  executing this testenv.
+
+  **Note:** Because ``pytype`` does not run on Windows,
+  This testenv must be invoked explicitly; it will not automatically run.
+
+.. _`all its dependencies`: https://github.com/google/pytype/blob/2021.02.09/CONTRIBUTING.md#pytype-dependencies
 
 
 Environment Variables

--- a/README.rst
+++ b/README.rst
@@ -268,6 +268,23 @@ and the cached Python bytecode messes up execution
 will cause problems as Python becomes confused about the locations of the source code).
 
 
+Signing Keys
+============
+
+Starting version 1.3.1,
+files provided through `PyPI`_ or `GitHub Releases`_
+will be signed using one of the following GPG Keys:
+
++-------------------------+----------------+------------------------------+
+| GPG Key ID              | Owner          | Email                        |
++=========================+================+==============================+
+| ``5D60 CE28 9CD7 C258`` | Pandu E POLUAN | pepoluan at gmail period com |
++-------------------------+----------------+------------------------------+
+
+.. _PyPI: https://pypi.org/project/aiosmtpd/
+.. _`GitHub Releases`: https://github.com/aio-libs/aiosmtpd/releases
+
+
 License
 =======
 

--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,8 @@
 .. |PyPI| image:: https://badge.fury.io/py/aiosmtpd.svg
    :target: https://badge.fury.io/py/aiosmtpd
    :alt: PyPI Package
+.. .. If you edit the above badges, don't forget to edit setup.cfg
+.. .. The |Discourse| badge MUST NOT be included in setup.cfg
 .. |Discourse| image:: https://img.shields.io/discourse/status?server=https%3A%2F%2Faio-libs.discourse.group%2F&style=social
    :target: https://aio-libs.discourse.group/
    :alt: Discourse status

--- a/aiosmtpd/__init__.py
+++ b/aiosmtpd/__init__.py
@@ -1,4 +1,4 @@
 # Copyright 2014-2021 The aiosmtpd Developers
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "1.3.1"
+__version__ = "1.3.2a1"

--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -9,6 +9,7 @@
 Fixed/Improved
 --------------
 * Fixed Documentation Issues that might cause automatic package builders to fail
+* Also consider ``EAFNOSUPPORT`` in IPv6 detection (Closes #244, again)
 
 
 1.3.1 (2021-02-18)

--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -1,13 +1,21 @@
-===================
+###################
  NEWS for aiosmtpd
-===================
+###################
+
+
+1.3.2 (2021-02-19)
+==================
+
+Fixed/Improved
+--------------
+* Fixed Documentation Issues that might cause automatic package builders to fail
 
 
 1.3.1 (2021-02-18)
 ==================
 
 Fixed/Improved
-==============
+--------------
 * ``ready_timeout`` now actually enforced, raising ``TimeoutError`` if breached
 * Hides only expected exceptions raised by ``Controller._testconn()``
 * No longer fail with opaque "Unknown Error" if ``hostname=""`` (Closes #244)

--- a/aiosmtpd/docs/controller.rst
+++ b/aiosmtpd/docs/controller.rst
@@ -166,6 +166,32 @@ Controller API
 
 .. py:module:: aiosmtpd.controller
 
+.. class:: IP6_IS
+
+   .. py:attribute:: NO
+      :type: set
+
+      Contains constants from :mod:`errno` that will be raised by `socket.bind()`
+      if IPv6 is not available on the system.
+
+      .. important::
+
+         If your system does not have IPv6 support but :func:`get_localhost`
+         raises an error instead of returning ``"127.0.0.1"``,
+         you can add the error number into this attribute.
+
+   .. py:attribute:: YES
+      :type: set
+
+      Contains constants from :mod:`errno` that will be raised by `socket.bind()`
+      if IPv6 is not available on the system.
+
+.. py:function:: get_localhost
+
+   :return: The numeric address of the loopback interface; ``"::1"`` if IPv6 is supported,
+      ``"127.0.0.1"`` if IPv6 is not supported.
+   :rtype: str
+
 .. class:: Controller(\
    handler, loop=None, hostname=None, port=8025, \
    *, \

--- a/housekeep.py
+++ b/housekeep.py
@@ -58,7 +58,7 @@ WORKFILES = (
 # region #### Helper funcs ############################################################
 
 
-def deldir(targ: Path):
+def deldir(targ: Path, verbose: bool = True):
     if not targ.exists():
         return
     for i, pp in enumerate(reversed(sorted(targ.rglob("*"))), start=1):
@@ -72,7 +72,7 @@ def deldir(targ: Path):
             pp.rmdir()
         else:
             raise RuntimeError(f"Don't know how to handle '{pp}'")
-        if (i & 0xFFF) == 0:
+        if verbose and (i & 0x1FF) == 0:
             print(".", end="", flush=True)
     targ.rmdir()
 
@@ -113,13 +113,13 @@ def pycache_clean(verbose=False):
     """Cleanup __pycache__ dirs & bytecode files (if any)"""
     aiosmtpdpath = Path(".")
     for i, f in enumerate(aiosmtpdpath.rglob("*.py[co]"), start=1):
-        if verbose and (i % 63) == 0:
+        if verbose and (i % 0x3FF) == 0:
             print(".", end="", flush=True)
         f.unlink()
     for d in aiosmtpdpath.rglob("__pycache__"):
         if verbose:
             print(".", end="", flush=True)
-        d.rmdir()
+        deldir(d, verbose)
     if verbose:
         print()
 

--- a/housekeep.py
+++ b/housekeep.py
@@ -72,7 +72,7 @@ def deldir(targ: Path):
             pp.rmdir()
         else:
             raise RuntimeError(f"Don't know how to handle '{pp}'")
-        if (i & 1023) == 0:
+        if (i & 0xFFF) == 0:
             print(".", end="", flush=True)
     targ.rmdir()
 

--- a/release.py
+++ b/release.py
@@ -90,7 +90,7 @@ try:
     if has_verify:
         print("Waiting for package to be received by PyPI...", end="")
         for i in range(10, 0, -1):
-            print(i, end=" ")
+            print(i, end="..")
             time.sleep(1.0)
         print()
         twine_verif = ["twine", "verify_upload"] + DISTFILES

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,12 +2,7 @@
 name = aiosmtpd
 version = attr: aiosmtpd.__version__
 description = aiosmtpd - asyncio based SMTP server
-long_description =
-    This is a server for SMTP and related protocols, similar in utility to the
-    standard library's smtpd.py module, but rewritten to be based on asyncio for
-    Python 3.
-
-    Please visit the Project Homepage for more information.
+long_description = file: DESCRIPTION.rst
 long_description_content_type = text/x-rst
 url = https://aiosmtpd.readthedocs.io/
 project_urls =

--- a/tox.ini
+++ b/tox.ini
@@ -82,6 +82,21 @@ deps:
     sphinx_rtd_theme
     pickle5 ; python_version < '3.8'
 
+[testenv:type]
+basepython = python3
+envdir = {toxworkdir}/type
+commands =
+    python housekeep.py prep
+    pytype --keep-going .
+deps:
+    pytype
+    # Deps of conf.py
+    sphinx_rtd_theme
+    # Deps of test files
+    pytest
+    pytest-mock
+    packaging
+
 # I'd love to fold flake8 into pyproject.toml, because the flake8 settings
 # should be "project-wide" settings (enforced not only during tox).
 # But the flake8 maintainers seem to harbor a severe dislike of pyproject.toml.

--- a/tox.ini
+++ b/tox.ini
@@ -82,9 +82,9 @@ deps:
     sphinx_rtd_theme
     pickle5 ; python_version < '3.8'
 
-[testenv:type]
+[testenv:static]
 basepython = python3
-envdir = {toxworkdir}/type
+envdir = {toxworkdir}/static
 commands =
     python housekeep.py prep
     pytype --keep-going .


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Add `errno.EAFNOSUPPORT` to IPv6 detection.

Also:
* Update test cases
* Update `controller.rst`
* Update `README.rst` -- now contains ID of Signing Key for PyPI and GH Releases
* Update PyPI Long Description -- now contains ID of Signing Key for PyPI and GH Releases
* Update `housekeep.py`

## Are there changes in behavior for the user?

None.

## Related issue number

Closes #244 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] tox testenvs have been executed in the following environments:
    - [x] Windows 10 (via PyCharm tox runner): `(ALL)`
    - [x] Windows 10 (via PSCore 7.1.2): `(ALL)`
    - [x] Windows 10 (via Cygwin):
    - [x] Ubuntu 18.04 on WSL 1.0: `(ALL+pypy3)` + `type`
    - [x] FreeBSD 12.2 on VBox: `(ALL+pypy3)` + `type`
    - [x] OpenSUSE Leap 15.2 on VBox: `(ALL+pypy3) 
- [x] Documentation reflects the changes
- [x] Add a news fragment into the `NEWS.rst` file
