### PR TITLE
Fix SMTPS / implicit TLS

### DIFF
--- a/aiosmtpd/main.py
+++ b/aiosmtpd/main.py
@@ -241,6 +241,13 @@ def main(args: Optional[Sequence[str]] = None) -> None:
     else:
         tls_context = None
 
+    if args.smtpscert and args.smtpskey:
+        smtps_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+        smtps_context.check_hostname = False
+        smtps_context.load_cert_chain(str(args.smtpscert), str(args.smtpskey))
+    else:
+        smtps_context = None
+
     factory = partial(
         SMTP,
         args.handler,
@@ -248,6 +255,7 @@ def main(args: Optional[Sequence[str]] = None) -> None:
         enable_SMTPUTF8=args.smtputf8,
         tls_context=tls_context,
         require_starttls=args.requiretls,
+        is_using_smtps=smtps_context is not None,
     )
 
     logging.basicConfig(level=logging.ERROR)
@@ -260,13 +268,6 @@ def main(args: Optional[Sequence[str]] = None) -> None:
         log.setLevel(logging.DEBUG)
     if args.debug > 2:
         loop.set_debug(enabled=True)
-
-    if args.smtpscert and args.smtpskey:
-        smtps_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
-        smtps_context.check_hostname = False
-        smtps_context.load_cert_chain(str(args.smtpscert), str(args.smtpskey))
-    else:
-        smtps_context = None
 
     log.debug("Attempting to start server on %s:%s", args.host, args.port)
     server = server_loop = None


### PR DESCRIPTION
## What do these changes do?

Allow for implicit TLS usage (based solely on provided context data as, like @pepoluan mentioned in #281, it is not quite feasible to detect any wrapping (nor should it be done).

## Are there changes in behavior for the user?

Should not be any, as the only change affects a feature that did not quite work, like, ever.

## Related issue number

Fixes #274 and most likely also closes #281.

## Checklist

- [✓] I think the code is well written
- [  ] Unit tests for the changes exist
- [  ] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [  ] Linux (Ubuntu 18.04, Ubuntu 20.04, Arch): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, qa, docs`
  - [  ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [  ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [  ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [  ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- [✓] Documentation reflects the changes
- [✓] Add a news fragment into the `NEWS.rst` file
  <!-- Delete the following bullet points prior to submitting the PR -->
  * I cannot find "NEWS.rst" in this repository
