### PR TITLE
Remove Discourse, replace with GH Discussions

### DIFF
--- a/DESCRIPTION.rst
+++ b/DESCRIPTION.rst
@@ -7,6 +7,8 @@
 | |GH Release| |_| |GH PRs| |_| |GH LastCommit|
 | |PyPI DL| |_| |GH DL|
 |
+| |GH Discussions|
+|
 
 .. .. U+00A0 is non-breaking space
 .. |_| unicode:: 0xA0
@@ -36,7 +38,6 @@
 .. |readthedocs| image:: https://img.shields.io/readthedocs/aiosmtpd?logo=Read+the+Docs
    :target: https://aiosmtpd.readthedocs.io/en/latest/?badge=latest
    :alt: Documentation Status
-.. .. Do NOT include the Discourse badge!
 .. |GH Release| image:: https://img.shields.io/github/v/release/aio-libs/aiosmtpd?logo=github
    :target: https://github.com/aio-libs/aiosmtpd/releases
    :alt: GitHub latest release
@@ -52,7 +53,9 @@
 .. |GH DL| image:: https://img.shields.io/github/downloads/aio-libs/aiosmtpd/total?logo=github
    :target: https://github.com/aio-libs/aiosmtpd/releases
    :alt: GitHub downloads
-
+.. |GH Discussions| image:: https://img.shields.io/github/discussions/aio-libs/aiosmtpd?logo=github&style=social
+   :target: https://github.com/aio-libs/aiosmtpd/discussions
+   :alt: GitHub Discussions
 
 This is a server for SMTP and related MTA protocols,
 similar in utility to the standard library's |smtpd.py|_ module,

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,8 @@
 | |github license| |_| |PyPI Version| |_| |PyPI Python| |_| |PyPI PythonImpl|
 | |GA badge| |_| |CodeQL badge| |_| |codecov| |_| |readthedocs|
 |
-| |Discourse|
+| |GH Discussions|
+|
 
 .. |_| unicode:: 0xA0
    :trim:
@@ -34,11 +35,9 @@
 .. |readthedocs| image:: https://img.shields.io/readthedocs/aiosmtpd?logo=Read+the+Docs&logoColor=white
    :target: https://aiosmtpd.readthedocs.io/en/latest/
    :alt: Documentation Status
-.. .. If you edit the above badges, don't forget to edit setup.cfg
-.. .. The |Discourse| badge MUST NOT be included in setup.cfg
-.. |Discourse| image:: https://img.shields.io/discourse/status?server=https%3A%2F%2Faio-libs.discourse.group%2F&style=social
-   :target: https://aio-libs.discourse.group/
-   :alt: Discourse
+.. |GH Discussions| image:: https://img.shields.io/github/discussions/aio-libs/aiosmtpd?logo=github&style=social
+   :target: https://github.com/aio-libs/aiosmtpd/discussions
+   :alt: GitHub Discussions
 
 The Python standard library includes a basic |SMTP|_ server in the |smtpd|_ module,
 based on the old asynchronous libraries |asyncore|_ and |asynchat|_.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

As mentioned [here](https://github.com/aio-libs/aiohttp/discussions/7140) and [here](https://github.com/aio-libs/aiohttp/issues/7141), it's clear that the Discourse dicussion group at `aio-libs.discourse.group` is dead.

There's even already a [**merged PR**](https://github.com/aio-libs/aiohttp/pull/7144) where the Discourse link is removed from `aiohttp`.

## Are there changes in behavior for the user?

When they click the link they will now go to GH Discussions.

## Related issue number

Not issue, but Discussion #340 

## Checklist

- [x] I think the code is well written
