### PR TITLE
tests: Run pytype as a part of tox qa testenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -108,12 +108,14 @@ commands =
     python -m flake8 aiosmtpd setup.py housekeep.py release.py
     check-manifest -v
     pytest -v --tb=short aiosmtpd/qa
+    pytype --keep-going --jobs auto .
 deps =
     colorama
     flake8
     {[flake8_plugins]deps}
     pytest
     check-manifest
+    pytype
 
 [testenv:docs]
 basepython = python3


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Run type checking during the tox qa env so that we can test
locally for any typing related errors instead of manually
installing and running pytype.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

Developers will now also see typing related failures when
running qa tox env locally.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

Fixes #310 
<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Use the "closing keywords" such as "Closes" or "Fixes" to automatically link to Issues. -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [ ] Linux (Ubuntu 18.04, Ubuntu 20.04, Arch): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, qa, docs`
  - [ ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- [ ] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file
  <!-- Delete the following bullet points prior to submitting the PR -->
  * Add under the "aiosmtpd-next" section, creating one if necessary
    * You may create subsections to group the changes, if you like
  * Use full sentences with correct case and punctuation
  * Refer to relevant Issue if applicable
