### PR TITLE
feat: Add support for Python 3.11

### DIFF
--- a/.github/workflows/unit-testing-and-coverage.yml
+++ b/.github/workflows/unit-testing-and-coverage.yml
@@ -89,7 +89,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "macos-10.15", "ubuntu-18.04", "ubuntu-20.04", "windows-latest" ]
-        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10", "pypy3.6" ]
+        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.6" ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15  # Slowest so far is pypy3 on MacOS, taking almost 7m
     steps:

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -907,7 +907,7 @@ class SMTP(asyncio.StreamReaderProtocol):
         self._original_transport.set_protocol(self._tls_protocol)
         # Reconfigure the protocol layer.  Why is the app transport a protected
         # property, if it MUST be used externally?
-        self.transport = self._tls_protocol._get_app_transport()   # pytype: disable=attribute-error # noqa: E501
+        self.transport = self._tls_protocol._app_transport
         self._tls_protocol.connection_made(self._original_transport)
         # wait until handshake complete
         try:

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -904,7 +904,7 @@ class SMTP(asyncio.StreamReaderProtocol):
         # transport so that we can close it explicitly when the connection is
         # lost.
         self._original_transport = self.transport
-        self.transport.set_protocol(self._tls_protocol)
+        self._original_transport.set_protocol(self._tls_protocol)
         # Reconfigure the protocol layer.  Why is the app transport a protected
         # property, if it MUST be used externally?
         self.transport = self._tls_protocol._get_app_transport()

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -907,7 +907,7 @@ class SMTP(asyncio.StreamReaderProtocol):
         self._original_transport.set_protocol(self._tls_protocol)
         # Reconfigure the protocol layer.  Why is the app transport a protected
         # property, if it MUST be used externally?
-        self.transport = self._tls_protocol._get_app_transport()
+        self.transport = self._tls_protocol._get_app_transport()   # pytype: disable=attribute-error # noqa: E501
         self._tls_protocol.connection_made(self._original_transport)
         # wait until handshake complete
         try:

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -529,8 +529,8 @@ class SMTP(asyncio.StreamReaderProtocol):
         # otherwise an unexpected eof_received() will be called *after* the
         # connection_lost().  At that point the stream reader will already be
         # destroyed and we'll get a traceback in super().eof_received() below.
-        if self._original_transport is not None:
-            self._original_transport.close()
+        # if self._original_transport is not None:
+        #     self._original_transport.close()
         super().connection_lost(error)
         self._handler_coroutine.cancel()
         self.transport = None
@@ -899,15 +899,17 @@ class SMTP(asyncio.StreamReaderProtocol):
             self.tls_context,
             waiter,
             server_side=True)
+
         # Reconfigure transport layer.  Keep a reference to the original
         # transport so that we can close it explicitly when the connection is
         # lost.  XXX BaseTransport.set_protocol() was added in Python 3.5.3 :(
         self._original_transport = self.transport
-        self._original_transport._protocol = self._tls_protocol
+        self.transport.set_protocol(self._tls_protocol)
+        # self._original_transport._protocol = self._tls_protocol
         # Reconfigure the protocol layer.  Why is the app transport a protected
         # property, if it MUST be used externally?
-        self.transport = self._tls_protocol._app_transport
-        self._tls_protocol.connection_made(self._original_transport)
+        # self.transport = self._tls_protocol._get_app_transport()
+        self._tls_protocol.connection_made(self.transport)
         # wait until handshake complete
         try:
             await waiter

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -53,6 +53,7 @@ CRLF = "\r\n"
 BCRLF = b"\r\n"
 MAIL_LOG = logging.getLogger("mail.log")
 MAIL_LOG.setLevel(logging.DEBUG)
+B64EQUALS = b64encode(b"=").decode()
 
 # fh = logging.FileHandler("~smtp.log")
 # fh.setFormatter(logging.Formatter("{asctime} - {levelname} - {message}", style="{"))
@@ -985,7 +986,7 @@ class TestSMTPAuth(_CommonMethods):
         resp = client.docmd("AUTH WITH_UNDERSCORE")
         assert resp == (334, b"challenge")
         with warnings.catch_warnings(record=True) as w:
-            assert client.docmd("=") == S.S235_AUTH_SUCCESS
+            assert client.docmd(B64EQUALS) == S.S235_AUTH_SUCCESS
         assert len(w) > 0
         assert str(w[0].message) == "AUTH interaction logging is enabled!"
         assert str(w[1].message) == "Sensitive information might be leaked!"
@@ -1099,7 +1100,7 @@ class TestAuthMechanisms(_CommonMethods):
         assert resp == S.S535_AUTH_INVALID
 
     def test_plain1_empty(self, do_auth_plain1):
-        resp = do_auth_plain1("=")
+        resp = do_auth_plain1(B64EQUALS)
         assert resp == S.S501_AUTH_CANTSPLIT
 
     def test_plain1_good_credentials(
@@ -1161,7 +1162,7 @@ class TestAuthMechanisms(_CommonMethods):
         assert resp == S.S535_AUTH_INVALID
 
     def test_plain2_no_credentials(self, client_auth_plain2):
-        resp = client_auth_plain2.docmd("=")
+        resp = client_auth_plain2.docmd(B64EQUALS)
         assert resp == S.S501_AUTH_CANTSPLIT
 
     def test_plain2_abort(self, client_auth_plain2):
@@ -1230,9 +1231,9 @@ class TestAuthMechanisms(_CommonMethods):
         assert resp == S.S535_AUTH_INVALID
 
     def test_login3_empty_credentials(self, do_auth_login3):
-        resp = do_auth_login3("=")
+        resp = do_auth_login3(B64EQUALS)
         assert resp == S.S334_AUTH_PASSWORD
-        resp = do_auth_login3("=")
+        resp = do_auth_login3(B64EQUALS)
         assert resp == S.S535_AUTH_INVALID
 
     def test_login3_abort_username(self, do_auth_login3):
@@ -1240,7 +1241,7 @@ class TestAuthMechanisms(_CommonMethods):
         assert resp == S.S501_AUTH_ABORTED
 
     def test_login3_abort_password(self, do_auth_login3):
-        resp = do_auth_login3("=")
+        resp = do_auth_login3(B64EQUALS)
         assert resp == S.S334_AUTH_PASSWORD
         resp = do_auth_login3("*")
         assert resp == S.S501_AUTH_ABORTED

--- a/aiosmtpd/tests/test_starttls.py
+++ b/aiosmtpd/tests/test_starttls.py
@@ -347,8 +347,8 @@ class TestRequireTLSAUTH:
         resp = client.docmd("AUTH ")
         assert resp == S.S538_AUTH_ENCRYPTREQ
 
-    def test_auth_tls(self, client, ssl_context_client):
-        resp = client.starttls(context=ssl_context_client)
+    def test_auth_tls(self, client):
+        resp = client.starttls()
         assert resp == S.S220_READY_TLS
         code, _ = client.ehlo("example.com")
         assert code == 250

--- a/aiosmtpd/tests/test_starttls.py
+++ b/aiosmtpd/tests/test_starttls.py
@@ -347,8 +347,8 @@ class TestRequireTLSAUTH:
         resp = client.docmd("AUTH ")
         assert resp == S.S538_AUTH_ENCRYPTREQ
 
-    def test_auth_tls(self, client):
-        resp = client.starttls()
+    def test_auth_tls(self, client, ssl_context_client):
+        resp = client.starttls(context=ssl_context_client)
         assert resp == S.S220_READY_TLS
         code, _ = client.ehlo("example.com")
         assert code == 250

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Communications :: Email :: Mail Transport Agents

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ envdir =
     py38: {toxworkdir}/3.8
     py39: {toxworkdir}/3.9
     py310: {toxworkdir}/3.10
+    py311: {toxworkdir}/3.11
     pypy3: {toxworkdir}/pypy3
     py: {toxworkdir}/py
 commands =


### PR DESCRIPTION
Changes:

- ci: Enable 3.11 in CI
- use b64 encoded "=" commands otherwise we get decoding errors. 
- fixes to use set_protocol() instead of setting an internal property
  as we no longer support 3.5.

<!-- Thank you for your contribution! -->

## What do these changes do?

Add support for Python 3.11

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

No.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Use the "closing keywords" such as "Closes" or "Fixes" to automatically link to Issues. -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [x] Linux (Ubuntu 18.04, Ubuntu 20.04, Arch): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, qa, docs`
  - [x] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- [ ] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file
  <!-- Delete the following bullet points prior to submitting the PR -->
  * Add under the "aiosmtpd-next" section, creating one if necessary
    * You may create subsections to group the changes, if you like
  * Use full sentences with correct case and punctuation
  * Refer to relevant Issue if applicable
