### PR TITLE
Avoid SSLError: Cannot create a client socket with a PROTOCOL_TLS_SERVER context

### DIFF
--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -424,7 +424,7 @@ class InetMixin(BaseController, metaclass=ABCMeta):
         hostname = self.hostname or self._localhost
         with ExitStack() as stk:
             s = stk.enter_context(create_connection((hostname, self.port), 1.0))
-            if self.ssl_context:
+            if self.ssl_context and self.ssl_context.protocol != ssl.PROTOCOL_TLS_SERVER:
                 s = stk.enter_context(self.ssl_context.wrap_socket(s))
             s.recv(1024)
 


### PR DESCRIPTION
When we build mailman3 in Fedora with Python 3.10.0rc2,
we see the following problem:

    Traceback (most recent call last):
      File "/builddir/build/BUILD/mailman-3.3.4/src/mailman/testing/layers.py", line 297, in setUp
        cls.smtpd.start()
      File "/builddir/build/BUILD/mailman-3.3.4/src/mailman/testing/mta.py", line 177, in start
        super().start()
      File "/usr/lib/python3.10/site-packages/aiosmtpd/controller.py", line 288, in start
        self._trigger_server()
      File "/usr/lib/python3.10/site-packages/aiosmtpd/controller.py", line 481, in _trigger_server
        InetMixin._trigger_server(self)
      File "/usr/lib/python3.10/site-packages/aiosmtpd/controller.py", line 428, in _trigger_server
        s = stk.enter_context(self.ssl_context.wrap_socket(s))
      File "/usr/lib64/python3.10/ssl.py", line 512, in wrap_socket
        return self.sslsocket_class._create(
      File "/usr/lib64/python3.10/ssl.py", line 1061, in _create
        self._sslobj = self._context._wrap_socket(
    ssl.SSLError: Cannot create a client socket with a PROTOCOL_TLS_SERVER context (_ssl.c:801)

This makes the problem go away.

Disclaimer: I have no idea what I'm doing here.

<!-- Thank you for your contribution! -->

## What do these changes do?

They check if the context we are about to wrap to is not server context.

## Are there changes in behavior for the user?

I hope not.

## Related issue number

Related to https://github.com/aio-libs/aiosmtpd/issues/277

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist (the original tests suite)
- [ ] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [ ] Linux (Ubuntu 18.04, Ubuntu 20.04, Arch): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, qa, docs`
  - [ ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- [ ] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file
  <!-- Delete the following bullet points prior to submitting the PR -->
  * Add under the "aiosmtpd-next" section, creating one if necessary
    * You may create subsections to group the changes, if you like
  * Use full sentences with correct case and punctuation
  * Refer to relevant Issue if applicable
 
I am sorry but I won't be able to finish this checklist. Maybe my change is good, maybe not, but it helped me in mailman3 in Fedora.
