### PR TITLE
fix: Fix the testcase that isn't applicable to all python version.

### DIFF
--- a/.github/workflows/unit-testing-and-coverage.yml
+++ b/.github/workflows/unit-testing-and-coverage.yml
@@ -83,7 +83,6 @@ jobs:
           pytest -v aiosmtpd/qa
           check-manifest -v
   testing:
-    needs: qa_docs
     strategy:
       # If a matrix fail, do NOT stop other matrix, let them run to completion
       fail-fast: false

--- a/.github/workflows/unit-testing-and-coverage.yml
+++ b/.github/workflows/unit-testing-and-coverage.yml
@@ -88,7 +88,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "macos-10.15", "ubuntu-18.04", "ubuntu-20.04", "windows-latest" ]
-        python-version: [ "3.6", "3.7", "3.8", "3.9", "pypy3" ]
+        python-version: [ "3.6", "3.7", "3.8", "3.9", "pypy3.7" ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15  # Slowest so far is pypy3 on MacOS, taking almost 7m
     steps:

--- a/.github/workflows/unit-testing-and-coverage.yml
+++ b/.github/workflows/unit-testing-and-coverage.yml
@@ -88,7 +88,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "macos-10.15", "ubuntu-18.04", "ubuntu-20.04", "windows-latest" ]
-        python-version: [ "3.6", "3.7", "3.8", "3.9", "pypy3.7" ]
+        python-version: [ "3.6", "3.7", "3.8", "3.9", "pypy3.6" ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15  # Slowest so far is pypy3 on MacOS, taking almost 7m
     steps:

--- a/.github/workflows/unit-testing-and-coverage.yml
+++ b/.github/workflows/unit-testing-and-coverage.yml
@@ -83,6 +83,7 @@ jobs:
           pytest -v aiosmtpd/qa
           check-manifest -v
   testing:
+    needs: qa_docs
     strategy:
       # If a matrix fail, do NOT stop other matrix, let them run to completion
       fail-fast: false

--- a/.github/workflows/unit-testing-and-coverage.yml
+++ b/.github/workflows/unit-testing-and-coverage.yml
@@ -98,7 +98,7 @@ jobs:
       with:
         fetch-depth: 0  # Required by codecov/codecov-action@v1
     - name: "Set up Python ${{ matrix.python-version }}"
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: "Install dependencies"

--- a/aiosmtpd/tests/test_handlers.py
+++ b/aiosmtpd/tests/test_handlers.py
@@ -821,7 +821,7 @@ class TestProxyMocked:
             if rt == (
                 logger_name,
                 logging.INFO,
-                "we got some refusals: {'bart@example.com': (-1, 'ignore')}",
+                "we got some refusals: {'bart@example.com': (-1, b'ignore')}",
             ):
                 break
         else:

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -7,6 +7,7 @@ import asyncio
 import itertools
 import logging
 import socket
+import sys
 import time
 import warnings
 from asyncio.transports import Transport
@@ -1060,7 +1061,12 @@ class TestAuthMechanisms(_CommonMethods):
         client.user = "goodlogin"
         client.password = PW
         auth_meth = getattr(client, "auth_" + mechanism)
-        if (mechanism, init_resp) == ("login", False):
+        if (mechanism, init_resp) == ("login", False) and (
+                sys.version_info < (3, 8, 9) or
+                ((3, 9, 0) < sys.version_info < (3, 9, 4))):
+            # The bug with SMTP.auth_login was fixed in Python 3.10 and backported
+            # to 3.9.4 and and 3.8.9.
+            # See https://github.com/python/cpython/pull/24118 for the fixes.:
             with pytest.raises(SMTPAuthenticationError):
                 client.auth(mechanism, auth_meth, initial_response_ok=init_resp)
             client.docmd("*")

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -1062,8 +1062,8 @@ class TestAuthMechanisms(_CommonMethods):
         client.password = PW
         auth_meth = getattr(client, "auth_" + mechanism)
         if (mechanism, init_resp) == ("login", False) and (
-                sys.version_info < (3, 8, 9) or
-                ((3, 9, 0) < sys.version_info < (3, 9, 4))):
+                sys.version_info < (3, 8, 9)
+                or (3, 9, 0) < sys.version_info < (3, 9, 4)):
             # The bug with SMTP.auth_login was fixed in Python 3.10 and backported
             # to 3.9.4 and and 3.8.9.
             # See https://github.com/python/cpython/pull/24118 for the fixes.:

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,7 @@ deps =
     pytest-print
     pytest-profiling
     pytest-sugar
+    py # needed for pytest-sugar as it doesn't declare dependency on it.
     diff_cover
 setenv =
     cov: COVERAGE_FILE={toxinidir}/_dump/.coverage


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
* One of the test cases are testing a bug in Python stdlib that was
  fixed in 3.10 and backported to 3.9 and 3.8. This updates the
  version check to make it pass on all supported versions.
* Bump dependency on actions/setup-python@v4
* Add dependency on 'py' to fix the non-declared dependency in
  pytest-sugar.
* Temporarily break the dependency between unit tests and QA tests
  so we can make progress on fixing the unit tests and QA in parallel.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No.
<!-- Outline any notable behaviour for the end users. -->

## Related issue number
Partially related to #277 

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Use the "closing keywords" such as "Closes" or "Fixes" to automatically link to Issues. -->

## Checklist

- [ ] I think the code is well written
- [x] Unit tests for the changes exist
- [x] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [ ] Linux (Ubuntu 18.04, Ubuntu 20.04, Arch): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, qa, docs`
  - [ ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- [ ] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file
  <!-- Delete the following bullet points prior to submitting the PR -->
  * Add under the "aiosmtpd-next" section, creating one if necessary
    * You may create subsections to group the changes, if you like
  * Use full sentences with correct case and punctuation
  * Refer to relevant Issue if applicable
