### PR TITLE
Bump 1.4.3 final (for release!)

### DIFF
--- a/aiosmtpd/__init__.py
+++ b/aiosmtpd/__init__.py
@@ -1,4 +1,4 @@
 # Copyright 2014-2021 The aiosmtpd Developers
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "1.4.3rc2"
+__version__ = "1.4.3"

--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -27,6 +27,7 @@ Fixed/Improved
   * Drop Python 3.6, PyPy 3.6 (some) and MacOS 10
   * Add Python 3.10 & 3.11, PyPy 3.7 & 3.8, Ubuntu 22.04, MacOS 11 & 12
 
+* Expanded tox environments
 * Longer AUTOSTOP_DELAY especially for Windows (Closes #313)
 * Update signing keys
 

--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -16,7 +16,7 @@ Fixed/Improved
 * A whole bunch of annotations
 
 
-1.4.3rc2 (2022-12-18)
+1.4.3 (2022-12-21)
 =====================
 
 Fixed/Improved
@@ -30,6 +30,7 @@ Fixed/Improved
 * Expanded tox environments
 * Longer AUTOSTOP_DELAY especially for Windows (Closes #313)
 * Update signing keys
+* Some documentation fixes
 
 
 1.4.2 (2021-03-08)

--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -21,6 +21,7 @@ Fixed/Improved
 
 Fixed/Improved
 --------------
+* Is now compatible with uvloop
 * Add compatibility for Python 3.10 and 3.11 (Closes #322)
 * Test matrix update (Closes #306)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.9.0
-envlist = qa, static, docs, py{37,38,39,py3}-{nocov,cov,diffcov}
+envlist = qa, static, docs, py{37,38,39,310,311,py3}-{nocov,cov,diffcov}
 skip_missing_interpreters = True
 
 [testenv]
@@ -62,6 +62,8 @@ passenv =
 # Snippets of letters above these plugins are tests that need to be "select"-ed in flake8 config (in
 # setup.cfg) to activate the respective plugins. If no snippet is given, that means the plugin is
 # always active.
+# IMPORTANT: It's a good idea to restrict the version numbers of the plugins. Without version limits, GHCI's pip
+# sometimes simply gives up trying to figure the right deps, causing the test to fail.
 deps =
     flake8-bugbear>=22.12.6
     flake8-builtins>=2.0.1


### PR DESCRIPTION
## What do these changes do?

Bumping version to 1.4.3 which includes:
* Updates to NEWS
* Updates to DESCRIPTION and README
* Integrates updates since 1.4.3rc2. Notable ones:
  * Compatibility with `uvloop`
  * Expanded tox environments

## Are there changes in behavior for the user?

Shouldn't be any.

## Related issue number

Closes #322 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] GitHub CI all green
- [x] Documentation reflects the changes
- [x] Add a news fragment into the `NEWS.rst` file
