### PR TITLE
fixed right order for EHLO handler

### DIFF
--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -854,8 +854,8 @@ class SMTP(asyncio.StreamReaderProtocol):
             # New behavior: hand over list of responses so far to the hook, and
             # REPLACE existing list of responses with what the hook returns.
             # We will handle the push()ing
-            response.append('250 HELP')
             response = await self._call_handler_hook("EHLO", hostname, response)
+            response.append('250 HELP')
 
         for r in response:
             await self.push(r)


### PR DESCRIPTION
## What do these changes do?

Fix in EHLO handler, where the `250 HELP` response line, means without dash should be the last one.
My tetsing postix server do not accept nre EHLO extensions after `250 HELP`

## Are there changes in behavior for the user?

There is no change for user, just fix according the RFC https://datatracker.ietf.org/doc/html/rfc5321#section-4.1.1.1

## Related issue number

None

## Checklist

- [x ] I think the code is well written
