### PR TITLE
Implement custom SSL handshake timeout on Controller

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  schedule:
+    - cron: "42 17 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ python ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+          queries: +security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/unit-testing-and-coverage.yml
+++ b/.github/workflows/unit-testing-and-coverage.yml
@@ -89,7 +89,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "macos-10.15", "ubuntu-18.04", "ubuntu-20.04", "windows-latest" ]
-        python-version: [ "3.6", "3.7", "3.8", "3.9", "pypy3" ]
+        python-version: [ "3.6", "3.7", "3.8", "3.9", "pypy3.6" ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15  # Slowest so far is pypy3 on MacOS, taking almost 7m
     steps:
@@ -98,7 +98,7 @@ jobs:
       with:
         fetch-depth: 0  # Required by codecov/codecov-action@v1
     - name: "Set up Python ${{ matrix.python-version }}"
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: "Install dependencies"

--- a/.github/workflows/unit-testing-and-coverage.yml
+++ b/.github/workflows/unit-testing-and-coverage.yml
@@ -89,7 +89,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "macos-10.15", "ubuntu-18.04", "ubuntu-20.04", "windows-latest" ]
-        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10", "pypy3.6" ]
+        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.6" ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15  # Slowest so far is pypy3 on MacOS, taking almost 7m
     steps:

--- a/.github/workflows/unit-testing-and-coverage.yml
+++ b/.github/workflows/unit-testing-and-coverage.yml
@@ -8,17 +8,19 @@ on:
     paths:
       - "aiosmtpd/**"
       - "setup.cfg"  # To monitor changes in dependencies
+      - "pyproject.toml"  # To monitor changes in dependencies
   # This is for PRs
   pull_request:
     branches: [ "master" ]
     paths:
       - "aiosmtpd/**"
       - "setup.cfg"  # To monitor changes in dependencies
+      - "pyproject.toml"  # To monitor changes in dependencies
   # Manual/on-demand
   workflow_dispatch:
   # When doing "releases"
   release:
-    types: [ "created", "edited", "published", "prereleased", "released" ]
+    types: [ "created", "edited" ]
 
 jobs:
   qa_docs:
@@ -27,7 +29,7 @@ jobs:
       - name: "Checkout latest PR commit"
         uses: actions/checkout@v3
       - name: "Set up Python"
-        uses: actions/setup-python@v4.3.1
+        uses: actions/setup-python@v4
         with:
           # 3.8 is chosen because it seems to be the fastest for <3.9
           # (3.9 excluded because it seems to be still very unstable)
@@ -60,7 +62,7 @@ jobs:
           sphinx-build --color -b doctest -d build/.doctree aiosmtpd/docs build/doctest
           sphinx-build --color -b html    -d build/.doctree aiosmtpd/docs build/html
           sphinx-build --color -b man     -d build/.doctree aiosmtpd/docs build/man
-      - name: "Static Code Checking"
+      - name: "Static Type Checking"
         # language=bash
         run: |
           # Required by examples
@@ -88,10 +90,12 @@ jobs:
       # If a matrix fail, do NOT stop other matrix, let them run to completion
       fail-fast: false
       matrix:
-        os: [ "macos-11", "macos-12", "ubuntu-18.04", "ubuntu-20.04", "ubuntu-22.04", "windows-latest" ]
         python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.6", "pypy3.7", "pypy3.8" ]
+        os: [ "macos-11", "macos-12", "ubuntu-18.04", "ubuntu-20.04", "ubuntu-22.04", "windows-2019", "windows-2022" ]
         exclude:
-          - os: windows-latest
+          - os: windows-2019
+            python-version: pypy3.6
+          - os: windows-2022
             python-version: pypy3.6
           - os: macos-11
             python-version: pypy3.6
@@ -105,7 +109,7 @@ jobs:
       with:
         fetch-depth: 0  # Required by codecov/codecov-action@v1
     - name: "Set up Python ${{ matrix.python-version }}"
-      uses: actions/setup-python@v4.3.1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: "Install dependencies"
@@ -113,7 +117,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         # Test deps
-        pip install colorama coverage[toml] coverage-conditional-plugin packaging pytest pytest-cov pytest-mock
+        pip install colorama coverage[toml] "coverage-conditional-plugin>=0.7.0" packaging pytest pytest-cov pytest-mock
         # Package deps
         python setup.py develop
     - name: "Security checking"
@@ -121,6 +125,10 @@ jobs:
       run: |
         pip install bandit
         bandit -c bandit.yml -r aiosmtpd
+
+    # IMPORTANT: pypy3.8 is currently excluded from coverage testing because coverage seems to be unstable when
+    # running on PyPy 3.8. This is still under investigation (See issue #325)
+
     - name: "Execute testing with coverage"
       if: matrix.python-version != 'pypy3.8'
       shell: bash
@@ -143,10 +151,11 @@ jobs:
         fi
         pytest
         #
+
     - name: "Report to codecov"
       # Ubuntu 18.04 came out of the box with 3.6, and LOTS of system are still running
       # 18.04 happily, so we choose this as the 'canonical' code coverage testing.
       # One day we'll have to revisit this and bump the version ...
       # 2022-12-16: Bumped to Python 3.8 and Ubuntu 20.04. Yeah, we take the conservative LTS route.
       if: matrix.python-version == '3.8' && matrix.os == 'ubuntu-20.04'
-      uses: codecov/codecov-action@v3.1.1
+      uses: codecov/codecov-action@v3

--- a/.github/workflows/unit-testing-and-coverage.yml
+++ b/.github/workflows/unit-testing-and-coverage.yml
@@ -22,12 +22,12 @@ on:
 
 jobs:
   qa_docs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: "Checkout latest PR commit"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: "Set up Python"
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4.3.1
         with:
           # 3.8 is chosen because it seems to be the fastest for <3.9
           # (3.9 excluded because it seems to be still very unstable)
@@ -88,17 +88,24 @@ jobs:
       # If a matrix fail, do NOT stop other matrix, let them run to completion
       fail-fast: false
       matrix:
-        os: [ "macos-10.15", "ubuntu-18.04", "ubuntu-20.04", "windows-latest" ]
-        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.6" ]
+        os: [ "macos-11", "macos-12", "ubuntu-18.04", "ubuntu-20.04", "ubuntu-22.04", "windows-latest" ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.6", "pypy3.7", "pypy3.8" ]
+        exclude:
+          - os: windows-latest
+            python-version: pypy3.6
+          - os: macos-11
+            python-version: pypy3.6
+          - os: macos-12
+            python-version: pypy3.6
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15  # Slowest so far is pypy3 on MacOS, taking almost 7m
     steps:
     - name: "Checkout latest commit"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0  # Required by codecov/codecov-action@v1
     - name: "Set up Python ${{ matrix.python-version }}"
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v4.3.1
       with:
         python-version: ${{ matrix.python-version }}
     - name: "Install dependencies"
@@ -114,7 +121,8 @@ jobs:
       run: |
         pip install bandit
         bandit -c bandit.yml -r aiosmtpd
-    - name: "Execute testing"
+    - name: "Execute testing with coverage"
+      if: matrix.python-version != 'pypy3.8'
       shell: bash
       # language=bash
       run: |
@@ -123,9 +131,22 @@ jobs:
           git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin master:master
         fi
         pytest --cov --cov-report=xml --cov-report=term
+        #
+    - name: "Execute testing w/o coverage"
+      if: matrix.python-version == 'pypy3.8'
+      shell: bash
+      # language=bash
+      run: |
+        # Fetch master if needed because some test cases need its existence
+        if [[ $GITHUB_REF != refs/heads/master ]]; then
+          git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin master:master
+        fi
+        pytest
+        #
     - name: "Report to codecov"
       # Ubuntu 18.04 came out of the box with 3.6, and LOTS of system are still running
       # 18.04 happily, so we choose this as the 'canonical' code coverage testing.
       # One day we'll have to revisit this and bump the version ...
-      if: matrix.python-version == '3.6' && matrix.os == 'ubuntu-18.04'
-      uses: codecov/codecov-action@v1
+      # 2022-12-16: Bumped to Python 3.8 and Ubuntu 20.04. Yeah, we take the conservative LTS route.
+      if: matrix.python-version == '3.8' && matrix.os == 'ubuntu-20.04'
+      uses: codecov/codecov-action@v3.1.1

--- a/.github/workflows/unit-testing-and-coverage.yml
+++ b/.github/workflows/unit-testing-and-coverage.yml
@@ -52,7 +52,7 @@ jobs:
             "config.read('tox.ini');"
             "print(config['flake8_plugins']['deps']);"
           )
-          pip install flake8 $(python -c "${grab_f8_plugins[*]}")
+          pip install "flake8>=5.0.4" $(python -c "${grab_f8_plugins[*]}")
           python -m flake8 aiosmtpd setup.py housekeep.py release.py
       - name: "Docs Checking"
         # language=bash

--- a/.github/workflows/unit-testing-and-coverage.yml
+++ b/.github/workflows/unit-testing-and-coverage.yml
@@ -89,7 +89,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "macos-10.15", "ubuntu-18.04", "ubuntu-20.04", "windows-latest" ]
-        python-version: [ "3.6", "3.7", "3.8", "3.9", "pypy3.6" ]
+        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10", "pypy3.6" ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15  # Slowest so far is pypy3 on MacOS, taking almost 7m
     steps:

--- a/.github/workflows/unit-testing-and-coverage.yml
+++ b/.github/workflows/unit-testing-and-coverage.yml
@@ -90,17 +90,8 @@ jobs:
       # If a matrix fail, do NOT stop other matrix, let them run to completion
       fail-fast: false
       matrix:
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.6", "pypy3.7", "pypy3.8" ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.7", "pypy3.8", "pypy3.9" ]
         os: [ "macos-11", "macos-12", "ubuntu-18.04", "ubuntu-20.04", "ubuntu-22.04", "windows-2019", "windows-2022" ]
-        exclude:
-          - os: windows-2019
-            python-version: pypy3.6
-          - os: windows-2022
-            python-version: pypy3.6
-          - os: macos-11
-            python-version: pypy3.6
-          - os: macos-12
-            python-version: pypy3.6
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15  # Slowest so far is pypy3 on MacOS, taking almost 7m
     steps:
@@ -117,7 +108,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         # Test deps
-        pip install colorama coverage[toml] "coverage-conditional-plugin>=0.5.0" packaging pytest pytest-cov pytest-mock
+        pip install colorama "coverage>=7.0.1" coverage[toml] "coverage-conditional-plugin>=0.5.0" packaging pytest pytest-cov pytest-mock
         # Package deps
         python setup.py develop
     - name: "Security checking"
@@ -128,6 +119,8 @@ jobs:
 
     # IMPORTANT: pypy3.8 is currently excluded from coverage testing because coverage seems to be unstable when
     # running on PyPy 3.8. This is still under investigation (See issue #325)
+    # Edit: This is due to change in behavior in PyPy v7.3.10, and coverage.py needs to adapt.
+    # See: https://github.com/nedbat/coveragepy/issues/1515
 
     - name: "Execute testing with coverage"
       if: matrix.python-version != 'pypy3.8'

--- a/.github/workflows/unit-testing-and-coverage.yml
+++ b/.github/workflows/unit-testing-and-coverage.yml
@@ -117,7 +117,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         # Test deps
-        pip install colorama coverage[toml] "coverage-conditional-plugin>=0.7.0" packaging pytest pytest-cov pytest-mock
+        pip install colorama coverage[toml] "coverage-conditional-plugin>=0.5.0" packaging pytest pytest-cov pytest-mock
         # Package deps
         python setup.py develop
     - name: "Security checking"

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ prof/
 .pytype/
 ~temp*
 *.sw[a-p]
+pyvenv.cfg

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ diffcov-*.html
 prof/
 .pytype/
 ~temp*
+*.sw[a-p]

--- a/DESCRIPTION.rst
+++ b/DESCRIPTION.rst
@@ -7,6 +7,8 @@
 | |GH Release| |_| |GH PRs| |_| |GH LastCommit|
 | |PyPI DL| |_| |GH DL|
 |
+| |GH Discussions|
+|
 
 .. .. U+00A0 is non-breaking space
 .. |_| unicode:: 0xA0
@@ -36,7 +38,6 @@
 .. |readthedocs| image:: https://img.shields.io/readthedocs/aiosmtpd?logo=Read+the+Docs
    :target: https://aiosmtpd.readthedocs.io/en/latest/?badge=latest
    :alt: Documentation Status
-.. .. Do NOT include the Discourse badge!
 .. |GH Release| image:: https://img.shields.io/github/v/release/aio-libs/aiosmtpd?logo=github
    :target: https://github.com/aio-libs/aiosmtpd/releases
    :alt: GitHub latest release
@@ -52,7 +53,9 @@
 .. |GH DL| image:: https://img.shields.io/github/downloads/aio-libs/aiosmtpd/total?logo=github
    :target: https://github.com/aio-libs/aiosmtpd/releases
    :alt: GitHub downloads
-
+.. |GH Discussions| image:: https://img.shields.io/github/discussions/aio-libs/aiosmtpd?logo=github&style=social
+   :target: https://github.com/aio-libs/aiosmtpd/discussions
+   :alt: GitHub Discussions
 
 This is a server for SMTP and related MTA protocols,
 similar in utility to the standard library's |smtpd.py|_ module,

--- a/DESCRIPTION.rst
+++ b/DESCRIPTION.rst
@@ -3,7 +3,7 @@
 ######################################
 
 | |github license| |_| |PyPI Version| |_| |PyPI Python| |_| |PyPI PythonImpl|
-| |GA badge| |_| |codecov| |_| |readthedocs|
+| |GA badge| |_| |CodeQL badge| |_| |codecov| |_| |readthedocs|
 | |GH Release| |_| |GH PRs| |_| |GH LastCommit|
 | |PyPI DL| |_| |GH DL|
 |
@@ -25,8 +25,11 @@
    :alt: Supported Python Implementations
 .. .. For |GA badge|, don't forget to check actual workflow name in unit-testing-and-coverage.yml
 .. |GA badge| image:: https://github.com/aio-libs/aiosmtpd/workflows/aiosmtpd%20CI/badge.svg
-   :target: https://github.com/aio-libs/aiosmtpd/actions
-   :alt: GitHub Actions status
+   :target: https://github.com/aio-libs/aiosmtpd/actions/workflows/unit-testing-and-coverage.yml
+   :alt: GitHub CI status
+.. |CodeQL badge| image:: https://github.com/aio-libs/aiosmtpd/workflows/CodeQL/badge.svg
+   :target: https://github.com/aio-libs/aiosmtpd/actions/workflows/codeql.yml
+   :alt: CodeQL status
 .. |codecov| image:: https://codecov.io/github/aio-libs/aiosmtpd/coverage.svg?branch=master
    :target: https://codecov.io/github/aio-libs/aiosmtpd?branch=master
    :alt: Code Coverage

--- a/DESCRIPTION.rst
+++ b/DESCRIPTION.rst
@@ -67,12 +67,18 @@ will be signed using one of the following GPG Keys:
    .. In the third column, refrain from putting in a direct link to keep the table tidy.
       Rather, use the |...|_ construct and do the replacement+linking directive below the table
 
-+-------------------------+--------------------------------+-----------+
-| GPG Key ID              | Owner / Email                  | Key       |
-+=========================+================================+===========+
-| ``5D60 CE28 9CD7 C258`` | | Pandu POLUAN /               | |pep_gh|_ |
-|                         | | pepoluan at gmail period com |           |
-+-------------------------+--------------------------------+-----------+
++-------------------------+------------------------------------+-----------+
+| GPG Key ID              | Owner / Email                      | Key       |
++=========================+====================================+===========+
+| ``5D60 CE28 9CD7 C258`` | | Pandu POLUAN /                   | |pep_gh|_ |
+|                         | | pepoluan at gmail period com     |           |
++-------------------------+------------------------------------+-----------+
+| ``5555 A6A6 7AE1 DC91`` | | Pandu E POLUAN                   |           |
+|                         | | pepoluan at gmail period com     |           |
++-------------------------+------------------------------------+-----------+
+| ``E309 FD82 73BD 8465`` | | Wayne Werner                     |           |
+|                         | | waynejwerner at gmail period com |           |
++-------------------------+------------------------------------+-----------+
 
 .. .. The |_| contruct is U+00A0 (non-breaking space), defined at the start of the file
 .. |pep_gh| replace:: On |_| GitHub

--- a/DESCRIPTION.rst
+++ b/DESCRIPTION.rst
@@ -45,7 +45,7 @@
 
 This is a server for SMTP and related MTA protocols,
 similar in utility to the standard library's |smtpd.py|_ module,
-but rewritten to be based on ``asyncio`` for Python 3.6+.
+but rewritten to be based on ``asyncio`` for Python 3.7+.
 
 Please visit the `Project Homepage`_ for more information.
 

--- a/DESCRIPTION.rst
+++ b/DESCRIPTION.rst
@@ -2,11 +2,13 @@
  aiosmtpd - asyncio based SMTP server
 ######################################
 
-| |github license| |_| |PyPI Version| |_| |PyPI Python|
-| |GA badge| |_| |codecov| |_| |LGTM.com| |_| |readthedocs|
+| |github license| |_| |PyPI Version| |_| |PyPI Python| |_| |PyPI PythonImpl|
+| |GA badge| |_| |codecov| |_| |readthedocs|
 | |GH Release| |_| |GH PRs| |_| |GH LastCommit|
+| |PyPI DL| |_| |GH DL|
 |
 
+.. .. U+00A0 is non-breaking space
 .. |_| unicode:: 0xA0
    :trim:
 .. |github license| image:: https://img.shields.io/github/license/aio-libs/aiosmtpd?logo=Open+Source+Initiative&logoColor=0F0
@@ -18,6 +20,9 @@
 .. |PyPI Python| image:: https://img.shields.io/pypi/pyversions/aiosmtpd?logo=python&logoColor=yellow
    :target: https://pypi.org/project/aiosmtpd/
    :alt: Supported Python Versions
+.. |PyPI PythonImpl| image:: https://img.shields.io/pypi/implementation/aiosmtpd?logo=python
+   :target: https://pypi.org/project/aiosmtpd/
+   :alt: Supported Python Implementations
 .. .. For |GA badge|, don't forget to check actual workflow name in unit-testing-and-coverage.yml
 .. |GA badge| image:: https://github.com/aio-libs/aiosmtpd/workflows/aiosmtpd%20CI/badge.svg
    :target: https://github.com/aio-libs/aiosmtpd/actions
@@ -25,14 +30,10 @@
 .. |codecov| image:: https://codecov.io/github/aio-libs/aiosmtpd/coverage.svg?branch=master
    :target: https://codecov.io/github/aio-libs/aiosmtpd?branch=master
    :alt: Code Coverage
-.. |LGTM.com| image:: https://img.shields.io/lgtm/grade/python/github/aio-libs/aiosmtpd.svg?logo=lgtm&logoWidth=18
-   :target: https://lgtm.com/projects/g/aio-libs/aiosmtpd/context:python
-   :alt: Semmle/LGTM.com quality
 .. |readthedocs| image:: https://img.shields.io/readthedocs/aiosmtpd?logo=Read+the+Docs
    :target: https://aiosmtpd.readthedocs.io/en/latest/?badge=latest
    :alt: Documentation Status
 .. .. Do NOT include the Discourse badge!
-.. .. Below are badges just for PyPI
 .. |GH Release| image:: https://img.shields.io/github/v/release/aio-libs/aiosmtpd?logo=github
    :target: https://github.com/aio-libs/aiosmtpd/releases
    :alt: GitHub latest release
@@ -42,6 +43,13 @@
 .. |GH LastCommit| image:: https://img.shields.io/github/last-commit/aio-libs/aiosmtpd?logo=GitHub
    :target: https://github.com/aio-libs/aiosmtpd/commits/master
    :alt: GitHub last commit
+.. |PyPI DL| image:: https://img.shields.io/pypi/dm/aiosmtpd?logo=pypi
+   :target: https://pypi.org/project/aiosmtpd/
+   :alt: PyPI monthly downloads
+.. |GH DL| image:: https://img.shields.io/github/downloads/aio-libs/aiosmtpd/total?logo=github
+   :target: https://github.com/aio-libs/aiosmtpd/releases
+   :alt: GitHub downloads
+
 
 This is a server for SMTP and related MTA protocols,
 similar in utility to the standard library's |smtpd.py|_ module,

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 graft aiosmtpd
 include LICENSE NOTICE *.cfg *.ini *.py *.rst *.yml *.toml
-global-exclude *.py[oc]
+global-exclude *.py[oc] *.sw[a-p]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 graft aiosmtpd
 include LICENSE NOTICE *.cfg *.ini *.py *.rst *.yml *.toml
-global-exclude *.py[oc] *.sw[a-p]
+global-exclude *.py[oc] *.sw[a-p] pyvenv.cfg

--- a/README.rst
+++ b/README.rst
@@ -55,13 +55,13 @@ Full documentation is available on |aiosmtpd rtd|_
 Requirements
 ============
 
-You need **at least Python 3.6** to use this library.
+You need **at least Python 3.7** to use this library.
 
 
 Supported Platforms
 -----------------------
 
-``aiosmtpd`` has been tested on **CPython** and |PyPy3.7|_
+``aiosmtpd`` has been tested on **CPython**>=3.7 and |PyPy|_>=3.7
 for the following platforms (in alphabetical order):
 
 * Cygwin (on Windows 10) [1]
@@ -69,6 +69,7 @@ for the following platforms (in alphabetical order):
 * OpenSUSE Leap 15 [2]
 * Ubuntu 18.04
 * Ubuntu 20.04
+* Ubuntu 22.04
 * Windows 10
 
   | [1] Supported only with Cygwin-provided CPython versions
@@ -77,8 +78,8 @@ for the following platforms (in alphabetical order):
 ``aiosmtpd`` *probably* can run on platforms not listed above,
 but we cannot provide support for unlisted platforms.
 
-.. |PyPy3.7| replace:: **PyPy3.7**
-.. _`PyPy3.7`: https://www.pypy.org/
+.. |PyPy| replace:: **PyPy**
+.. _`PyPy`: https://www.pypy.org/
 
 
 Installation
@@ -175,7 +176,7 @@ In general, the ``-e`` parameter to tox specifies one (or more) **testenv**
 to run (separate using comma if more than one testenv). The following testenvs
 have been configured and tested:
 
-* ``{py36,py37,py38,py39,pypy3}-{nocov,cov,diffcov,profile}``
+* ``{py37,py38,py39,py310,py311,pypy3}-{nocov,cov,diffcov,profile}``
 
   Specifies the interpreter to run and the kind of testing to perform.
 

--- a/README.rst
+++ b/README.rst
@@ -314,11 +314,17 @@ Starting version 1.3.1,
 files provided through `PyPI`_ or `GitHub Releases`_
 will be signed using one of the following GPG Keys:
 
-+-------------------------+----------------+------------------------------+
-| GPG Key ID              | Owner          | Email                        |
-+=========================+================+==============================+
-| ``5D60 CE28 9CD7 C258`` | Pandu E POLUAN | pepoluan at gmail period com |
-+-------------------------+----------------+------------------------------+
++-------------------------+----------------+----------------------------------+
+| GPG Key ID              | Owner          | Email                            |
++=========================+================+==================================+
+| ``5D60 CE28 9CD7 C258`` | Pandu E POLUAN | pepoluan at gmail period com     |
++-------------------------+----------------+----------------------------------+
+| ``5555 A6A6 7AE1 DC91`` | Pandu E POLUAN | pepoluan at gmail period com     |
++-------------------------+----------------+----------------------------------+
+| ``E309 FD82 73BD 8465`` | Wayne Werner   | waynejwerner at gmail period com |
++-------------------------+----------------+----------------------------------+
+
+
 
 .. _PyPI: https://pypi.org/project/aiosmtpd/
 .. _`GitHub Releases`: https://github.com/aio-libs/aiosmtpd/releases

--- a/README.rst
+++ b/README.rst
@@ -155,11 +155,11 @@ option::
 
 You can also add the ``-s``/``--capture=no`` option to show output, e.g.::
 
-    $ tox -e py36-nocov -- -s
+    $ tox -e py37-nocov -- -s
 
 and these options can be combined::
 
-    $ tox -e py36-nocov -- -x -s <testname>
+    $ tox -e py37-nocov -- -x -s <testname>
 
 (The ``-e`` parameter is explained in the next section about 'testenvs'.
 In general, you'll want to choose the ``nocov`` testenvs if you want to show output,
@@ -173,7 +173,7 @@ In general, the ``-e`` parameter to tox specifies one (or more) **testenv**
 to run (separate using comma if more than one testenv). The following testenvs
 have been configured and tested:
 
-* ``{py37,py38,py39,py310,py311,pypy3}-{nocov,cov,diffcov,profile}``
+* ``{py37,py38,py39,py310,py311,pypy3,pypy37,pypy38,pypy39}-{nocov,cov,diffcov,profile}``
 
   Specifies the interpreter to run and the kind of testing to perform.
 

--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@
  aiosmtpd - An asyncio based SMTP server
 =========================================
 
-| |github license| |_| |PyPI Version| |_| |PyPI Python|
-| |GA badge| |_| |codecov| |_| |LGTM.com| |_| |readthedocs|
+| |github license| |_| |PyPI Version| |_| |PyPI Python| |_| |PyPI PythonImpl|
+| |GA badge| |_| |codecov| |_| |readthedocs|
 |
 | |Discourse|
 
@@ -18,6 +18,9 @@
 .. |PyPI Python| image:: https://img.shields.io/pypi/pyversions/aiosmtpd?logo=python&logoColor=yellow
    :target: https://pypi.org/project/aiosmtpd/
    :alt: Supported Python Versions
+.. |PyPI PythonImpl| image:: https://img.shields.io/pypi/implementation/aiosmtpd?logo=python
+   :target: https://pypi.org/project/aiosmtpd/
+   :alt: Supported Python Implementations
 .. .. For |GA badge|, don't forget to check actual workflow name in unit-testing-and-coverage.yml
 .. |GA badge| image:: https://github.com/aio-libs/aiosmtpd/workflows/aiosmtpd%20CI/badge.svg
    :target: https://github.com/aio-libs/aiosmtpd/actions
@@ -25,9 +28,6 @@
 .. |codecov| image:: https://codecov.io/github/aio-libs/aiosmtpd/coverage.svg?branch=master
    :target: https://codecov.io/github/aio-libs/aiosmtpd?branch=master
    :alt: Code Coverage
-.. |LGTM.com| image:: https://img.shields.io/lgtm/grade/python/github/aio-libs/aiosmtpd.svg?logo=lgtm&logoWidth=18
-   :target: https://lgtm.com/projects/g/aio-libs/aiosmtpd/context:python
-   :alt: Semmle/LGTM.com quality
 .. |readthedocs| image:: https://img.shields.io/readthedocs/aiosmtpd?logo=Read+the+Docs&logoColor=white
    :target: https://aiosmtpd.readthedocs.io/en/latest/
    :alt: Documentation Status
@@ -41,6 +41,7 @@ The Python standard library includes a basic |SMTP|_ server in the |smtpd|_ modu
 based on the old asynchronous libraries |asyncore|_ and |asynchat|_.
 These modules are quite old and are definitely showing their age;
 ``asyncore`` and ``asynchat`` are difficult APIs to work with, understand, extend, and fix.
+(And have been deprecated since Python 3.6, and will be removed in Python 3.12.)
 
 With the introduction of the |asyncio|_ module in Python 3.4,
 a much better way of doing asynchronous I/O is now available.

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
 =========================================
 
 | |github license| |_| |PyPI Version| |_| |PyPI Python| |_| |PyPI PythonImpl|
-| |GA badge| |_| |codecov| |_| |readthedocs|
+| |GA badge| |_| |CodeQL badge| |_| |codecov| |_| |readthedocs|
 |
 | |Discourse|
 
@@ -23,8 +23,11 @@
    :alt: Supported Python Implementations
 .. .. For |GA badge|, don't forget to check actual workflow name in unit-testing-and-coverage.yml
 .. |GA badge| image:: https://github.com/aio-libs/aiosmtpd/workflows/aiosmtpd%20CI/badge.svg
-   :target: https://github.com/aio-libs/aiosmtpd/actions
-   :alt: GitHub Actions status
+   :target: https://github.com/aio-libs/aiosmtpd/actions/workflows/unit-testing-and-coverage.yml
+   :alt: GitHub CI status
+.. |CodeQL badge| image:: https://github.com/aio-libs/aiosmtpd/workflows/CodeQL/badge.svg
+   :target: https://github.com/aio-libs/aiosmtpd/actions/workflows/codeql.yml
+   :alt: CodeQL status
 .. |codecov| image:: https://codecov.io/github/aio-libs/aiosmtpd/coverage.svg?branch=master
    :target: https://codecov.io/github/aio-libs/aiosmtpd?branch=master
    :alt: Code Coverage

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,8 @@
 | |github license| |_| |PyPI Version| |_| |PyPI Python| |_| |PyPI PythonImpl|
 | |GA badge| |_| |CodeQL badge| |_| |codecov| |_| |readthedocs|
 |
-| |Discourse|
+| |GH Discussions|
+|
 
 .. |_| unicode:: 0xA0
    :trim:
@@ -34,11 +35,9 @@
 .. |readthedocs| image:: https://img.shields.io/readthedocs/aiosmtpd?logo=Read+the+Docs&logoColor=white
    :target: https://aiosmtpd.readthedocs.io/en/latest/
    :alt: Documentation Status
-.. .. If you edit the above badges, don't forget to edit setup.cfg
-.. .. The |Discourse| badge MUST NOT be included in setup.cfg
-.. |Discourse| image:: https://img.shields.io/discourse/status?server=https%3A%2F%2Faio-libs.discourse.group%2F&style=social
-   :target: https://aio-libs.discourse.group/
-   :alt: Discourse
+.. |GH Discussions| image:: https://img.shields.io/github/discussions/aio-libs/aiosmtpd?logo=github&style=social
+   :target: https://github.com/aio-libs/aiosmtpd/discussions
+   :alt: GitHub Discussions
 
 The Python standard library includes a basic |SMTP|_ server in the |smtpd|_ module,
 based on the old asynchronous libraries |asyncore|_ and |asynchat|_.

--- a/README.rst
+++ b/README.rst
@@ -64,16 +64,14 @@ Supported Platforms
 ``aiosmtpd`` has been tested on **CPython**>=3.7 and |PyPy|_>=3.7
 for the following platforms (in alphabetical order):
 
-* Cygwin (on Windows 10) [1]
-* FreeBSD 12 [2]
-* OpenSUSE Leap 15 [2]
+* Cygwin (as of 2022-12-22, only for CPython 3.7, 3.8, and 3.9)
+* MacOS 11 and 12
 * Ubuntu 18.04
 * Ubuntu 20.04
 * Ubuntu 22.04
 * Windows 10
-
-  | [1] Supported only with Cygwin-provided CPython versions
-  | [2] Supported only on the latest minor release
+* Windows Server 2019
+* Windows Server 2022
 
 ``aiosmtpd`` *probably* can run on platforms not listed above,
 but we cannot provide support for unlisted platforms.
@@ -164,10 +162,6 @@ and these options can be combined::
 In general, you'll want to choose the ``nocov`` testenvs if you want to show output,
 so you can see which test is generating which output.)
 
-The `-x` and `-s` options can be combined::
-
-    $ tox -e py36-nocov -- -x -s <testname>
-
 
 Supported 'testenvs'
 ------------------------
@@ -189,7 +183,7 @@ have been configured and tested:
     This must be **invoked manually** using the ``-e`` parameter
 
   **Note 1:** As of 2021-02-23,
-  only the ``{py36,py38}-{nocov,cov}`` combinations work on **Cygwin**.
+  only the ``{py37,py38,py39}-{nocov,cov}`` combinations work on **Cygwin**.
 
   **Note 2:** It is also possible to use whatever Python version is used when
   invoking ``tox`` by using the ``py`` target, but you must explicitly include

--- a/aiosmtpd/__init__.py
+++ b/aiosmtpd/__init__.py
@@ -4,7 +4,7 @@ import asyncio
 import warnings
 
 
-__version__ = "1.4.4a1"
+__version__ = "1.4.4"
 
 
 def _get_or_new_eventloop() -> asyncio.AbstractEventLoop:

--- a/aiosmtpd/__init__.py
+++ b/aiosmtpd/__init__.py
@@ -1,4 +1,4 @@
 # Copyright 2014-2021 The aiosmtpd Developers
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "1.4.3.dev0"
+__version__ = "1.4.3rc1"

--- a/aiosmtpd/__init__.py
+++ b/aiosmtpd/__init__.py
@@ -1,4 +1,21 @@
 # Copyright 2014-2021 The aiosmtpd Developers
 # SPDX-License-Identifier: Apache-2.0
+import asyncio
+import warnings
 
-__version__ = "1.4.4a0"
+
+__version__ = "1.4.4a1"
+
+
+def _get_or_new_eventloop() -> asyncio.AbstractEventLoop:
+    loop = None
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        try:
+            loop = asyncio.get_event_loop()
+        except (DeprecationWarning, RuntimeError):  # pragma: py-lt-310
+            if loop is None:  # pragma: py-lt-312
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+    assert isinstance(loop, asyncio.AbstractEventLoop)
+    return loop

--- a/aiosmtpd/__init__.py
+++ b/aiosmtpd/__init__.py
@@ -1,4 +1,4 @@
 # Copyright 2014-2021 The aiosmtpd Developers
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "1.4.3rc2"
+__version__ = "1.4.3"

--- a/aiosmtpd/__init__.py
+++ b/aiosmtpd/__init__.py
@@ -1,4 +1,4 @@
 # Copyright 2014-2021 The aiosmtpd Developers
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "1.5.0a2"
+__version__ = "1.4.3.dev0"

--- a/aiosmtpd/__init__.py
+++ b/aiosmtpd/__init__.py
@@ -1,4 +1,4 @@
 # Copyright 2014-2021 The aiosmtpd Developers
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "1.4.3rc1"
+__version__ = "1.4.3rc2"

--- a/aiosmtpd/__init__.py
+++ b/aiosmtpd/__init__.py
@@ -1,4 +1,4 @@
 # Copyright 2014-2021 The aiosmtpd Developers
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "1.4.3"
+__version__ = "1.4.4a0"

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -142,6 +142,12 @@ class BaseController(metaclass=ABCMeta):
             self.loop = loop
         self.ssl_context = ssl_context
         self.ssl_handshake_timeout = ssl_handshake_timeout
+        # Add a warning in the log that the ssl_handshake_timeout is ignored on
+        # Prython 3.6 and earlier.
+        if (self.ssl_handshake_timeout is not None and
+                sys.version_info < (3, 7)):  # pragma: no cover
+            log.warning("SSL handshake timeout is ignored on Python 3.6 and "
+                        "earlier.")
         self.SMTP_kwargs: Dict[str, Any] = {}
         if "server_kwargs" in SMTP_parameters:
             warn(
@@ -432,7 +438,8 @@ class InetMixin(BaseController, metaclass=ABCMeta):
         Does NOT actually start the protocol object itself;
         _factory_invoker() is only called upon fist connection attempt.
         """
-        if sys.version_info >= (3, 7) and self.ssl_context is not None:
+        if (sys.version_info >= (3, 7) and
+                self.ssl_context is not None):  # pragma: no cover
             kwargs = {"ssl_handshake_timeout": self.ssl_handshake_timeout}
         else:
             kwargs = {}

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -148,7 +148,7 @@ class BaseController(metaclass=ABCMeta):
         # Add a warning in the log that the ssl_handshake_timeout is ignored on
         # Prython 3.6 and earlier.
         if (self.ssl_handshake_timeout is not None and
-                sys.version_info < (3, 7)):  # pragma: no cover
+                sys.version_info < (3, 7)):  # pragma: py-lt-37
             log.warning("SSL handshake timeout is ignored on Python 3.6 and "
                         "earlier.")
         self.SMTP_kwargs: Dict[str, Any] = {}
@@ -442,7 +442,7 @@ class InetMixin(BaseController, metaclass=ABCMeta):
         _factory_invoker() is only called upon fist connection attempt.
         """
         if (sys.version_info >= (3, 7) and
-                self.ssl_context is not None):  # pragma: no cover
+                self.ssl_context is not None):  # pragma: py-ge-37
             kwargs = {"ssl_handshake_timeout": self.ssl_handshake_timeout}
         else:
             kwargs = {}
@@ -494,7 +494,8 @@ class UnixSocketMixin(BaseController, metaclass=ABCMeta):  # pragma: no-unixsock
         Does NOT actually start the protocol object itself;
         _factory_invoker() is only called upon fist connection attempt.
         """
-        if sys.version_info >= (3, 7) and self.ssl_context is not None:
+        if (sys.version_info >= (3, 7) and
+                self.ssl_context is not None):  # pragma: py-ge-37
             kwargs = {"ssl_handshake_timeout": self.ssl_handshake_timeout}
         else:
             kwargs = {}

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -109,7 +109,7 @@ class BaseController(metaclass=ABCMeta):
     def __init__(
         self,
         handler: Any,
-        loop: asyncio.AbstractEventLoop = None,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
         *,
         ssl_context: Optional[ssl.SSLContext] = None,
         # SMTP parameters
@@ -184,7 +184,7 @@ class BaseController(metaclass=ABCMeta):
         try:
             _all_tasks = asyncio.all_tasks  # pytype: disable=module-attr
         except AttributeError:  # pragma: py-gt-36
-            _all_tasks = asyncio.Task.all_tasks
+            _all_tasks = asyncio.Task.all_tasks  # pytype: disable=attribute-error
         for task in _all_tasks(self.loop):
             # This needs to be invoked in a thread-safe way
             task.cancel()
@@ -198,7 +198,7 @@ class BaseThreadedController(BaseController, metaclass=ABCMeta):
     def __init__(
         self,
         handler: Any,
-        loop: asyncio.AbstractEventLoop = None,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
         *,
         ready_timeout: float = DEFAULT_READY_TIMEOUT,
         ssl_context: Optional[ssl.SSLContext] = None,
@@ -322,7 +322,7 @@ class BaseUnthreadedController(BaseController, metaclass=ABCMeta):
     def __init__(
         self,
         handler: Any,
-        loop: asyncio.AbstractEventLoop = None,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
         *,
         ssl_context: Optional[ssl.SSLContext] = None,
         # SMTP parameters
@@ -388,7 +388,7 @@ class InetMixin(BaseController, metaclass=ABCMeta):
         handler: Any,
         hostname: Optional[str] = None,
         port: int = 8025,
-        loop: asyncio.AbstractEventLoop = None,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
         **kwargs,
     ):
         super().__init__(
@@ -435,7 +435,7 @@ class UnixSocketMixin(BaseController, metaclass=ABCMeta):  # pragma: no-unixsock
         self,
         handler: Any,
         unix_socket: Union[str, Path],
-        loop: asyncio.AbstractEventLoop = None,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
         **kwargs,
     ):
         super().__init__(
@@ -497,13 +497,9 @@ class UnixSocketController(  # pragma: no-unixsock
 class UnthreadedController(InetMixin, BaseUnthreadedController):
     """Provides an unthreaded controller that listens on an INET endpoint"""
 
-    pass
-
 
 @public
 class UnixSocketUnthreadedController(  # pragma: no-unixsock
     UnixSocketMixin, BaseUnthreadedController
 ):
     """Provides an unthreaded controller that listens on a Unix Socket file"""
-
-    pass

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -107,11 +107,11 @@ class _FakeServer(asyncio.StreamReaderProtocol):
         # Imitate what SMTP does
         super().__init__(
             asyncio.StreamReader(loop=loop),
-            client_connected_cb=self._client_connected_cb,
+            client_connected_cb=self._cb_client_connected,
             loop=loop,
         )
 
-    def _client_connected_cb(
+    def _cb_client_connected(
             self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
     ) -> None:
         pass

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -79,6 +79,24 @@ def get_localhost() -> Literal["::1", "127.0.0.1"]:
         raise
 
 
+def _server_to_client_ssl_ctx(server_ctx: ssl.SSLContext) -> ssl.SSLContext:
+    """
+    Given an SSLContext object with TLS_SERVER_PROTOCOL return a client
+    context that can connect to the server.
+    """
+    client_ctx = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
+    client_ctx.options = server_ctx.options
+    client_ctx.check_hostname = False
+    # We do not verify the ssl cert for the server here simply because this
+    # is a local connection to poke at the server for it to do its lazy
+    # initialization sequence. The only purpose of this client context
+    # is to make a connection to the *local* server created using the same
+    # code. That is also the reason why we disable cert verification below
+    # and the flake8 check for the same.
+    client_ctx.verify_mode = ssl.CERT_NONE    # noqa: DUO122
+    return client_ctx
+
+
 class _FakeServer(asyncio.StreamReaderProtocol):
     """
     Returned by _factory_invoker() in lieu of an SMTP instance in case
@@ -425,7 +443,8 @@ class InetMixin(BaseController, metaclass=ABCMeta):
         with ExitStack() as stk:
             s = stk.enter_context(create_connection((hostname, self.port), 1.0))
             if self.ssl_context:
-                s = stk.enter_context(self.ssl_context.wrap_socket(s))
+                client_ctx = _server_to_client_ssl_ctx(self.ssl_context)
+                s = stk.enter_context(client_ctx.wrap_socket(s))
             s.recv(1024)
 
 
@@ -467,7 +486,8 @@ class UnixSocketMixin(BaseController, metaclass=ABCMeta):  # pragma: no-unixsock
             s: makesock = stk.enter_context(makesock(AF_UNIX, SOCK_STREAM))
             s.connect(self.unix_socket)
             if self.ssl_context:
-                s = stk.enter_context(self.ssl_context.wrap_socket(s))
+                client_ctx = _server_to_client_ssl_ctx(self.ssl_context)
+                s = stk.enter_context(client_ctx.wrap_socket(s))
             s.recv(1024)
 
 

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import errno
+import logging
 import os
 import ssl
 import sys
@@ -32,6 +33,8 @@ from public import public
 from aiosmtpd.smtp import SMTP
 
 AsyncServer = asyncio.base_events.Server
+
+log = logging.getLogger('mail.log')
 
 DEFAULT_READY_TIMEOUT: float = 5.0
 

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -154,6 +154,8 @@ class BaseController(metaclass=ABCMeta):
         self.SMTP_kwargs.update(SMTP_parameters)
         if server_hostname:
             self.SMTP_kwargs["hostname"] = server_hostname
+        if ssl_handshake_timeout:
+            self.SMTP_kwargs["tls_handshake_timeout"] = ssl_handshake_timeout
         # Emulate previous behavior of defaulting enable_SMTPUTF8 to True
         # It actually conflicts with SMTP class's default, but the reasoning is
         # discussed in the docs.

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -147,8 +147,8 @@ class BaseController(metaclass=ABCMeta):
         self.ssl_handshake_timeout = ssl_handshake_timeout
         # Add a warning in the log that the ssl_handshake_timeout is ignored on
         # Prython 3.6 and earlier.
-        if (self.ssl_handshake_timeout is not None and
-                sys.version_info < (3, 7)):  # pragma: py-lt-37
+        if (self.ssl_handshake_timeout is not None
+                and sys.version_info < (3, 7)):  # pragma: py-lt-37
             log.warning("SSL handshake timeout is ignored on Python 3.6 and "
                         "earlier.")
         self.SMTP_kwargs: Dict[str, Any] = {}
@@ -441,8 +441,8 @@ class InetMixin(BaseController, metaclass=ABCMeta):
         Does NOT actually start the protocol object itself;
         _factory_invoker() is only called upon fist connection attempt.
         """
-        if (sys.version_info >= (3, 7) and
-                self.ssl_context is not None):  # pragma: py-ge-37
+        if (sys.version_info >= (3, 7)
+                and self.ssl_context is not None):  # pragma: py-ge-37
             kwargs = {"ssl_handshake_timeout": self.ssl_handshake_timeout}
         else:
             kwargs = {}
@@ -494,8 +494,8 @@ class UnixSocketMixin(BaseController, metaclass=ABCMeta):  # pragma: no-unixsock
         Does NOT actually start the protocol object itself;
         _factory_invoker() is only called upon fist connection attempt.
         """
-        if (sys.version_info >= (3, 7) and
-                self.ssl_context is not None):  # pragma: py-ge-37
+        if (sys.version_info >= (3, 7)
+                and self.ssl_context is not None):  # pragma: py-ge-37
             kwargs = {"ssl_handshake_timeout": self.ssl_handshake_timeout}
         else:
             kwargs = {}

--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -16,6 +16,12 @@ Fixed/Improved
 * A whole bunch of annotations
 
 
+1.4.4a0 (ad hoc)
+================
+
+(Stub ``NEWS.rst`` entry as placeholder for ``qa`` test.)
+
+
 1.4.3 (2022-12-21)
 =====================
 

--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -14,6 +14,8 @@ Fixed/Improved
 --------------
 * All Controllers now have more rationale design, as they are now composited from a Base + a Mixin
 * A whole bunch of annotations
+* Adds ``ssl_handshake_timeout`` parameter to the Controller to allow setting the timeout
+  with SSL to be different than the default 60 seconds on Python 3.7 and later. (See #269)
 
 
 1.4.4 (2023-01-13)

--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -16,6 +16,20 @@ Fixed/Improved
 * A whole bunch of annotations
 
 
+1.4.3 (2022-12-16)
+==================
+
+Fixed/Improved
+--------------
+* Add compatibility for Python 3.10 and 3.11 (Closes #322)
+* Test matrix update (Closes #306)
+
+  * Drop Python 3.6, PyPy 3.6 (some) and MacOS 10
+  * Add Python 3.10 & 3.11, PyPy 3.7 & 3.8, Ubuntu 22.04, MacOS 11 & 12
+
+* Longer AUTOSTOP_DELAY especially for Windows (Closes #313)
+
+
 1.4.2 (2021-03-08)
 =====================
 

--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -16,10 +16,12 @@ Fixed/Improved
 * A whole bunch of annotations
 
 
-1.4.4a0 (ad hoc)
+1.4.4a1 (ad hoc)
 ================
 
-(Stub ``NEWS.rst`` entry as placeholder for ``qa`` test.)
+Fixed/Improved
+--------------
+* No longer expect an implicit creation of the event loop through ``get_event_loop()`` (Closes #353)
 
 
 1.4.3 (2022-12-21)

--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -16,7 +16,7 @@ Fixed/Improved
 * A whole bunch of annotations
 
 
-1.4.3rc1 (2022-12-16)
+1.4.3rc2 (2022-12-18)
 =====================
 
 Fixed/Improved
@@ -28,6 +28,7 @@ Fixed/Improved
   * Add Python 3.10 & 3.11, PyPy 3.7 & 3.8, Ubuntu 22.04, MacOS 11 & 12
 
 * Longer AUTOSTOP_DELAY especially for Windows (Closes #313)
+* Update signing keys
 
 
 1.4.2 (2021-03-08)

--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -16,19 +16,22 @@ Fixed/Improved
 * A whole bunch of annotations
 
 
-1.4.3rc2 (2022-12-18)
+1.4.3 (2022-12-21)
 =====================
 
 Fixed/Improved
 --------------
+* Is now compatible with uvloop
 * Add compatibility for Python 3.10 and 3.11 (Closes #322)
 * Test matrix update (Closes #306)
 
   * Drop Python 3.6, PyPy 3.6 (some) and MacOS 10
   * Add Python 3.10 & 3.11, PyPy 3.7 & 3.8, Ubuntu 22.04, MacOS 11 & 12
 
+* Expanded tox environments
 * Longer AUTOSTOP_DELAY especially for Windows (Closes #313)
 * Update signing keys
+* Some documentation fixes
 
 
 1.4.2 (2021-03-08)

--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -16,8 +16,8 @@ Fixed/Improved
 * A whole bunch of annotations
 
 
-1.4.3 (2022-12-16)
-==================
+1.4.3rc1 (2022-12-16)
+=====================
 
 Fixed/Improved
 --------------

--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -16,8 +16,8 @@ Fixed/Improved
 * A whole bunch of annotations
 
 
-1.4.4a1 (ad hoc)
-================
+1.4.4 (2023-01-13)
+==================
 
 Fixed/Improved
 --------------

--- a/aiosmtpd/docs/_exts/autoprogramm.py
+++ b/aiosmtpd/docs/_exts/autoprogramm.py
@@ -34,9 +34,9 @@ import collections
 import os
 import sphinx
 
-from docutils import nodes
-from docutils.parsers.rst import Directive
-from docutils.parsers.rst.directives import unchanged
+from docutils import nodes  # pytype: disable=pyi-error
+from docutils.parsers.rst import Directive  # pytype: disable=pyi-error
+from docutils.parsers.rst.directives import unchanged  # pytype: disable=pyi-error
 from docutils.statemachine import StringList
 from functools import reduce
 from sphinx.util.nodes import nested_parse_with_titles
@@ -59,7 +59,7 @@ def get_subparser_action(parser: argparse.ArgumentParser) -> argparse._SubParser
 
 def scan_programs(
     parser: argparse.ArgumentParser,
-    command: List[str] = None,
+    command: Optional[List[str]] = None,
     maxdepth: int = 0,
     depth: int = 0,
     groups: bool = False,
@@ -111,8 +111,8 @@ def scan_options(actions: list):
 
 
 def format_positional_argument(arg: argparse.Action) -> Tuple[List[str], str]:
-    desc = (arg.help or "") % {"default": arg.default}
-    name = arg.metavar or arg.dest
+    desc: str = (arg.help or "") % {"default": arg.default}
+    name: str = arg.metavar or arg.dest or ""
     return [name], desc
 
 
@@ -297,6 +297,7 @@ def render_rst(
     options_adornment: str,
 ):
     if usage_strip:
+        assert usage is not None
         to_strip = title.rsplit(" ", 1)[0]
 
         len_to_strip = len(to_strip) - 4

--- a/aiosmtpd/docs/_exts/autoprogramm.py
+++ b/aiosmtpd/docs/_exts/autoprogramm.py
@@ -40,7 +40,7 @@ from docutils.parsers.rst.directives import unchanged  # pytype: disable=pyi-err
 from docutils.statemachine import StringList
 from functools import reduce
 from sphinx.util.nodes import nested_parse_with_titles
-from typing import Any, Dict, List, Optional, Tuple, cast
+from typing import Any, Dict, List, Optional, Tuple
 
 
 __all__ = ("AutoprogrammDirective", "import_object", "scan_programs", "setup")

--- a/aiosmtpd/docs/_exts/autoprogramm.py
+++ b/aiosmtpd/docs/_exts/autoprogramm.py
@@ -40,7 +40,7 @@ from docutils.parsers.rst.directives import unchanged  # pytype: disable=pyi-err
 from docutils.statemachine import StringList
 from functools import reduce
 from sphinx.util.nodes import nested_parse_with_titles
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 
 __all__ = ("AutoprogrammDirective", "import_object", "scan_programs", "setup")
@@ -112,7 +112,11 @@ def scan_options(actions: list):
 
 def format_positional_argument(arg: argparse.Action) -> Tuple[List[str], str]:
     desc: str = (arg.help or "") % {"default": arg.default}
-    name: str = arg.metavar or arg.dest or ""
+    name: str
+    if isinstance(arg.metavar, tuple):
+        name = arg.metavar[0]
+    else:
+        name = arg.metavar or arg.dest or ""
     return [name], desc
 
 

--- a/aiosmtpd/docs/_exts/autoprogramm.py
+++ b/aiosmtpd/docs/_exts/autoprogramm.py
@@ -149,7 +149,6 @@ def import_object(import_name: str) -> Any:
         # an ImportError as it did before.
         import glob
         import sys
-        import os
         import imp
 
         for p in sys.path:

--- a/aiosmtpd/docs/_exts/autoprogramm.py
+++ b/aiosmtpd/docs/_exts/autoprogramm.py
@@ -46,13 +46,16 @@ from typing import Any, Dict, List, Optional, Tuple
 __all__ = ("AutoprogrammDirective", "import_object", "scan_programs", "setup")
 
 
-# Need to temporarily disable this particular check, because although this function is guaranteed to return a proper
-# value (due to how ArgumentParser works), pytype doesn't really know that, and therefore raised an error
-# in the (to its view) possible fallthrough of "implicit return None" if the "for a" loop exits without finding the
-# right item.
+# Need to temporarily disable this particular check, because although this function
+# is guaranteed to return a proper value (due to how ArgumentParser works), pytype
+# doesn't really know that, and therefore raised an error  in the (to its view)
+# possible fallthrough of "implicit return None" if the "for a" loop exits without
+# finding the right item.
 #
 # pytype: disable=bad-return-type
-def get_subparser_action(parser: argparse.ArgumentParser) -> argparse._SubParsersAction:
+def get_subparser_action(
+    parser: argparse.ArgumentParser
+) -> argparse._SubParsersAction:
     neg1_action = parser._actions[-1]
 
     if isinstance(neg1_action, argparse._SubParsersAction):

--- a/aiosmtpd/docs/_exts/autoprogramm.py
+++ b/aiosmtpd/docs/_exts/autoprogramm.py
@@ -46,6 +46,11 @@ from typing import Any, Dict, List, Optional, Tuple
 __all__ = ("AutoprogrammDirective", "import_object", "scan_programs", "setup")
 
 
+# Need to temporarily disable this particular check, because although this function is guaranteed to return a proper
+# value (due to how ArgumentParser works), pytype doesn't really know that, and therefore raised an error
+# in the (to its view) possible fallthrough of "implicit return None" if the "for a" loop exits without finding the
+# right item.
+#
 # pytype: disable=bad-return-type
 def get_subparser_action(parser: argparse.ArgumentParser) -> argparse._SubParsersAction:
     neg1_action = parser._actions[-1]

--- a/aiosmtpd/docs/_exts/autoprogramm.py
+++ b/aiosmtpd/docs/_exts/autoprogramm.py
@@ -40,7 +40,7 @@ from docutils.parsers.rst.directives import unchanged  # pytype: disable=pyi-err
 from docutils.statemachine import StringList
 from functools import reduce
 from sphinx.util.nodes import nested_parse_with_titles
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 
 __all__ = ("AutoprogrammDirective", "import_object", "scan_programs", "setup")
@@ -54,7 +54,7 @@ def get_subparser_action(parser: argparse.ArgumentParser) -> argparse._SubParser
 
     for a in parser._actions:
         if isinstance(a, argparse._SubParsersAction):
-            return a
+            return cast(argparse._SubParsersAction, a)
 
 
 def scan_programs(

--- a/aiosmtpd/docs/_exts/autoprogramm.py
+++ b/aiosmtpd/docs/_exts/autoprogramm.py
@@ -40,12 +40,13 @@ from docutils.parsers.rst.directives import unchanged  # pytype: disable=pyi-err
 from docutils.statemachine import StringList
 from functools import reduce
 from sphinx.util.nodes import nested_parse_with_titles
-from typing import Any, Dict, List, Optional, Tuple, cast
+from typing import Any, Dict, List, Optional, Tuple
 
 
 __all__ = ("AutoprogrammDirective", "import_object", "scan_programs", "setup")
 
 
+# pytype: disable=bad-return-type
 def get_subparser_action(parser: argparse.ArgumentParser) -> argparse._SubParsersAction:
     neg1_action = parser._actions[-1]
 
@@ -54,7 +55,8 @@ def get_subparser_action(parser: argparse.ArgumentParser) -> argparse._SubParser
 
     for a in parser._actions:
         if isinstance(a, argparse._SubParsersAction):
-            return cast(argparse._SubParsersAction, a)
+            return a
+# pytype: enable=bad-return-type
 
 
 def scan_programs(

--- a/aiosmtpd/docs/controller.rst
+++ b/aiosmtpd/docs/controller.rst
@@ -406,6 +406,7 @@ Controller API
     loop=None, \
     *, \
     ssl_context=None, \
+    ssl_handshake_timeout=None, \
     server_hostname=None, \
     server_kwargs=None, \
     **SMTP_parameters, \
@@ -421,6 +422,10 @@ Controller API
     :param ssl_context: SSL Context to wrap the socket in.
         Will be passed-through to  :meth:`~asyncio.loop.create_server` method
     :type ssl_context: ssl.SSLContext
+    :param: ssl_handshake_timeout: Timeout for the SSL handshake in seconds.
+        Will be passed through to  :meth:`~asyncio.loop.create_server` method on Python 3.7
+        and later.
+    :type ssl_handshake_timeout: float
     :param server_hostname: Server's hostname,
         will be passed-through as ``hostname`` parameter of :class:`~aiosmtpd.smtp.SMTP`
     :type server_hostname: Optional[str]
@@ -489,6 +494,7 @@ Controller API
     *, \
     ready_timeout=DEFAULT_READY_TIMEOUT, \
     ssl_context=None, \
+    ssl_handshake_timeout, \
     server_hostname=None, \
     server_kwargs=None, \
     **SMTP_parameters)

--- a/aiosmtpd/docs/controller.rst
+++ b/aiosmtpd/docs/controller.rst
@@ -21,6 +21,12 @@ In both cases, you need to pass a :ref:`handler <handlers>` to the ``SMTP``
 constructor.  Handlers respond to events that you care about during the SMTP
 dialog.
 
+.. important::
+
+  Consider running the controller in a separate Python process (e.g., using the
+  :mod:`multiprocessing` module) if you don't want your main Python process to be
+  blocked when aiosmtpd is handling extra-large emails.
+
 
 Using the controller
 ====================

--- a/aiosmtpd/docs/controller.rst
+++ b/aiosmtpd/docs/controller.rst
@@ -261,7 +261,7 @@ we'll also schedule an autostop so it won't hang:
     ...     loop.run_forever()
     >>> import threading
     >>> thread = threading.Thread(target=runner)
-    >>> thread.setDaemon(True)
+    >>> thread.daemon = True
     >>> thread.start()
     >>> import time
     >>> time.sleep(0.1)  # Allow the loop to begin

--- a/aiosmtpd/docs/controller.rst
+++ b/aiosmtpd/docs/controller.rst
@@ -236,7 +236,8 @@ you'll have to do something similar to this:
 .. doctest:: unthreaded
 
     >>> import asyncio
-    >>> loop = asyncio.get_event_loop()
+    >>> loop = asyncio.new_event_loop()
+    >>> asyncio.set_event_loop(loop)
     >>> from aiosmtpd.controller import UnthreadedController
     >>> from aiosmtpd.handlers import Sink
     >>> controller = UnthreadedController(Sink(), loop=loop)

--- a/aiosmtpd/docs/handlers.rst
+++ b/aiosmtpd/docs/handlers.rst
@@ -207,7 +207,7 @@ The following hooks are currently supported (in alphabetical order):
 .. py:method:: handle_RCPT(server, session, envelope, address, rcpt_options) -> str
    :async:
 
-   :param address: The parsed email address given by the client in the ``MAIL FROM`` command
+   :param address: The parsed email address given by the client in the ``RCPT TO`` command
    :type address: str
    :param rcpt_options: Additional ESMTP RCPT options provided by the client
    :type rcpt_options: List[str]

--- a/aiosmtpd/docs/smtp.rst
+++ b/aiosmtpd/docs/smtp.rst
@@ -160,9 +160,9 @@ aiosmtpd.smtp
 
 .. class:: SMTP(handler, *, data_size_limit=33554432, enable_SMTPUTF8=False, \
    decode_data=False, hostname=None, ident=None, tls_context=None, \
-   require_starttls=False, timeout=300, auth_required=False, \
-   auth_require_tls=True, auth_exclude_mechanism=None, auth_callback=None, \
-   authenticator=None, command_call_limit=None, \
+   tls_handshake_timeout=None, require_starttls=False, timeout=300, \
+   auth_required=False, auth_require_tls=True, auth_exclude_mechanism=None, \
+   auth_callback=None, authenticator=None, command_call_limit=None, \
    proxy_protocol_timeout=None, \
    loop=None)
 
@@ -226,6 +226,15 @@ aiosmtpd.smtp
       as defined in :rfc:`3207`.
 
       See :ref:`tls` for a more in-depth discussion on enabling ``STARTTLS``.
+
+   .. py:attribute:: tls_handshake_timeout
+      :type: float
+      :value: None
+      :noindex:
+
+      Sets the timeout for the SSL handshake in seconds. 
+      When running on python 3.7 or later this overrides the default SSL handshake
+      timeout of 60 seconds. On python 3.6 and earlier this has no effect.
 
    .. py:attribute:: require_starttls
       :type: bool

--- a/aiosmtpd/handlers.py
+++ b/aiosmtpd/handlers.py
@@ -25,6 +25,7 @@ from typing import Any, AnyStr, List, Type, TypeVar, Optional
 
 from public import public
 
+from aiosmtpd import _get_or_new_eventloop
 from aiosmtpd.smtp import SMTP as SMTPServer
 from aiosmtpd.smtp import Envelope as SMTPEnvelope
 from aiosmtpd.smtp import Session as SMTPSession
@@ -218,7 +219,7 @@ class AsyncMessage(Message, metaclass=ABCMeta):
         loop: Optional[asyncio.AbstractEventLoop] = None,
     ):
         super().__init__(message_class)
-        self.loop = loop or asyncio.get_event_loop()
+        self.loop = loop or _get_or_new_eventloop()
 
     async def handle_DATA(
         self, server: SMTPServer, session: SMTPSession, envelope: SMTPEnvelope

--- a/aiosmtpd/main.py
+++ b/aiosmtpd/main.py
@@ -1,7 +1,6 @@
 # Copyright 2014-2021 The aiosmtpd Developers
 # SPDX-License-Identifier: Apache-2.0
 
-import asyncio
 import logging
 import os
 import signal
@@ -16,7 +15,7 @@ from typing import Optional, Sequence, Tuple
 
 from public import public
 
-from aiosmtpd import __version__
+from aiosmtpd import __version__, _get_or_new_eventloop
 from aiosmtpd.smtp import DATA_SIZE_DEFAULT, SMTP
 
 try:
@@ -252,7 +251,7 @@ def main(args: Optional[Sequence[str]] = None) -> None:
 
     logging.basicConfig(level=logging.ERROR)
     log = logging.getLogger("mail.log")
-    loop = asyncio.get_event_loop()
+    loop = _get_or_new_eventloop()
 
     if args.debug > 0:
         log.setLevel(logging.INFO)

--- a/aiosmtpd/proxy_protocol.py
+++ b/aiosmtpd/proxy_protocol.py
@@ -104,15 +104,12 @@ class UnknownTypeTLV(KeyError):
 class AsyncReader(Protocol):
     async def read(self, num_bytes: Optional[int] = None) -> bytes:
         ...
-        return b""
 
     async def readexactly(self, num_bytes: int) -> bytes:
         ...
-        return b""
 
     async def readuntil(self, until_chars: Optional[bytes] = None) -> bytes:
         ...
-        return b""
 
 
 _anoinit = partial(attr.ib, init=False)

--- a/aiosmtpd/proxy_protocol.py
+++ b/aiosmtpd/proxy_protocol.py
@@ -9,7 +9,7 @@ from collections import deque
 from enum import IntEnum
 from functools import partial
 from ipaddress import IPv4Address, IPv6Address, ip_address
-from typing import Any, AnyStr, ByteString, Dict, Optional, Tuple, Union
+from typing import Any, ByteString, Dict, Optional, Tuple, Union
 
 import attr
 from public import public
@@ -87,7 +87,7 @@ log = logging.getLogger("mail.debug")
 
 # region #### Custom Types ############################################################
 
-EndpointAddress = Union[IPv4Address, IPv6Address, AnyStr]
+EndpointAddress = Union[IPv4Address, IPv6Address, Union[str, bytes]]
 
 
 @public

--- a/aiosmtpd/qa/test_0packaging.py
+++ b/aiosmtpd/qa/test_0packaging.py
@@ -56,7 +56,7 @@ class TestVersion:
 
 
 class TestNews:
-    news_rst = list(Path("..").rglob("*/NEWS.rst"))[0]
+    news_rst = list(Path(__file__).parent.parent.rglob("*/NEWS.rst"))[0]
 
     def test_NEWS_version(self, aiosmtpd_version: version.Version):
         with self.news_rst.open("rt") as fin:

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -361,8 +361,8 @@ class SMTP(asyncio.StreamReaderProtocol):
                 log.warning("tls_context.check_hostname == True; "
                             "this might cause client connection problems")
         self.tls_handshake_timeout = tls_handshake_timeout
-        if (tls_handshake_timeout is not None and
-                sys.version_info < (3, 7)):  # pragma: py-lt-37
+        if (tls_handshake_timeout is not None
+                and sys.version_info < (3, 7)):  # pragma: py-lt-37
             log.warning("Setting TLS handshake timeout on python 3.6 or "
                         "earlier has no effect.")
         self.require_starttls = tls_context and require_starttls

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -899,11 +899,12 @@ class SMTP(asyncio.StreamReaderProtocol):
             self.tls_context,
             waiter,
             server_side=True)
+
         # Reconfigure transport layer.  Keep a reference to the original
         # transport so that we can close it explicitly when the connection is
-        # lost.  XXX BaseTransport.set_protocol() was added in Python 3.5.3 :(
+        # lost.
         self._original_transport = self.transport
-        self._original_transport._protocol = self._tls_protocol
+        self._original_transport.set_protocol(self._tls_protocol)
         # Reconfigure the protocol layer.  Why is the app transport a protected
         # property, if it MUST be used externally?
         self.transport = self._tls_protocol._app_transport

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -361,7 +361,8 @@ class SMTP(asyncio.StreamReaderProtocol):
                 log.warning("tls_context.check_hostname == True; "
                             "this might cause client connection problems")
         self.tls_handshake_timeout = tls_handshake_timeout
-        if tls_handshake_timeout is not None and sys.version_info < (3, 7):
+        if (tls_handshake_timeout is not None and
+                sys.version_info < (3, 7)):  # pragma: py-lt-37
             log.warning("Setting TLS handshake timeout on python 3.6 or "
                         "earlier has no effect.")
         self.require_starttls = tls_context and require_starttls
@@ -898,7 +899,7 @@ class SMTP(asyncio.StreamReaderProtocol):
         # Create a waiter Future to wait for SSL handshake to complete
         waiter = self.loop.create_future()
         # If on python 3.7 or greater set the ssl_handshake_timeout.
-        if sys.version_info >= (3, 7):
+        if sys.version_info >= (3, 7):  # pragma: py-ge-37
             tls_kwargs = {"ssl_handshake_timeout": self.tls_handshake_timeout}
         else:
             tls_kwargs = {}

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -11,6 +11,7 @@ import logging
 import re
 import socket
 import ssl
+import sys
 from base64 import b64decode, b64encode
 from email._header_value_parser import get_addr_spec, get_angle_addr
 from email.errors import HeaderParseError
@@ -321,6 +322,7 @@ class SMTP(asyncio.StreamReaderProtocol):
             hostname: Optional[str] = None,
             ident: Optional[str] = None,
             tls_context: Optional[ssl.SSLContext] = None,
+            tls_handshake_timeout: float = None,
             require_starttls: bool = False,
             timeout: float = 300,
             auth_required: bool = False,
@@ -358,6 +360,10 @@ class SMTP(asyncio.StreamReaderProtocol):
             elif tls_context.check_hostname:
                 log.warning("tls_context.check_hostname == True; "
                             "this might cause client connection problems")
+        self.tls_handshake_timeout = tls_handshake_timeout
+        if tls_handshake_timeout is not None and sys.version_info < (3, 7):
+            log.warning("Setting TLS handshake timeout on python 3.6 or "
+                        "earlier has no effect.")
         self.require_starttls = tls_context and require_starttls
         self._timeout_duration = timeout
         self._timeout_handle = None
@@ -891,6 +897,11 @@ class SMTP(asyncio.StreamReaderProtocol):
         await self.push('220 Ready to start TLS')
         # Create a waiter Future to wait for SSL handshake to complete
         waiter = self.loop.create_future()
+        # If on python 3.7 or greater set the ssl_handshake_timeout.
+        if sys.version_info >= (3, 7):
+            tls_kwargs = {"ssl_handshake_timeout": self.tls_handshake_timeout}
+        else:
+            tls_kwargs = {}
         # Create SSL layer.
         # noinspection PyTypeChecker
         self._tls_protocol = sslproto.SSLProtocol(
@@ -898,8 +909,8 @@ class SMTP(asyncio.StreamReaderProtocol):
             self,
             self.tls_context,
             waiter,
-            server_side=True)
-
+            server_side=True,
+            **tls_kwargs)
         # Reconfigure transport layer.  Keep a reference to the original
         # transport so that we can close it explicitly when the connection is
         # lost.

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -34,7 +34,7 @@ from warnings import warn
 import attr
 from public import public
 
-from aiosmtpd import __version__
+from aiosmtpd import __version__, _get_or_new_eventloop
 from aiosmtpd.proxy_protocol import ProxyData, get_proxy
 
 
@@ -208,7 +208,7 @@ class Envelope:
 # unit test suite.  In that case, this function is mocked to set the debug
 # level on the loop (as if PYTHONASYNCIODEBUG=1 were set).
 def make_loop() -> asyncio.AbstractEventLoop:
-    return asyncio.get_event_loop()
+    return _get_or_new_eventloop()
 
 
 @public

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -213,7 +213,7 @@ def make_loop() -> asyncio.AbstractEventLoop:
 
 @public
 def syntax(
-        text: str, extended: str = None, when: Optional[str] = None
+        text: str, extended: Optional[str] = None, when: Optional[str] = None
 ) -> DecoratorType:
     """
     A @decorator that provides helptext for (E)SMTP HELP.
@@ -318,19 +318,19 @@ class SMTP(asyncio.StreamReaderProtocol):
             data_size_limit: int = DATA_SIZE_DEFAULT,
             enable_SMTPUTF8: bool = False,
             decode_data: bool = False,
-            hostname: str = None,
-            ident: str = None,
+            hostname: Optional[str] = None,
+            ident: Optional[str] = None,
             tls_context: Optional[ssl.SSLContext] = None,
             require_starttls: bool = False,
             timeout: float = 300,
             auth_required: bool = False,
             auth_require_tls: bool = True,
             auth_exclude_mechanism: Optional[Iterable[str]] = None,
-            auth_callback: AuthCallbackType = None,
+            auth_callback: Optional[AuthCallbackType] = None,
             command_call_limit: Union[int, Dict[str, int], None] = None,
-            authenticator: AuthenticatorType = None,
+            authenticator: Optional[AuthenticatorType] = None,
             proxy_protocol_timeout: Optional[Union[int, float]] = None,
-            loop: asyncio.AbstractEventLoop = None
+            loop: Optional[asyncio.AbstractEventLoop] = None
     ):
         self.__ident__ = ident or __ident__
         self.loop = loop if loop else make_loop()
@@ -492,7 +492,7 @@ class SMTP(asyncio.StreamReaderProtocol):
         if closed.done() and not closed.cancelled():
             closed.exception()
 
-    def connection_made(self, transport: asyncio.transports.Transport) -> None:
+    def connection_made(self, transport: asyncio.transports.BaseTransport) -> None:
         # Reset state due to rfc3207 part 4.2.
         self._set_rset_state()
         self.session = self._create_session()
@@ -545,7 +545,7 @@ class SMTP(asyncio.StreamReaderProtocol):
             return False
         return super().eof_received()
 
-    def _reset_timeout(self, duration: float = None) -> None:
+    def _reset_timeout(self, duration: Optional[float] = None) -> None:
         if self._timeout_handle is not None:
             self._timeout_handle.cancel()
         self._timeout_handle = self.loop.call_later(
@@ -766,10 +766,16 @@ class SMTP(asyncio.StreamReaderProtocol):
                         status = '500 Error: Cannot describe error'
                 finally:
                     if isinstance(error, TLSSetupException):
-                        self.transport.close()
+                        # This code branch is inside None check for self.transport
+                        # so there shouldn't be a None self.transport but pytype
+                        # still complains, so silence that error.
+                        self.transport.close()  # pytype: disable=attribute-error
                         self.connection_lost(error)
                     else:
-                        await self.push(status)
+                        # The value of status is being set with ex-except and it
+                        # shouldn't be None, but pytype isn't able to infer that
+                        # so ignore the error related to wrong argument types.
+                        await self.push(status)  # pytype: disable=wrong-arg-types
 
     async def check_helo_needed(self, helo: str = "HELO") -> bool:
         """
@@ -816,10 +822,9 @@ class SMTP(asyncio.StreamReaderProtocol):
             await self.push('501 Syntax: EHLO hostname')
             return
 
-        response = []
+        response = ['250-' + self.hostname, ]
         self._set_rset_state()
         self.session.extended_smtp = True
-        response.append('250-' + self.hostname)
         if self.data_size_limit:
             response.append(f'250-SIZE {self.data_size_limit}')
             self.command_size_limits['MAIL'] += 26
@@ -1010,7 +1015,7 @@ class SMTP(asyncio.StreamReaderProtocol):
         challenge = b"334 " + (b64encode(challenge) if encode_to_b64 else challenge)
         log.debug("%r << challenge: %r", self.session.peer, challenge)
         await self.push(challenge)
-        line = await self._reader.readline()
+        line = await self._reader.readline()      # pytype: disable=attribute-error
         if log_client_response:
             warn("AUTH interaction logging is enabled!")
             warn("Sensitive information might be leaked!")
@@ -1097,7 +1102,7 @@ class SMTP(asyncio.StreamReaderProtocol):
             # login data is "{authz_id}\x00{login_id}\x00{password}"
             # authz_id can be null, and currently ignored
             # See https://tools.ietf.org/html/rfc4616#page-3
-            _, login, password = login_and_password.split(b"\x00")
+            _, login, password = login_and_password.split(b"\x00")  # pytype: disable=attribute-error  # noqa: E501
         except ValueError:  # not enough args
             await self.push("501 5.5.2 Can't split auth value")
             return AuthResult(success=False, handled=True)

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -336,7 +336,7 @@ class SMTP(asyncio.StreamReaderProtocol):
         self.loop = loop if loop else make_loop()
         super().__init__(
             asyncio.StreamReader(loop=self.loop, limit=self.line_length_limit),
-            client_connected_cb=self._client_connected_cb,
+            client_connected_cb=self._cb_client_connected,
             loop=self.loop)
         self.event_handler = handler
         assert data_size_limit is None or isinstance(data_size_limit, int)
@@ -560,7 +560,7 @@ class SMTP(asyncio.StreamReaderProtocol):
         # up state.
         self.transport.close()
 
-    def _client_connected_cb(
+    def _cb_client_connected(
             self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
     ):
         # This is redundant since we subclass StreamReaderProtocol, but I like

--- a/aiosmtpd/tests/conftest.py
+++ b/aiosmtpd/tests/conftest.py
@@ -71,7 +71,7 @@ class Global:
 
 # If less than 1.0, might cause intermittent error if test system
 # is too busy/overloaded.
-AUTOSTOP_DELAY = 1.0
+AUTOSTOP_DELAY = 1.5
 SERVER_CRT = resource_filename("aiosmtpd.tests.certs", "server.crt")
 SERVER_KEY = resource_filename("aiosmtpd.tests.certs", "server.key")
 

--- a/aiosmtpd/tests/test_handlers.py
+++ b/aiosmtpd/tests/test_handlers.py
@@ -55,7 +55,7 @@ class FakeParser:
     Emulates ArgumentParser.error() to catch the message
     """
 
-    message: AnyStr = None
+    message: Union[str, bytes, None] = None
 
     def error(self, message: AnyStr):
         self.message = message
@@ -63,7 +63,7 @@ class FakeParser:
 
 
 class DataHandler:
-    content: AnyStr = None
+    content: Union[str, bytes, None] = None
     original_content: bytes = None
 
     async def handle_DATA(
@@ -319,7 +319,7 @@ class TestDebugging:
                 From: Anne Person <anne@example.com>
                 To: Bart Person <bart@example.com>
                 Subject: A test
-    
+
                 Testing
                 """
             ),
@@ -352,7 +352,7 @@ class TestDebugging:
                 From: Anne Person <anne@example.com>
                 To: Bart Person <bart@example.com>
                 Subject: A test
-    
+
                 Testing
                 """
             ),
@@ -387,7 +387,7 @@ class TestDebugging:
                 From: Anne Person <anne@example.com>
                 To: Bart Person <bart@example.com>
                 Subject: A test
-    
+
                 Testing
                 """
             ),
@@ -418,7 +418,7 @@ class TestDebugging:
                 From: Anne Person <anne@example.com>
                 To: Bart Person <bart@example.com>
                 Subject: A test
-    
+
                 Testing
                 """
             ),
@@ -495,7 +495,7 @@ class TestMessage:
                 To: Bart Person <bart@example.com>
                 Subject: A test
                 Message-ID: <ant>
-    
+
                 Testing
                 """
             ),
@@ -519,7 +519,7 @@ class TestMessage:
                 To: Bart Person <bart@example.com>
                 Subject: A test
                 Message-ID: <ant>
-    
+
                 Testing
                 """
             ),
@@ -542,7 +542,7 @@ class TestMessage:
                 To: Bart Person <bart@example.com>
                 Subject: A test
                 Message-ID: <ant>
-    
+
                 Testing
                 """
             ),
@@ -571,7 +571,7 @@ class TestMessage:
                 To: Bart Person <bart@example.com>
                 Subject: A test
                 Message-ID: <ant>
-    
+
                 Testing
                 """
             ),
@@ -595,7 +595,7 @@ class TestMailbox:
                 To: Bart Person <bart@example.com>
                 Subject: A test
                 Message-ID: <ant>
-    
+
                 Hi Bart, this is Anne.
                 """
             ),
@@ -609,7 +609,7 @@ class TestMailbox:
                 To: Dave Person <dave@example.com>
                 Subject: A test
                 Message-ID: <bee>
-    
+
                 Hi Dave, this is Cate.
                 """
             ),
@@ -623,7 +623,7 @@ class TestMailbox:
                 To: Fred Person <fred@example.com>
                 Subject: A test
                 Message-ID: <cat>
-    
+
                 Hi Fred, this is Elle.
                 """
             ),
@@ -644,7 +644,7 @@ class TestMailbox:
                 To: Bart Person <bart@example.com>
                 Subject: A test
                 Message-ID: <ant>
-    
+
                 Hi Bart, this is Anne.
                 """
             ),
@@ -961,7 +961,7 @@ class TestHooks:
                 From: anne@example.com
                 To: bart@example.com
                 Subject: Test
-    
+
                 """
             )
         )
@@ -981,7 +981,7 @@ class TestDeprecation:
                     From: Anne Person <anne@example.com>
                     To: Bart Person <bart@example.com>
                     Subject: A test
-    
+
                     Testing
                     """
                 ),

--- a/aiosmtpd/tests/test_handlers.py
+++ b/aiosmtpd/tests/test_handlers.py
@@ -821,7 +821,7 @@ class TestProxyMocked:
             if rt == (
                 logger_name,
                 logging.INFO,
-                "we got some refusals: {'bart@example.com': (-1, 'ignore')}",
+                "we got some refusals: {'bart@example.com': (-1, b'ignore')}",
             ):
                 break
         else:

--- a/aiosmtpd/tests/test_handlers.py
+++ b/aiosmtpd/tests/test_handlers.py
@@ -816,8 +816,7 @@ class TestProxyMocked:
         logger_name = "mail.debug"
         caplog.set_level(logging.INFO, logger=logger_name)
         client.sendmail("anne@example.com", ["bart@example.com"], self.SOURCE)
-        _l1 = -1
-        for _l1, rt in enumerate(reversed(caplog.record_tuples)):
+        for rt in reversed(caplog.record_tuples):
             if rt == (
                 logger_name,
                 logging.INFO,

--- a/aiosmtpd/tests/test_misc.py
+++ b/aiosmtpd/tests/test_misc.py
@@ -1,0 +1,52 @@
+# Copyright 2014-2021 The aiosmtpd Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test other aspects of the server implementation."""
+
+import asyncio
+import warnings
+from typing import Generator, Optional
+
+import pytest
+
+from aiosmtpd import _get_or_new_eventloop
+
+
+@pytest.fixture(scope="module")
+def close_existing_loop() -> Generator[Optional[asyncio.AbstractEventLoop], None, None]:
+    loop: Optional[asyncio.AbstractEventLoop]
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error")
+        try:
+            loop = asyncio.get_event_loop()
+        except (DeprecationWarning, RuntimeError):
+            loop = None
+    if loop:
+        loop.stop()
+        loop.close()
+        asyncio.set_event_loop(None)
+        yield loop
+    else:
+        yield None
+
+
+class TestInit:
+
+    def test_create_new_if_none(self, close_existing_loop):
+        old_loop = close_existing_loop
+        loop: Optional[asyncio.AbstractEventLoop]
+        loop = _get_or_new_eventloop()
+        assert loop is not None
+        assert loop is not old_loop
+        assert isinstance(loop, asyncio.AbstractEventLoop)
+
+    def test_not_create_new_if_exist(self, close_existing_loop):
+        old_loop = close_existing_loop
+        loop: Optional[asyncio.AbstractEventLoop]
+        loop = asyncio.new_event_loop()
+        assert loop is not old_loop
+        asyncio.set_event_loop(loop)
+        ret_loop = _get_or_new_eventloop()
+        assert ret_loop is not old_loop
+        assert ret_loop == loop
+        assert ret_loop is loop

--- a/aiosmtpd/tests/test_proxyprotocol.py
+++ b/aiosmtpd/tests/test_proxyprotocol.py
@@ -903,7 +903,7 @@ class TestGetV2(_TestProxyProtocolCommon):
         fam: int = 0,
         proto: int = 0,
         payload: bytes = b"",
-        expect: str = None,
+        expect: Optional[str] = None,
     ) -> ProxyData:
         ver_cmd = (ver << 4) | cmd
         fam_pro = (fam << 4) | proto

--- a/aiosmtpd/tests/test_proxyprotocol.py
+++ b/aiosmtpd/tests/test_proxyprotocol.py
@@ -1112,7 +1112,6 @@ class TestHandlerAcceptReject:
         else:
             oper = operator.eq
             expect = pytest.raises(SMTPServerDisconnected)
-        oper = operator.ne if handler_retval else operator.eq
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
             sock.connect(Global.SrvAddr)
             sock.sendall(handshake)

--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -28,6 +28,7 @@ from aiosmtpd.controller import (
     UnixSocketUnthreadedController,
     _FakeServer,
     get_localhost,
+    _server_to_client_ssl_ctx,
 )
 from aiosmtpd.handlers import Sink
 from aiosmtpd.smtp import SMTP as Server
@@ -101,7 +102,10 @@ def safe_socket_dir() -> Generator[Path, None, None]:
 def assert_smtp_socket(controller: UnixSocketMixin) -> bool:
     assert Path(controller.unix_socket).exists()
     sockfile = controller.unix_socket
-    ssl_context = controller.ssl_context
+    if controller.ssl_context:
+        ssl_context = _server_to_client_ssl_ctx(controller.ssl_context)
+    else:
+        ssl_context = None
     with ExitStack() as stk:
         sock: socket.socket = stk.enter_context(
             socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)

--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -403,7 +403,7 @@ class TestUnthreaded:
             thread.start()
             catchup_delay()
 
-        def joiner(timeout: float = None):
+        def joiner(timeout: Optional[float] = None):
             nonlocal thread
             assert isinstance(thread, Thread)
             thread.join(timeout=timeout)

--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -403,7 +403,7 @@ class TestUnthreaded:
         def starter(loop: asyncio.AbstractEventLoop):
             nonlocal thread
             thread = Thread(target=_runner, args=(loop,))
-            thread.setDaemon(True)
+            thread.daemon = True
             thread.start()
             catchup_delay()
 

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -7,6 +7,7 @@ import asyncio
 import itertools
 import logging
 import socket
+import sys
 import time
 import warnings
 from asyncio.transports import Transport
@@ -1060,7 +1061,12 @@ class TestAuthMechanisms(_CommonMethods):
         client.user = "goodlogin"
         client.password = PW
         auth_meth = getattr(client, "auth_" + mechanism)
-        if (mechanism, init_resp) == ("login", False):
+        if (mechanism, init_resp) == ("login", False) and (
+                sys.version_info < (3, 8, 9)
+                or (3, 9, 0) < sys.version_info < (3, 9, 4)):
+            # The bug with SMTP.auth_login was fixed in Python 3.10 and backported
+            # to 3.9.4 and and 3.8.9.
+            # See https://github.com/python/cpython/pull/24118 for the fixes.:
             with pytest.raises(SMTPAuthenticationError):
                 client.auth(mechanism, auth_meth, initial_response_ok=init_resp)
             client.docmd("*")

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -20,7 +20,7 @@ from smtplib import (
     SMTPServerDisconnected,
 )
 from textwrap import dedent
-from typing import cast, Any, AnyStr, Callable, Generator, List, Tuple
+from typing import cast, Any, Callable, Generator, List, Tuple, Union
 
 import pytest
 from pytest_mock import MockFixture
@@ -98,10 +98,10 @@ class ErrorSMTP(Server):
 # noinspection TimingAttack
 class PeekerHandler:
     sess: SMTPSession = None
-    login: AnyStr = None
+    login: Union[str, bytes, None] = None
     login_data: Any = None
-    mechanism: AnyStr = None
-    password: AnyStr = None
+    mechanism: Union[str, bytes, None] = None
+    password: Union[str, bytes, None] = None
 
     # Please do not insert "_" after auth; that will 'fool' SMTP into thinking this is
     # an AUTH Mechanism, and we totally do NOT want that.
@@ -1495,7 +1495,7 @@ class TestSMTPWithController(_CommonMethods):
                     From: anne@example.com
                     To: bart@example.com
                     Subjebgct: A test
-                    
+
                     Testing
                 """
                 ),

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -53,6 +53,7 @@ CRLF = "\r\n"
 BCRLF = b"\r\n"
 MAIL_LOG = logging.getLogger("mail.log")
 MAIL_LOG.setLevel(logging.DEBUG)
+B64EQUALS = b64encode(b"=").decode()
 
 # fh = logging.FileHandler("~smtp.log")
 # fh.setFormatter(logging.Formatter("{asctime} - {levelname} - {message}", style="{"))
@@ -985,7 +986,7 @@ class TestSMTPAuth(_CommonMethods):
         resp = client.docmd("AUTH WITH_UNDERSCORE")
         assert resp == (334, b"challenge")
         with warnings.catch_warnings(record=True) as w:
-            assert client.docmd("=") == S.S235_AUTH_SUCCESS
+            assert client.docmd(B64EQUALS) == S.S235_AUTH_SUCCESS
         assert len(w) > 0
         assert str(w[0].message) == "AUTH interaction logging is enabled!"
         assert str(w[1].message) == "Sensitive information might be leaked!"
@@ -1099,7 +1100,7 @@ class TestAuthMechanisms(_CommonMethods):
         assert resp == S.S535_AUTH_INVALID
 
     def test_plain1_empty(self, do_auth_plain1):
-        resp = do_auth_plain1("=")
+        resp = do_auth_plain1(B64EQUALS)
         assert resp == S.S501_AUTH_CANTSPLIT
 
     def test_plain1_good_credentials(
@@ -1161,7 +1162,7 @@ class TestAuthMechanisms(_CommonMethods):
         assert resp == S.S535_AUTH_INVALID
 
     def test_plain2_no_credentials(self, client_auth_plain2):
-        resp = client_auth_plain2.docmd("=")
+        resp = client_auth_plain2.docmd(B64EQUALS)
         assert resp == S.S501_AUTH_CANTSPLIT
 
     def test_plain2_abort(self, client_auth_plain2):
@@ -1230,9 +1231,9 @@ class TestAuthMechanisms(_CommonMethods):
         assert resp == S.S535_AUTH_INVALID
 
     def test_login3_empty_credentials(self, do_auth_login3):
-        resp = do_auth_login3("=")
+        resp = do_auth_login3(B64EQUALS)
         assert resp == S.S334_AUTH_PASSWORD
-        resp = do_auth_login3("=")
+        resp = do_auth_login3(B64EQUALS)
         assert resp == S.S535_AUTH_INVALID
 
     def test_login3_abort_username(self, do_auth_login3):
@@ -1240,7 +1241,7 @@ class TestAuthMechanisms(_CommonMethods):
         assert resp == S.S501_AUTH_ABORTED
 
     def test_login3_abort_password(self, do_auth_login3):
-        resp = do_auth_login3("=")
+        resp = do_auth_login3(B64EQUALS)
         assert resp == S.S334_AUTH_PASSWORD
         resp = do_auth_login3("*")
         assert resp == S.S501_AUTH_ABORTED

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -1946,12 +1946,16 @@ class TestAuthArgs:
     def test_warn_authreqnotls(self, caplog):
         with pytest.warns(UserWarning) as record:
             _ = Server(Sink(), auth_required=True, auth_require_tls=False)
-        assert len(record) == 1
-        assert (
-            record[0].message.args[0]
-            == "Requiring AUTH while not requiring TLS can lead to "
-            "security vulnerabilities!"
-        )
+        for warning in record:
+            if warning.message.args and (
+                warning.message.args[0]
+                == "Requiring AUTH while not requiring TLS can lead to "
+                "security vulnerabilities!"
+            ):
+                break
+            else:
+                pytest.xfail("Did not raise expected warning")
+
         assert caplog.record_tuples[0] == (
             "mail.log",
             logging.WARNING,

--- a/aiosmtpd/tests/test_smtps.py
+++ b/aiosmtpd/tests/test_smtps.py
@@ -23,7 +23,11 @@ def ssl_controller(
     get_controller, ssl_context_server
 ) -> Generator[Controller, None, None]:
     handler = ReceivingHandler()
-    controller = get_controller(handler, hostname="127.0.0.1", ssl_context=ssl_context_server)
+    controller = get_controller(
+        handler,
+        hostname="127.0.0.1",
+        ssl_context=ssl_context_server
+    )
     controller.start()
     Global.set_addr_from(controller)
     #

--- a/aiosmtpd/tests/test_smtps.py
+++ b/aiosmtpd/tests/test_smtps.py
@@ -63,8 +63,8 @@ class TestSMTPS:
     def test_SSL_timeout(self, ssl_controller):
         assert ssl_controller.server._ssl_handshake_timeout == 1.0
         start = time.monotonic()
-        with pytest.raises(SMTPServerDisconnected) as ex,\
-             SMTP(*Global.SrvAddr) as smtp_client:
+        with pytest.raises(SMTPServerDisconnected) as ex, \
+             SMTP(*Global.SrvAddr) as smtp_client:  # noqa: N400
             # smtplib.SMTP does not support opporutnistic SSL so the SSL
             # handshake never completes. On Python 3.6 and earlier this meant
             # that the connection would just hang.

--- a/aiosmtpd/tests/test_starttls.py
+++ b/aiosmtpd/tests/test_starttls.py
@@ -18,7 +18,7 @@ from aiosmtpd.smtp import TLSSetupException
 from aiosmtpd.testing.helpers import ReceivingHandler, catchup_delay
 from aiosmtpd.testing.statuscodes import SMTP_STATUS_CODES as S
 
-from .conftest import Global, handler_data
+from .conftest import Global, controller_data, handler_data
 
 # region #### Harness Classes & Functions #############################################
 
@@ -177,6 +177,12 @@ class TestStartTLS:
         tls_controller.stop()
         with pytest.raises(SMTPServerDisconnected):
             client.quit()
+
+    @controller_data(ssl_handshake_timeout=10.0)
+    def test_set_tls_handshake_timeout(self, tls_controller, client):
+        client.ehlo("example.com")
+        resp = client.starttls()
+        assert resp == S.S220_READY_TLS
 
     def test_tls_bad_syntax(self, client):
         code, _ = client.ehlo("example.com")

--- a/examples/authenticated_relayer/server.py
+++ b/examples/authenticated_relayer/server.py
@@ -99,4 +99,4 @@ if __name__ == '__main__':
     try:
         loop.run_forever()
     except KeyboardInterrupt:
-        pass
+        print("User abort indicated")

--- a/examples/authenticated_relayer/server.py
+++ b/examples/authenticated_relayer/server.py
@@ -94,7 +94,8 @@ if __name__ == '__main__':
         print(f"Please create {DB_AUTH} first using make_user_db.py")
         sys.exit(1)
     logging.basicConfig(level=logging.DEBUG)
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
     loop.create_task(amain())
     try:
         loop.run_forever()

--- a/examples/basic/server.py
+++ b/examples/basic/server.py
@@ -20,4 +20,4 @@ if __name__ == '__main__':
     try:
         loop.run_forever()
     except KeyboardInterrupt:
-        pass
+        print("User abort indicated")

--- a/examples/basic/server.py
+++ b/examples/basic/server.py
@@ -15,7 +15,8 @@ async def amain(loop):
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
     loop.create_task(amain(loop=loop))
     try:
         loop.run_forever()

--- a/housekeep.py
+++ b/housekeep.py
@@ -21,12 +21,12 @@ try:
 except ImportError:
     colorama_init = None
 
-    class Fore:
+    class Fore:                # noqa: PIE795
         CYAN = "\x1b[1;96m"
         GREEN = "\x1b[1;92m"
         YELLOW = "\x1b[1;93m"
 
-    class Style:
+    class Style:               # noqa: PIE795
         BRIGHT = "\x1b[1m"
         RESET_ALL = "\x1b[0m"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,8 @@ source = [
 
 [tool.coverage.coverage_conditional_plugin.rules]
 # Here we specify our pragma rules:
+py-lt-312 = "sys_version_info < (3, 12)"
+py-lt-310 = "sys_version_info < (3, 10)"
 py-ge-38 = "sys_version_info >= (3, 8)"
 py-lt-38 = "sys_version_info < (3, 8)"
 py-gt-36 = "sys_version_info > (3, 6)"

--- a/release.py
+++ b/release.py
@@ -5,6 +5,7 @@
 
 import os
 import re
+import shlex
 import subprocess
 import sys
 import time
@@ -26,11 +27,11 @@ DISTFILES = [
 ]
 
 printfl("Updating release toolkit first...", end="")
-run_hidden([sys.executable] + "-m pip install -U setuptools wheel twine".split())
+run_hidden([sys.executable] + shlex.split("-m pip install -U setuptools wheel twine"))
 print()
 
 printfl("Checking extra toolkit...", end="")
-result = run_hidden([sys.executable] + "-m pip freeze".split())
+result = run_hidden([sys.executable] + shlex.split("-m pip freeze"))
 print()
 if b"\ntwine-verify-upload==" not in result.stdout:
     print("*** Package twine-verify-upload is not yet installed.")
@@ -77,7 +78,7 @@ if choice.casefold() in ("y", "yes"):
             run_hidden("tox")
         else:
             printfl("Running 'tox -e qa,docs', please wait...", end="")
-            run_hidden("tox -e qa,docs".split())
+            run_hidden(shlex.split("tox -e qa,docs"))
         print()
     except subprocess.CalledProcessError:
         print("ERROR: tox failed. Please run all tests")

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ classifiers =
     Operating System :: POSIX :: BSD :: FreeBSD
     Operating System :: POSIX :: Linux
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -34,7 +33,7 @@ classifiers =
 
 [options]
 zip_safe = false
-python_requires = ~=3.6
+python_requires = ~=3.7
 packages = find:
 include_package_data = true
 install_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Communications :: Email :: Mail Transport Agents

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Communications :: Email :: Mail Transport Agents

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,12 +36,15 @@ zip_safe = false
 python_requires = ~=3.7
 packages = find:
 include_package_data = true
+setup_requires =
+    setuptools
 install_requires =
     atpublic
     attrs
     typing-extensions ; python_version < '3.8'
 tests_require =
     tox
+    setuptools
 
 [options.packages.find]
 exclude =

--- a/setup.cfg
+++ b/setup.cfg
@@ -97,6 +97,18 @@ ignore =
     ANN003
     # We have too many "if..elif..else: raise" structures that does not convert well to "error-first" design
     SIM106
+    # We have too many 'Any' type annotations.
+    ANN401
+    # Classes for some reason aren't always just replaceable by modules.
+    PIE798
+    # It is cleaner sometimes to assign and return, especially when using 'await' expressions.
+    PIE781
+    # Use f'strings instead of % formatters, the performance impact isn't too bad and f'strings are awesome!
+    PIE803
+    # It is more readable to instantiate and add items on-by-one instead of all at once.
+    PIE799
+    # Explicit is better than implicit, range(0, val) is more explicit than range(val).
+    PIE808
 per-file-ignores =
     aiosmtpd/tests/test_*:ANN001
     aiosmtpd/tests/test_proxyprotocol.py:DUO102

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ envdir =
     py38: {toxworkdir}/3.8
     py39: {toxworkdir}/3.9
     py310: {toxworkdir}/3.10
+    py311: {toxworkdir}/3.11
     pypy3: {toxworkdir}/pypy3
     py: {toxworkdir}/py
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -64,41 +64,41 @@ passenv =
 # setup.cfg) to activate the respective plugins. If no snippet is given, that means the plugin is
 # always active.
 deps =
-    flake8-bugbear
-    flake8-builtins
-    flake8-coding
+    flake8-bugbear>=22.12.6
+    flake8-builtins>=2.0.1
+    flake8-coding>=1.3.2
     # C4
-    flake8-comprehensions
+    flake8-comprehensions>=3.10.1
     # JS
-    flake8-multiline-containers
+    flake8-multiline-containers>=0.0.19
     # PIE
-    flake8-pie
+    flake8-pie>=0.16.0
     # MOD
-    flake8-printf-formatting
+    flake8-printf-formatting>=1.1.2
     # PT
-    flake8-pytest-style
+    flake8-pytest-style>=1.6.0
     # SIM
-    flake8-simplify
+    flake8-simplify>=0.19.3
     # Cognitive Complexity looks like a good idea, but to fix the complaints... it will be an epic effort.
     # So we disable it for now and reenable when we're ready, probably just before 2.0
     # # CCR
     # flake8-cognitive-complexity
     # ECE
-    flake8-expression-complexity
+    flake8-expression-complexity>=0.0.11
     # C801
-    flake8-copyright
+    flake8-copyright>=0.2.3
     # DUO
-    dlint
+    dlint>=0.13.0
     # TAE
-    flake8-annotations-complexity
+    flake8-annotations-complexity>=0.0.7
     # TAE
-    flake8-annotations-coverage
+    flake8-annotations-coverage>=0.0.6
     # ANN
-    flake8-annotations
+    flake8-annotations>=2.9.1
     # YTT
-    flake8-2020
+    flake8-2020>=1.7.0
     # N400
-    flake8-broken-line
+    flake8-broken-line>=0.6.0
 
 [testenv:qa]
 basepython = python3
@@ -113,7 +113,7 @@ commands =
     pytype --keep-going --jobs auto .
 deps =
     colorama
-    flake8
+    flake8>=5.0.4
     {[flake8_plugins]deps}
     pytest
     check-manifest

--- a/tox.ini
+++ b/tox.ini
@@ -4,15 +4,7 @@ envlist = qa, static, docs, py{37,38,39,310,311,py3}-{nocov,cov,diffcov}
 skip_missing_interpreters = True
 
 [testenv]
-# One virtualenv per Python version
-envdir =
-    py37: {toxworkdir}/3.7
-    py38: {toxworkdir}/3.8
-    py39: {toxworkdir}/3.9
-    py310: {toxworkdir}/3.10
-    py311: {toxworkdir}/3.11
-    pypy3: {toxworkdir}/pypy3
-    py: {toxworkdir}/py
+envdir = {toxworkdir}/{envname}
 commands =
     python housekeep.py prep
     # Bandit is not needed on diffcov, and seems to be incompatible with 310
@@ -27,20 +19,20 @@ commands =
 #sitepackages = True
 usedevelop = True
 deps =
-    # do NOT make these conditional, that way we can reuse same envdir for nocov+cov+diffcov
     bandit
     colorama
-    coverage[toml]
-    coverage-conditional-plugin
     packaging
     pytest >= 6.0  # Require >= 6.0 for pyproject.toml support (PEP 517)
-    pytest-cov
     pytest-mock
     pytest-print
     pytest-profiling
     pytest-sugar
     py # needed for pytest-sugar as it doesn't declare dependency on it.
-    diff_cover
+    !nocov: coverage>=7.0.1
+    !nocov: coverage[toml]
+    !nocov: coverage-conditional-plugin
+    !nocov: pytest-cov
+    diffcov: diff_cover
 setenv =
     cov: COVERAGE_FILE={toxinidir}/_dump/.coverage
     nocov: PYTHONASYNCIODEBUG=1
@@ -50,6 +42,8 @@ setenv =
     py310: INTERP=py310
     py311: INTERP=py311
     pypy3: INTERP=pypy3
+    pypy37: INTERP=pypy37
+    pypy38: INTERP=pypy38
     py: INTERP=py
 passenv =
     PYTHON*

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,7 @@ deps =
     pytest-print
     pytest-profiling
     pytest-sugar
+    py # needed for pytest-sugar as it doesn't declare dependency on it.
     diff_cover
 setenv =
     cov: COVERAGE_FILE={toxinidir}/_dump/.coverage

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
 minversion = 3.9.0
-envlist = qa, static, docs, py{36,37,38,39,py3}-{nocov,cov,diffcov}
+envlist = qa, static, docs, py{37,38,39,py3}-{nocov,cov,diffcov}
 skip_missing_interpreters = True
 
 [testenv]
 # One virtualenv per Python version
 envdir =
-    py36: {toxworkdir}/3.6
     py37: {toxworkdir}/3.7
     py38: {toxworkdir}/3.8
     py39: {toxworkdir}/3.9
@@ -45,11 +44,11 @@ deps =
 setenv =
     cov: COVERAGE_FILE={toxinidir}/_dump/.coverage
     nocov: PYTHONASYNCIODEBUG=1
-    py36: INTERP=py36
     py37: INTERP=py37
     py38: INTERP=py38
     py39: INTERP=py39
     py310: INTERP=py310
+    py311: INTERP=py311
     pypy3: INTERP=pypy3
     py: INTERP=py
 passenv =
@@ -110,14 +109,16 @@ commands =
     python -m flake8 aiosmtpd setup.py housekeep.py release.py
     check-manifest -v
     pytest -v --tb=short aiosmtpd/qa
-    pytype --keep-going --jobs auto .
+    # Disabled for now because pytype blows up in Windows
+    #pytype --keep-going --jobs auto .
 deps =
     colorama
     flake8>=5.0.4
     {[flake8_plugins]deps}
     pytest
     check-manifest
-    pytype
+    # Disabled for now because pytype blows up in Windows
+    #pytype
 
 [testenv:docs]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.9.0
-envlist = qa, static, docs, py{37,38,39,py3}-{nocov,cov,diffcov}
+envlist = qa, static, docs, py{37,38,39,310,311,py3}-{nocov,cov,diffcov}
 skip_missing_interpreters = True
 
 [testenv]
@@ -62,6 +62,8 @@ passenv =
 # Snippets of letters above these plugins are tests that need to be "select"-ed in flake8 config (in
 # setup.cfg) to activate the respective plugins. If no snippet is given, that means the plugin is
 # always active.
+# IMPORTANT: It's a good idea to restrict the version numbers of the plugins. Without version limits, GHCI's pip
+# sometimes simply gives up trying to figure the right deps, causing the test to fail.
 deps =
     flake8-bugbear>=22.12.6
     flake8-builtins>=2.0.1

--- a/tox.ini
+++ b/tox.ini
@@ -109,12 +109,14 @@ commands =
     python -m flake8 aiosmtpd setup.py housekeep.py release.py
     check-manifest -v
     pytest -v --tb=short aiosmtpd/qa
+    pytype --keep-going --jobs auto .
 deps =
     colorama
     flake8
     {[flake8_plugins]deps}
     pytest
     check-manifest
+    pytype
 
 [testenv:docs]
 basepython = python3


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This implements a custom `ssl_handshake_timeout` parameter on Controllers that is then passed to the `loop.create_server()` and used in the `smtp_STARTTLS` methods to modify the amount of time that the server will wait for the SSL handshake to complete.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

Closes #269 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [ ] Linux (Ubuntu 18.04, Ubuntu 20.04, Arch): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, qa, docs`
  - [ ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- [x] Documentation reflects the changes
- [x] Add a news fragment into the `NEWS.rst` file
  <!-- Delete the following bullet points prior to submitting the PR -->
  * Add under the "aiosmtpd-next" section, creating one if necessary
    * You may create subsections to group the changes, if you like
  * Use full sentences with correct case and punctuation
  * Refer to relevant Issue if applicable
