### PR TITLE
Explicitly require setuptools, tests/test_smtps.py and tests/test_starttls.py imports pkg_resources

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,12 +35,15 @@ zip_safe = false
 python_requires = ~=3.6
 packages = find:
 include_package_data = true
+setup_requires =
+    setuptools
 install_requires =
     atpublic
     attrs
     typing-extensions ; python_version < '3.8'
 tests_require =
     tox
+    setuptools
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Some files have runtime dependency on setuptools because of importing `pkg_resources` module. In Fedora, we build the package using setuptools, but we ship it to users potentially without it. I suggest explicitly list this requirement. 

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
No
<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Use the "closing keywords" such as "Closes" or "Fixes" to automatically link to Issues. -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [x] Linux (Ubuntu 18.04, Ubuntu 20.04, Arch): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, qa, docs`
- [ ] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file
  <!-- Delete the following bullet points prior to submitting the PR -->
  * Add under the "aiosmtpd-next" section, creating one if necessary
    * You may create subsections to group the changes, if you like
  * Use full sentences with correct case and punctuation
  * Refer to relevant Issue if applicable
