### PR TITLE
Sanitize AUTH Logging

### DIFF
--- a/aiosmtpd/__init__.py
+++ b/aiosmtpd/__init__.py
@@ -1,4 +1,4 @@
 # Copyright 2014-2021 The aiosmtpd Developers
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "1.4.2a1"
+__version__ = "1.4.2a2"

--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -16,7 +16,8 @@ Fixed/Improved
   (See #262)
 * Timeout messages in ``Controller.start()`` gets more details and a mention about the
   ``ready_timeout`` parameter. (See #262)
-
+* Prevent sensitive AUTH information leak by sanitizing the repr()
+  of AuthResult and LoginPassword.
 
 
 1.4.1 (2021-03-04)

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -14,7 +14,6 @@ import ssl
 from base64 import b64decode, b64encode
 from email._header_value_parser import get_addr_spec, get_angle_addr
 from email.errors import HeaderParseError
-from functools import partial
 from typing import (
     Any,
     AnyStr,
@@ -111,25 +110,24 @@ class AuthResult:
     Contains the result of authentication, to be returned to the smtp_AUTH method.
     All initialization arguments _must_ be keyworded!
     """
-    _kwattr = partial(attr.ib, kw_only=True)
 
-    success: bool = _kwattr()
+    success: bool = attr.ib(kw_only=True)
     """Indicates authentication is successful or not"""
 
-    handled: bool = _kwattr(default=True)
+    handled: bool = attr.ib(kw_only=True, default=True)
     """
     True means everything (including sending of status code) has been handled by the
     AUTH handler and smtp_AUTH should not do anything else.
     Applicable only if success == False.
     """
 
-    message: Optional[str] = _kwattr(default=None)
+    message: Optional[str] = attr.ib(kw_only=True, default=None)
     """
     Optional message for additional handling by smtp_AUTH.
     Applicable only if handled == False.
     """
 
-    auth_data: Optional[Any] = _kwattr(default=None, repr=lambda x: "...")
+    auth_data: Optional[Any] = attr.ib(kw_only=True, default=None, repr=lambda x: "...")
     """
     Optional free-form authentication data. For the built-in mechanisms, it is usually
     an instance of LoginPassword. Other implementations are free to use any data

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -935,7 +935,7 @@ class SMTP(asyncio.StreamReaderProtocol):
             # Pass 'self' to method so external methods can leverage this
             # class's helper methods such as push()
             auth_result = await auth_method.method(self, args)
-            log.debug(f"auth_%s returned %r", mechanism, auth_result)
+            log.debug("auth_%s returned %r", mechanism, auth_result)
 
             # New system using `authenticator` and AuthResult
             if isinstance(auth_result, AuthResult):

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -11,8 +11,6 @@ import logging
 import re
 import socket
 import ssl
-from aiosmtpd import __version__
-from aiosmtpd.proxy_protocol import get_proxy, ProxyData
 from base64 import b64decode, b64encode
 from email._header_value_parser import get_addr_spec, get_angle_addr
 from email.errors import HeaderParseError
@@ -34,6 +32,9 @@ from warnings import warn
 
 import attr
 from public import public
+
+from aiosmtpd import __version__
+from aiosmtpd.proxy_protocol import ProxyData, get_proxy
 
 
 # region #### Custom Data Types #######################################################

--- a/aiosmtpd/testing/statuscodes.py
+++ b/aiosmtpd/testing/statuscodes.py
@@ -13,19 +13,21 @@ class StatusCode(NamedTuple):
         nmsg = self.mesg % args
         return StatusCode(self.code, nmsg)
 
-    def to_bytes(self) -> bytes:
+    def to_bytes(self, crlf: bool = False) -> bytes:
         """
         Returns code + mesg as bytes.
         WARNING: This is NOT identical to __str()__.encode()!
         """
-        return str(self.code).encode() + b" " + self.mesg
+        _crlf = b"\r\n" if crlf else b""
+        return str(self.code).encode() + b" " + self.mesg + _crlf
 
-    def to_str(self) -> str:
+    def to_str(self, crlf: bool = False) -> str:
         """
         Returns code + mesg as a string.
         WARNING: This is NOT identical to __str__()!
         """
-        return str(self.code) + " " + self.mesg.decode()
+        _crlf = "\r\n" if crlf else ""
+        return str(self.code) + " " + self.mesg.decode() + _crlf
 
 
 _COMMON_COMMANDS = [

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -1676,7 +1676,7 @@ class TestSMTPWithController(_CommonMethods):
             assert rslt == b""
             rslt = send_recv(sock, b"\r\n.")
             # *NOW* we must receive status code
-            assert rslt == b"500 Line too long (see RFC5321 4.5.3.1.6)\r\n"
+            assert rslt == S.S500_DATALINE_TOO_LONG.to_bytes(crlf=True)
 
     @controller_data(data_size_limit=2000)
     def test_too_long_lines_then_too_long_body(self, plain_controller, client):

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -11,8 +11,8 @@ import time
 import warnings
 from base64 import b64encode
 from contextlib import suppress
-from smtplib import SMTP as SMTPClient
 from smtplib import (
+    SMTP as SMTPClient,
     SMTPAuthenticationError,
     SMTPDataError,
     SMTPResponseException,
@@ -24,6 +24,7 @@ from typing import Any, AnyStr, Callable, Generator, List, Tuple
 import pytest
 from pytest_mock import MockFixture
 
+from .conftest import Global, controller_data, handler_data
 from aiosmtpd.controller import Controller
 from aiosmtpd.handlers import Sink
 from aiosmtpd.smtp import (
@@ -45,8 +46,6 @@ from aiosmtpd.testing.helpers import (
     send_recv,
 )
 from aiosmtpd.testing.statuscodes import SMTP_STATUS_CODES as S
-
-from .conftest import Global, controller_data, handler_data
 
 CRLF = "\r\n"
 BCRLF = b"\r\n"

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -26,13 +26,18 @@ from pytest_mock import MockFixture
 
 from aiosmtpd.controller import Controller
 from aiosmtpd.handlers import Sink
-from aiosmtpd.smtp import BOGUS_LIMIT, CALL_LIMIT_DEFAULT, MISSING
-from aiosmtpd.smtp import SMTP as Server
-from aiosmtpd.smtp import AuthResult
-from aiosmtpd.smtp import Envelope as SMTPEnvelope
-from aiosmtpd.smtp import Session as SMTPSession
-from aiosmtpd.smtp import __ident__ as GREETING
-from aiosmtpd.smtp import auth_mechanism
+from aiosmtpd.smtp import (
+    BOGUS_LIMIT,
+    CALL_LIMIT_DEFAULT,
+    MISSING,
+    SMTP as Server,
+    AuthResult,
+    Envelope as SMTPEnvelope,
+    LoginPassword,
+    Session as SMTPSession,
+    __ident__ as GREETING,
+    auth_mechanism,
+)
 from aiosmtpd.testing.helpers import (
     ReceivingHandler,
     catchup_delay,
@@ -62,6 +67,17 @@ def auth_callback(mechanism, login, password) -> bool:
         return True
     else:
         return False
+
+
+def assert_nopassleak(passwd: str, record_tuples: List[Tuple[str, int, str]]):
+    """
+    :param passwd: The password we're looking for in the logs
+    :param record_tuples: Usually caplog.record_tuples
+    """
+    passwd_b64 = b64encode(passwd.encode("ascii")).decode("ascii")
+    for logname, loglevel, logmsg in record_tuples:
+        assert passwd not in logmsg
+        assert passwd_b64 not in logmsg
 
 
 class UndescribableError(Exception):
@@ -914,30 +930,35 @@ class TestSMTPAuth(_CommonMethods):
         resp = client.docmd("AUTH")
         assert resp == S.S501_TOO_FEW
 
-    def test_already_authenticated(self, client):
+    def test_already_authenticated(self, caplog, client):
+        PW = "goodpasswd"
         self._ehlo(client)
         resp = client.docmd(
-            "AUTH PLAIN " + b64encode(b"\0goodlogin\0goodpasswd").decode()
+            "AUTH PLAIN " + b64encode(b"\0goodlogin\0" + PW.encode("ascii")).decode()
         )
         assert resp == S.S235_AUTH_SUCCESS
         resp = client.docmd("AUTH")
         assert resp == S.S503_ALREADY_AUTH
         resp = client.docmd("MAIL FROM: <anne@example.com>")
         assert resp == S.S250_OK
+        assert_nopassleak(PW, caplog.record_tuples)
 
-    def test_auth_individually(self, client):
+    def test_auth_individually(self, caplog, client):
         """AUTH state of different clients must be independent"""
+        PW = "goodpasswd"
         client1 = client
         with SMTPClient(*Global.SrvAddr) as client2:
             for c in client1, client2:
                 c.ehlo("example.com")
-                resp = c.login("goodlogin", "goodpasswd")
+                resp = c.login("goodlogin", PW)
                 assert resp == S.S235_AUTH_SUCCESS
+        assert_nopassleak(PW, caplog.record_tuples)
 
-    def test_rset_maintain_authenticated(self, client):
+    def test_rset_maintain_authenticated(self, caplog, client):
         """RSET resets only Envelope not Session"""
+        PW = "goodpasswd"
         self._ehlo(client, "example.com")
-        resp = client.login("goodlogin", "goodpasswd")
+        resp = client.login("goodlogin", PW)
         assert resp == S.S235_AUTH_SUCCESS
         resp = client.mail("alice@example.com")
         assert resp == S.S250_OK
@@ -945,6 +966,7 @@ class TestSMTPAuth(_CommonMethods):
         assert resp == S.S250_OK
         resp = client.docmd("AUTH PLAIN")
         assert resp == S.S503_ALREADY_AUTH
+        assert_nopassleak(PW, caplog.record_tuples)
 
     @handler_data(class_=PeekerHandler)
     def test_auth_loginteract_warning(self, client):
@@ -1019,10 +1041,13 @@ class TestAuthMechanisms(_CommonMethods):
 
     @pytest.mark.parametrize("init_resp", [True, False])
     @pytest.mark.parametrize("mechanism", ["login", "plain"])
-    def test_byclient(self, auth_peeker_controller, client, mechanism, init_resp):
+    def test_byclient(
+        self, caplog, auth_peeker_controller, client, mechanism, init_resp
+    ):
         self._ehlo(client)
+        PW = "goodpasswd"
         client.user = "goodlogin"
-        client.password = "goodpasswd"
+        client.password = PW
         auth_meth = getattr(client, "auth_" + mechanism)
         if (mechanism, init_resp) == ("login", False):
             with pytest.raises(SMTPAuthenticationError):
@@ -1033,7 +1058,8 @@ class TestAuthMechanisms(_CommonMethods):
         peeker = auth_peeker_controller.handler
         assert isinstance(peeker, PeekerHandler)
         assert peeker.login == b"goodlogin"
-        assert peeker.password == b"goodpasswd"
+        assert peeker.password == PW.encode("ascii")
+        assert_nopassleak(PW, caplog.record_tuples)
 
     def test_plain1_bad_base64_encoding(self, do_auth_plain1):
         resp = do_auth_plain1("not-b64")
@@ -1059,22 +1085,29 @@ class TestAuthMechanisms(_CommonMethods):
         resp = do_auth_plain1("=")
         assert resp == S.S501_AUTH_CANTSPLIT
 
-    def test_plain1_good_credentials(self, auth_peeker_controller, do_auth_plain1):
-        resp = do_auth_plain1(b64encode(b"\0goodlogin\0goodpasswd").decode())
+    def test_plain1_good_credentials(
+        self, caplog, auth_peeker_controller, do_auth_plain1
+    ):
+        PW = "goodpasswd"
+        PWb = PW.encode("ascii")
+        resp = do_auth_plain1(b64encode(b"\0goodlogin\0" + PWb).decode())
         assert resp == S.S235_AUTH_SUCCESS
         peeker = auth_peeker_controller.handler
         assert isinstance(peeker, PeekerHandler)
         assert peeker.login == b"goodlogin"
-        assert peeker.password == b"goodpasswd"
+        assert peeker.password == PWb
         # noinspection PyUnresolvedReferences
         resp = do_auth_plain1.client.mail("alice@example.com")
         assert resp == S.S250_OK
+        assert_nopassleak(PW, caplog.record_tuples)
 
     def test_plain1_goodcreds_sanitized_log(self, caplog, client):
         caplog.set_level("DEBUG")
         client.ehlo("example.com")
+        PW = "goodpasswd"
+        PWb = PW.encode("ascii")
         code, response = client.docmd(
-            "AUTH PLAIN " + b64encode(b"\0goodlogin\0goodpasswd").decode()
+            "AUTH PLAIN " + b64encode(b"\0goodlogin\0" + PWb).decode()
         )
         interestings = [tup for tup in caplog.record_tuples if "AUTH PLAIN" in tup[-1]]
         assert len(interestings) == 2
@@ -1082,6 +1115,7 @@ class TestAuthMechanisms(_CommonMethods):
         assert interestings[0][2].endswith("b'AUTH PLAIN ********\\r\\n'")
         assert interestings[1][1] == logging.INFO
         assert interestings[1][2].endswith("b'AUTH PLAIN ********'")
+        assert_nopassleak(PW, caplog.record_tuples)
 
     @pytest.fixture
     def client_auth_plain2(self, client) -> Generator[SMTPClient, None, None]:
@@ -1090,8 +1124,12 @@ class TestAuthMechanisms(_CommonMethods):
         assert resp == S.S334_AUTH_EMPTYPROMPT
         yield client
 
-    def test_plain2_good_credentials(self, auth_peeker_controller, client_auth_plain2):
-        resp = client_auth_plain2.docmd(b64encode(b"\0goodlogin\0goodpasswd").decode())
+    def test_plain2_good_credentials(
+        self, caplog, auth_peeker_controller, client_auth_plain2
+    ):
+        PW = "goodpasswd"
+        PWb = PW.encode("ascii")
+        resp = client_auth_plain2.docmd(b64encode(b"\0goodlogin\0" + PWb).decode())
         assert resp == S.S235_AUTH_SUCCESS
         peeker = auth_peeker_controller.handler
         assert isinstance(peeker, PeekerHandler)
@@ -1099,6 +1137,7 @@ class TestAuthMechanisms(_CommonMethods):
         assert peeker.password == b"goodpasswd"
         resp = client_auth_plain2.mail("alice@example.com")
         assert resp == S.S250_OK
+        assert_nopassleak(PW, caplog.record_tuples)
 
     def test_plain2_bad_credentials(self, client_auth_plain2):
         resp = client_auth_plain2.docmd(b64encode(b"\0badlogin\0badpasswd").decode())
@@ -1121,33 +1160,41 @@ class TestAuthMechanisms(_CommonMethods):
         resp = client.docmd("AUTH LOGIN ab@%")
         assert resp == S.S501_AUTH_NOTB64
 
-    def test_login2_good_credentials(self, auth_peeker_controller, client):
+    def test_login2_good_credentials(self, caplog, auth_peeker_controller, client):
         self._ehlo(client)
+        PW = "goodpasswd"
+        PWb = PW.encode("ascii")
         line = "AUTH LOGIN " + b64encode(b"goodlogin").decode()
         resp = client.docmd(line)
         assert resp == S.S334_AUTH_PASSWORD
         assert resp == S.S334_AUTH_PASSWORD
-        resp = client.docmd(b64encode(b"goodpasswd").decode())
+        resp = client.docmd(b64encode(PWb).decode())
         assert resp == S.S235_AUTH_SUCCESS
         peeker = auth_peeker_controller.handler
         assert isinstance(peeker, PeekerHandler)
         assert peeker.login == b"goodlogin"
-        assert peeker.password == b"goodpasswd"
+        assert peeker.password == PWb
         resp = client.mail("alice@example.com")
         assert resp == S.S250_OK
+        assert_nopassleak(PW, caplog.record_tuples)
 
-    def test_login3_good_credentials(self, auth_peeker_controller, do_auth_login3):
+    def test_login3_good_credentials(
+        self, caplog, auth_peeker_controller, do_auth_login3
+    ):
+        PW = "goodpasswd"
+        PWb = PW.encode("ascii")
         resp = do_auth_login3(b64encode(b"goodlogin").decode())
         assert resp == S.S334_AUTH_PASSWORD
-        resp = do_auth_login3(b64encode(b"goodpasswd").decode())
+        resp = do_auth_login3(b64encode(PWb).decode())
         assert resp == S.S235_AUTH_SUCCESS
         peeker = auth_peeker_controller.handler
         assert isinstance(peeker, PeekerHandler)
         assert peeker.login == b"goodlogin"
-        assert peeker.password == b"goodpasswd"
+        assert peeker.password == PWb
         # noinspection PyUnresolvedReferences
         resp = do_auth_login3.client.mail("alice@example.com")
         assert resp == S.S250_OK
+        assert_nopassleak(PW, caplog.record_tuples)
 
     def test_login3_bad_base64(self, do_auth_login3):
         resp = do_auth_login3("not-b64")
@@ -1198,9 +1245,10 @@ class TestAuthMechanisms(_CommonMethods):
 
 
 class TestAuthenticator(_CommonMethods):
-    def test_success(self, authenticator_peeker_controller, client):
+    def test_success(self, caplog, authenticator_peeker_controller, client):
+        PW = "goodpasswd"
         client.user = "gooduser"
-        client.password = "goodpasswd"
+        client.password = PW
         self._ehlo(client)
         client.auth("plain", client.auth_plain)
         auth_peeker = authenticator_peeker_controller.handler
@@ -1208,12 +1256,14 @@ class TestAuthenticator(_CommonMethods):
         assert auth_peeker.sess.peer[0] in {"::1", "127.0.0.1", "localhost"}
         assert auth_peeker.sess.peer[1] > 0
         assert auth_peeker.sess.authenticated
-        assert auth_peeker.sess.auth_data == (b"gooduser", b"goodpasswd")
-        assert auth_peeker.login_data == (b"gooduser", b"goodpasswd")
+        assert auth_peeker.sess.auth_data == (b"gooduser", PW.encode("ascii"))
+        assert auth_peeker.login_data == (b"gooduser", PW.encode("ascii"))
+        assert_nopassleak(PW, caplog.record_tuples)
 
-    def test_fail_withmesg(self, authenticator_peeker_controller, client):
+    def test_fail_withmesg(self, caplog, authenticator_peeker_controller, client):
+        PW = "anypass"
         client.user = "failme_with454"
-        client.password = "anypass"
+        client.password = PW
         self._ehlo(client)
         with pytest.raises(SMTPAuthenticationError) as cm:
             client.auth("plain", client.auth_plain)
@@ -1223,7 +1273,8 @@ class TestAuthenticator(_CommonMethods):
         assert auth_peeker.sess.peer[0] in {"::1", "127.0.0.1", "localhost"}
         assert auth_peeker.sess.peer[1] > 0
         assert auth_peeker.sess.login_data is None
-        assert auth_peeker.login_data == (b"failme_with454", b"anypass")
+        assert auth_peeker.login_data == (b"failme_with454", PW.encode("ascii"))
+        assert_nopassleak(PW, caplog.record_tuples)
 
 
 @pytest.mark.filterwarnings("ignore:Requiring AUTH while not requiring TLS:UserWarning")
@@ -2000,3 +2051,17 @@ class TestLimits(_CommonMethods):
         assert client.docmd("LASTBOGUS") == S.S502_TOO_MANY_UNRECOG
         with pytest.raises(SMTPServerDisconnected):
             client.noop()
+
+
+class TestSanitize:
+    def test_loginpassword(self):
+        lp = LoginPassword(b"user", b"pass")
+        expect = "LoginPassword(login='b'user'', password=...)"
+        assert repr(lp) == expect
+        assert str(lp) == expect
+
+    def test_authresult(self):
+        ar = AuthResult(success=True, auth_data="user:pass")
+        expect = "AuthResult(success=True, handled=True, message=None, auth_data=...)"
+        assert repr(ar) == expect
+        assert str(ar) == expect

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -74,7 +74,7 @@ def assert_nopassleak(passwd: str, record_tuples: List[Tuple[str, int, str]]):
     :param record_tuples: Usually caplog.record_tuples
     """
     passwd_b64 = b64encode(passwd.encode("ascii")).decode("ascii")
-    for logname, loglevel, logmsg in record_tuples:
+    for _logname, _loglevel, logmsg in record_tuples:
         assert passwd not in logmsg
         assert passwd_b64 not in logmsg
 

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -98,6 +98,7 @@ class ErrorSMTP(Server):
 # region #### Special-Purpose Handlers ################################################
 
 
+# noinspection TimingAttack
 class PeekerHandler:
     sess: SMTPSession = None
     login: AnyStr = None
@@ -980,6 +981,7 @@ class TestSMTPAuth(_CommonMethods):
         assert str(w[1].message) == "Sensitive information might be leaked!"
 
 
+# noinspection TimingAttack,HardcodedPassword
 @pytest.mark.usefixtures("auth_peeker_controller")
 class TestAuthMechanisms(_CommonMethods):
     @pytest.fixture
@@ -1244,6 +1246,7 @@ class TestAuthMechanisms(_CommonMethods):
         assert resp == S.S235_AUTH_SUCCESS
 
 
+# noinspection HardcodedPassword
 class TestAuthenticator(_CommonMethods):
     def test_success(self, caplog, authenticator_peeker_controller, client):
         PW = "goodpasswd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,3 +72,7 @@ ignore = [
 [tool.isort]
 profile = "black"
 multi_line_output = 3
+known_local_folder = [
+    "aiosmtpd"
+]
+combine_as_imports = true


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

It has come to my attention that [one particular line of logging](https://github.com/aio-libs/aiosmtpd/blob/9c2a13eac52c6c293335b45c7c644ebc794a6905/aiosmtpd/smtp.py#L925) potentially leaks sensitive information (password).

This PR overrides the `__repr__` and `__str__` methods of `AuthResult` and `LoginPassword` to prevent this leakage. 

## Are there changes in behavior for the user?

This impacts Users that rely on the repr() and str() of AuthResult and LoginPassword (why??), directly or indirectly (via logs).

The impact should be deemed acceptable compared to the potential sensitive information leakage.

## Related issue number

None

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] tox testenvs have been executed in the following environments:
   - [x] Windows 10 (via PyCharm tox runner)
   - [x] Windows 10 (via PSCore 7.1.2)
   - [x] Windows 10 (via Cygwin)
   - [x] Ubuntu 18.04 on WSL 1.0
   - [x] FreeBSD 12.2 on VBox
   - [x] OpenSUSE Leap 15.2 on VBox
- [x] Documentation reflects the changes
- [x] Add a news fragment into the `NEWS.rst` file
