### PR TITLE
Add SMTP constructor keyword 'stream_reader_class', default asyncio.S…

### DIFF
--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -337,7 +337,7 @@ class SMTP(asyncio.StreamReaderProtocol):
         self.loop = loop if loop else make_loop()
         self.stream_reader_class = stream_reader_class
         super().__init__(
-            stream_reader_class(loop=self.loop, limit=self.line_length_limit),
+            self.stream_reader_class(loop=self.loop, limit=self.line_length_limit),
             client_connected_cb=self._client_connected_cb,
             loop=self.loop)
         self.event_handler = handler


### PR DESCRIPTION
…treamReader, allowing user subclass

<!-- Thank you for your contribution! -->

## What do these changes do?
Allows a caller to specify their own subclass of asyncio.StreamReader

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
This will not affect behaviour for users who do not provide a 'stream_reader_class' SMTP constructor keyword.
But for callers who do provide their own subclass, this gives the
ability to override methods of asyncio.StreamReader, such as .readuntil()

<!-- Outline any notable behaviour for the end users. -->

## Related issue number
#285 

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #285 
<!-- Use the "closing keywords" such as "Closes" or "Fixes" to automatically link to Issues. -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [ ] Linux (Ubuntu 18.04, Ubuntu 20.04, Arch): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, qa, docs`
  - [ ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- [ ] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file
  <!-- Delete the following bullet points prior to submitting the PR -->
  * Add under the "aiosmtpd-next" section, creating one if necessary
    * You may create subsections to group the changes, if you like
  * Use full sentences with correct case and punctuation
  * Refer to relevant Issue if applicable
