### PR TITLE
Enhance GitHUB CI Workflow

### DIFF
--- a/.github/workflows/unit-testing-and-coverage.yml
+++ b/.github/workflows/unit-testing-and-coverage.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           # 3.8 is chosen because it seems to be the fastest for <3.9
           # (3.9 excluded because it seems to be still very unstable)
-          python-version: 3.11
+          python-version: 3.8
       - name: "Update modules & install deps"
         # language=bash
         run: |

--- a/.github/workflows/unit-testing-and-coverage.yml
+++ b/.github/workflows/unit-testing-and-coverage.yml
@@ -135,4 +135,4 @@ jobs:
       # 18.04 happily, so we choose this as the 'canonical' code coverage testing.
       # One day we'll have to revisit this and bump the version ...
       if: matrix.python-version == '3.8' && matrix.os == 'ubuntu-20.04'
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3.1.1

--- a/.github/workflows/unit-testing-and-coverage.yml
+++ b/.github/workflows/unit-testing-and-coverage.yml
@@ -88,7 +88,7 @@ jobs:
       # If a matrix fail, do NOT stop other matrix, let them run to completion
       fail-fast: false
       matrix:
-        os: [ "macos-10.15", "ubuntu-18.04", "ubuntu-20.04", "ubuntu-22.04", "windows-latest" ]
+        os: [ "macos-11", "macos-12", "ubuntu-18.04", "ubuntu-20.04", "ubuntu-22.04", "windows-latest" ]
         python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.6", "pypy3.8" ]
         exclude:
           - os: windows-latest

--- a/.github/workflows/unit-testing-and-coverage.yml
+++ b/.github/workflows/unit-testing-and-coverage.yml
@@ -138,5 +138,6 @@ jobs:
       # Ubuntu 18.04 came out of the box with 3.6, and LOTS of system are still running
       # 18.04 happily, so we choose this as the 'canonical' code coverage testing.
       # One day we'll have to revisit this and bump the version ...
+      # 2022-12-16: Bumped to Python 3.8 and Ubuntu 20.04. Yeah, we take the conservative LTS route.
       if: matrix.python-version == '3.8' && matrix.os == 'ubuntu-20.04'
       uses: codecov/codecov-action@v3.1.1

--- a/.github/workflows/unit-testing-and-coverage.yml
+++ b/.github/workflows/unit-testing-and-coverage.yml
@@ -93,6 +93,10 @@ jobs:
         exclude:
           - os: windows-latest
             python-version: pypy3.6
+          - os: macos-11
+            python-version: pypy3.6
+          - os: macos-12
+            python-version: pypy3.6
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15  # Slowest so far is pypy3 on MacOS, taking almost 7m
     steps:

--- a/.github/workflows/unit-testing-and-coverage.yml
+++ b/.github/workflows/unit-testing-and-coverage.yml
@@ -89,7 +89,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "macos-10.15", "ubuntu-18.04", "ubuntu-20.04", "ubuntu-22.04", "windows-latest" ]
-        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.8" ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.8" ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15  # Slowest so far is pypy3 on MacOS, taking almost 7m
     steps:

--- a/.github/workflows/unit-testing-and-coverage.yml
+++ b/.github/workflows/unit-testing-and-coverage.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: "Checkout latest PR commit"
-        uses: actions/checkout@v2.6.0
+        uses: actions/checkout@v3
       - name: "Set up Python"
         uses: actions/setup-python@v4.3.1
         with:
@@ -97,7 +97,7 @@ jobs:
     timeout-minutes: 15  # Slowest so far is pypy3 on MacOS, taking almost 7m
     steps:
     - name: "Checkout latest commit"
-      uses: actions/checkout@v2.6.0
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0  # Required by codecov/codecov-action@v1
     - name: "Set up Python ${{ matrix.python-version }}"

--- a/.github/workflows/unit-testing-and-coverage.yml
+++ b/.github/workflows/unit-testing-and-coverage.yml
@@ -121,7 +121,8 @@ jobs:
       run: |
         pip install bandit
         bandit -c bandit.yml -r aiosmtpd
-    - name: "Execute testing"
+    - name: "Execute testing with coverage"
+      if: matrix.python-version != 'pypy3.8' or (matrix.os != 'ubuntu-18.04' and matrix.os != 'ubuntu-20.04')
       shell: bash
       # language=bash
       run: |
@@ -129,11 +130,19 @@ jobs:
         if [[ $GITHUB_REF != refs/heads/master ]]; then
           git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin master:master
         fi
-        if [[ ${{ matrix.python-version }} = "pypy3.8" ]]; then
-          pytest
-        else
-          pytest --cov --cov-report=xml --cov-report=term
+        pytest --cov --cov-report=xml --cov-report=term
+        #
+    - name: "Execute testing w/o coverage"
+      if: matrix.python-version == 'pypy3.8' and (matrix.os == 'ubuntu-18.04' or matrix.os == 'ubuntu-20.04')
+      shell: bash
+      # language=bash
+      run: |
+        # Fetch master if needed because some test cases need its existence
+        if [[ $GITHUB_REF != refs/heads/master ]]; then
+          git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin master:master
         fi
+        pytest
+        #
     - name: "Report to codecov"
       # Ubuntu 18.04 came out of the box with 3.6, and LOTS of system are still running
       # 18.04 happily, so we choose this as the 'canonical' code coverage testing.

--- a/.github/workflows/unit-testing-and-coverage.yml
+++ b/.github/workflows/unit-testing-and-coverage.yml
@@ -89,7 +89,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "macos-11", "macos-12", "ubuntu-18.04", "ubuntu-20.04", "ubuntu-22.04", "windows-latest" ]
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.6", "pypy3.8" ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.6", "pypy3.7", "pypy3.8" ]
         exclude:
           - os: windows-latest
             python-version: pypy3.6

--- a/.github/workflows/unit-testing-and-coverage.yml
+++ b/.github/workflows/unit-testing-and-coverage.yml
@@ -88,8 +88,8 @@ jobs:
       # If a matrix fail, do NOT stop other matrix, let them run to completion
       fail-fast: false
       matrix:
-        os: [ "macos-10.15", "ubuntu-18.04", "ubuntu-20.04", "windows-latest" ]
-        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.6" ]
+        os: [ "macos-10.15", "ubuntu-18.04", "ubuntu-20.04", "ubuntu-22.04", "windows-latest" ]
+        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.8" ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15  # Slowest so far is pypy3 on MacOS, taking almost 7m
     steps:

--- a/.github/workflows/unit-testing-and-coverage.yml
+++ b/.github/workflows/unit-testing-and-coverage.yml
@@ -25,9 +25,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: "Checkout latest PR commit"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.6.0
       - name: "Set up Python"
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4.3.1
         with:
           # 3.8 is chosen because it seems to be the fastest for <3.9
           # (3.9 excluded because it seems to be still very unstable)
@@ -94,11 +94,11 @@ jobs:
     timeout-minutes: 15  # Slowest so far is pypy3 on MacOS, taking almost 7m
     steps:
     - name: "Checkout latest commit"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.6.0
       with:
         fetch-depth: 0  # Required by codecov/codecov-action@v1
     - name: "Set up Python ${{ matrix.python-version }}"
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v4.3.1
       with:
         python-version: ${{ matrix.python-version }}
     - name: "Install dependencies"
@@ -127,5 +127,5 @@ jobs:
       # Ubuntu 18.04 came out of the box with 3.6, and LOTS of system are still running
       # 18.04 happily, so we choose this as the 'canonical' code coverage testing.
       # One day we'll have to revisit this and bump the version ...
-      if: matrix.python-version == '3.6' && matrix.os == 'ubuntu-18.04'
+      if: matrix.python-version == '3.7' && matrix.os == 'ubuntu-18.04'
       uses: codecov/codecov-action@v1

--- a/.github/workflows/unit-testing-and-coverage.yml
+++ b/.github/workflows/unit-testing-and-coverage.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   qa_docs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: "Checkout latest PR commit"
         uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
         with:
           # 3.8 is chosen because it seems to be the fastest for <3.9
           # (3.9 excluded because it seems to be still very unstable)
-          python-version: 3.8
+          python-version: 3.11
       - name: "Update modules & install deps"
         # language=bash
         run: |

--- a/.github/workflows/unit-testing-and-coverage.yml
+++ b/.github/workflows/unit-testing-and-coverage.yml
@@ -122,7 +122,7 @@ jobs:
         pip install bandit
         bandit -c bandit.yml -r aiosmtpd
     - name: "Execute testing with coverage"
-      if: matrix.python-version != 'pypy3.8' || (matrix.os != 'ubuntu-18.04' && matrix.os != 'ubuntu-20.04')
+      if: matrix.python-version != 'pypy3.8'
       shell: bash
       # language=bash
       run: |
@@ -133,7 +133,7 @@ jobs:
         pytest --cov --cov-report=xml --cov-report=term
         #
     - name: "Execute testing w/o coverage"
-      if: matrix.python-version == 'pypy3.8' && (matrix.os == 'ubuntu-18.04' || matrix.os == 'ubuntu-20.04')
+      if: matrix.python-version == 'pypy3.8'
       shell: bash
       # language=bash
       run: |

--- a/.github/workflows/unit-testing-and-coverage.yml
+++ b/.github/workflows/unit-testing-and-coverage.yml
@@ -122,7 +122,7 @@ jobs:
         pip install bandit
         bandit -c bandit.yml -r aiosmtpd
     - name: "Execute testing with coverage"
-      if: matrix.python-version != 'pypy3.8' or (matrix.os != 'ubuntu-18.04' and matrix.os != 'ubuntu-20.04')
+      if: matrix.python-version != 'pypy3.8' || (matrix.os != 'ubuntu-18.04' && matrix.os != 'ubuntu-20.04')
       shell: bash
       # language=bash
       run: |
@@ -133,7 +133,7 @@ jobs:
         pytest --cov --cov-report=xml --cov-report=term
         #
     - name: "Execute testing w/o coverage"
-      if: matrix.python-version == 'pypy3.8' and (matrix.os == 'ubuntu-18.04' or matrix.os == 'ubuntu-20.04')
+      if: matrix.python-version == 'pypy3.8' && (matrix.os == 'ubuntu-18.04' || matrix.os == 'ubuntu-20.04')
       shell: bash
       # language=bash
       run: |

--- a/.github/workflows/unit-testing-and-coverage.yml
+++ b/.github/workflows/unit-testing-and-coverage.yml
@@ -89,7 +89,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "macos-10.15", "ubuntu-18.04", "ubuntu-20.04", "ubuntu-22.04", "windows-latest" ]
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.6" ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.6", "pypy3.8" ]
         exclude:
           - os: windows-latest
             python-version: pypy3.6
@@ -125,10 +125,14 @@ jobs:
         if [[ $GITHUB_REF != refs/heads/master ]]; then
           git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin master:master
         fi
-        pytest --cov --cov-report=xml --cov-report=term
+        if [[ ${{ matrix.python-version }} = "pypy3.8" ]]; then
+          pytest
+        else
+          pytest --cov --cov-report=xml --cov-report=term
+        fi
     - name: "Report to codecov"
       # Ubuntu 18.04 came out of the box with 3.6, and LOTS of system are still running
       # 18.04 happily, so we choose this as the 'canonical' code coverage testing.
       # One day we'll have to revisit this and bump the version ...
-      if: matrix.python-version == '3.7' && matrix.os == 'ubuntu-18.04'
+      if: matrix.python-version == '3.8' && matrix.os == 'ubuntu-20.04'
       uses: codecov/codecov-action@v1

--- a/.github/workflows/unit-testing-and-coverage.yml
+++ b/.github/workflows/unit-testing-and-coverage.yml
@@ -89,7 +89,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "macos-10.15", "ubuntu-18.04", "ubuntu-20.04", "ubuntu-22.04", "windows-latest" ]
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.8" ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.6" ]
+        exclude:
+          - os: windows-latest
+            python-version: pypy3.6
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15  # Slowest so far is pypy3 on MacOS, taking almost 7m
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -64,41 +64,41 @@ passenv =
 # setup.cfg) to activate the respective plugins. If no snippet is given, that means the plugin is
 # always active.
 deps =
-    flake8-bugbear
-    flake8-builtins
-    flake8-coding
+    flake8-bugbear >= 22.12.6
+    flake8-builtins >= 2.0.1
+    flake8-coding >= 1.3.2
     # C4
-    flake8-comprehensions
+    flake8-comprehensions >= 3.10.1
     # JS
-    flake8-multiline-containers
+    flake8-multiline-containers >= 0.0.19
     # PIE
-    flake8-pie
+    flake8-pie >= 0.16.0
     # MOD
-    flake8-printf-formatting
+    flake8-printf-formatting >= 1.1.2
     # PT
-    flake8-pytest-style
+    flake8-pytest-style >= 1.6.0
     # SIM
-    flake8-simplify
+    flake8-simplify >= 0.19.3
     # Cognitive Complexity looks like a good idea, but to fix the complaints... it will be an epic effort.
     # So we disable it for now and reenable when we're ready, probably just before 2.0
     # # CCR
     # flake8-cognitive-complexity
     # ECE
-    flake8-expression-complexity
+    flake8-expression-complexity >= 0.0.11
     # C801
-    flake8-copyright
+    flake8-copyright >= 0.2.3
     # DUO
     dlint
     # TAE
-    flake8-annotations-complexity
+    flake8-annotations-complexity >= 0.0.7
     # TAE
-    flake8-annotations-coverage
+    flake8-annotations-coverage >= 0.0.6
     # ANN
-    flake8-annotations
+    flake8-annotations >= 2.9.1
     # YTT
-    flake8-2020
+    flake8-2020 > 1.7.0
     # N400
-    flake8-broken-line
+    flake8-broken-line >= 0.6.0
 
 [testenv:qa]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -64,41 +64,41 @@ passenv =
 # setup.cfg) to activate the respective plugins. If no snippet is given, that means the plugin is
 # always active.
 deps =
-    flake8-bugbear >= 22.12.6
-    flake8-builtins >= 2.0.1
-    flake8-coding >= 1.3.2
+    flake8-bugbear>=22.12.6
+    flake8-builtins>=2.0.1
+    flake8-coding>=1.3.2
     # C4
-    flake8-comprehensions >= 3.10.1
+    flake8-comprehensions>=3.10.1
     # JS
-    flake8-multiline-containers >= 0.0.19
+    flake8-multiline-containers>=0.0.19
     # PIE
-    flake8-pie >= 0.16.0
+    flake8-pie>=0.16.0
     # MOD
-    flake8-printf-formatting >= 1.1.2
+    flake8-printf-formatting>=1.1.2
     # PT
-    flake8-pytest-style >= 1.6.0
+    flake8-pytest-style>=1.6.0
     # SIM
-    flake8-simplify >= 0.19.3
+    flake8-simplify>=0.19.3
     # Cognitive Complexity looks like a good idea, but to fix the complaints... it will be an epic effort.
     # So we disable it for now and reenable when we're ready, probably just before 2.0
     # # CCR
     # flake8-cognitive-complexity
     # ECE
-    flake8-expression-complexity >= 0.0.11
+    flake8-expression-complexity>=0.0.11
     # C801
-    flake8-copyright >= 0.2.3
+    flake8-copyright>=0.2.3
     # DUO
     dlint
     # TAE
-    flake8-annotations-complexity >= 0.0.7
+    flake8-annotations-complexity>=0.0.7
     # TAE
-    flake8-annotations-coverage >= 0.0.6
+    flake8-annotations-coverage>=0.0.6
     # ANN
-    flake8-annotations >= 2.9.1
+    flake8-annotations>=2.9.1
     # YTT
-    flake8-2020 > 1.7.0
+    flake8-2020>=1.7.0
     # N400
-    flake8-broken-line >= 0.6.0
+    flake8-broken-line>=0.6.0
 
 [testenv:qa]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -88,7 +88,7 @@ deps =
     # C801
     flake8-copyright>=0.2.3
     # DUO
-    dlint
+    dlint>=0.13.0
     # TAE
     flake8-annotations-complexity>=0.0.7
     # TAE
@@ -113,7 +113,7 @@ commands =
     pytype --keep-going --jobs auto .
 deps =
     colorama
-    flake8
+    flake8>=5.0.4
     {[flake8_plugins]deps}
     pytest
     check-manifest


### PR DESCRIPTION
Speedup of #323 + many modernizations, such as:

* Add pypy3.8
* Exclude pypy3.6 on Windows (no longer available)
* Remove 3.6 (end of life already -- let it rest in peace)
* Actions use Node 16

And a workaround:
* Skip code coverage when running on pypy3.8 (not sure why it doesn't hit 100%)

Now all steps are green and runs in acceptable time, as can be seen in [CI #451](https://github.com/aio-libs/aiosmtpd/actions/runs/3696059951)

If merged this closes #316 