### PR TITLE
Workaround for asyncio.get_event_loop() deprecation

### DIFF
--- a/aiosmtpd/__init__.py
+++ b/aiosmtpd/__init__.py
@@ -4,7 +4,7 @@ import asyncio
 import warnings
 
 
-__version__ = "1.4.4a0"
+__version__ = "1.4.4a1"
 
 
 def _get_or_new_eventloop() -> asyncio.AbstractEventLoop:

--- a/aiosmtpd/__init__.py
+++ b/aiosmtpd/__init__.py
@@ -1,4 +1,18 @@
 # Copyright 2014-2021 The aiosmtpd Developers
 # SPDX-License-Identifier: Apache-2.0
+import asyncio
+import warnings
+
 
 __version__ = "1.4.4a0"
+
+
+def _get_or_new_eventloop() -> asyncio.AbstractEventLoop:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        try:
+            loop = asyncio.get_event_loop()
+        except (DeprecationWarning, RuntimeError):
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+    return loop

--- a/aiosmtpd/__init__.py
+++ b/aiosmtpd/__init__.py
@@ -12,7 +12,7 @@ def _get_or_new_eventloop() -> asyncio.AbstractEventLoop:
         warnings.simplefilter("error")
         try:
             loop = asyncio.get_event_loop()
-        except (DeprecationWarning, RuntimeError):  # pragma: no cover
+        except (DeprecationWarning, RuntimeError):  # pragma: py-lt-310
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
     return loop

--- a/aiosmtpd/__init__.py
+++ b/aiosmtpd/__init__.py
@@ -12,7 +12,7 @@ def _get_or_new_eventloop() -> asyncio.AbstractEventLoop:
         warnings.simplefilter("ignore")
         try:
             loop = asyncio.get_event_loop()
-        except (DeprecationWarning, RuntimeError):
+        except (DeprecationWarning, RuntimeError):  # pragma: no cover
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
     return loop

--- a/aiosmtpd/__init__.py
+++ b/aiosmtpd/__init__.py
@@ -9,7 +9,7 @@ __version__ = "1.4.4a1"
 
 def _get_or_new_eventloop() -> asyncio.AbstractEventLoop:
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+        warnings.simplefilter("error")
         try:
             loop = asyncio.get_event_loop()
         except (DeprecationWarning, RuntimeError):  # pragma: no cover

--- a/aiosmtpd/__init__.py
+++ b/aiosmtpd/__init__.py
@@ -8,11 +8,14 @@ __version__ = "1.4.4a1"
 
 
 def _get_or_new_eventloop() -> asyncio.AbstractEventLoop:
+    loop = None
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         try:
             loop = asyncio.get_event_loop()
         except (DeprecationWarning, RuntimeError):  # pragma: py-lt-310
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
+            if loop is None:  # pragma: py-lt-312
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+    assert isinstance(loop, asyncio.AbstractEventLoop)
     return loop

--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -16,10 +16,12 @@ Fixed/Improved
 * A whole bunch of annotations
 
 
-1.4.4a0 (ad hoc)
+1.4.4a1 (ad hoc)
 ================
 
-(Stub ``NEWS.rst`` entry as placeholder for ``qa`` test.)
+Fixed/Improved
+--------------
+* No longer expect an implicit creation of the event loop through ``get_event_loop()`` (Closes #353)
 
 
 1.4.3 (2022-12-21)

--- a/aiosmtpd/docs/controller.rst
+++ b/aiosmtpd/docs/controller.rst
@@ -236,7 +236,8 @@ you'll have to do something similar to this:
 .. doctest:: unthreaded
 
     >>> import asyncio
-    >>> loop = asyncio.get_event_loop()
+    >>> loop = asyncio.new_event_loop()
+    >>> asyncio.set_event_loop(loop)
     >>> from aiosmtpd.controller import UnthreadedController
     >>> from aiosmtpd.handlers import Sink
     >>> controller = UnthreadedController(Sink(), loop=loop)

--- a/aiosmtpd/handlers.py
+++ b/aiosmtpd/handlers.py
@@ -25,6 +25,7 @@ from typing import Any, AnyStr, List, Type, TypeVar, Optional
 
 from public import public
 
+from aiosmtpd import _get_or_new_eventloop
 from aiosmtpd.smtp import SMTP as SMTPServer
 from aiosmtpd.smtp import Envelope as SMTPEnvelope
 from aiosmtpd.smtp import Session as SMTPSession
@@ -218,7 +219,10 @@ class AsyncMessage(Message, metaclass=ABCMeta):
         loop: Optional[asyncio.AbstractEventLoop] = None,
     ):
         super().__init__(message_class)
-        self.loop = loop or asyncio.get_event_loop()
+        if loop is not None:
+            self.loop = None
+        else:
+            self.loop = _get_or_new_eventloop()
 
     async def handle_DATA(
         self, server: SMTPServer, session: SMTPSession, envelope: SMTPEnvelope

--- a/aiosmtpd/handlers.py
+++ b/aiosmtpd/handlers.py
@@ -219,10 +219,7 @@ class AsyncMessage(Message, metaclass=ABCMeta):
         loop: Optional[asyncio.AbstractEventLoop] = None,
     ):
         super().__init__(message_class)
-        if loop is not None:
-            self.loop = None
-        else:
-            self.loop = _get_or_new_eventloop()
+        self.loop = loop or _get_or_new_eventloop()
 
     async def handle_DATA(
         self, server: SMTPServer, session: SMTPSession, envelope: SMTPEnvelope

--- a/aiosmtpd/main.py
+++ b/aiosmtpd/main.py
@@ -1,7 +1,6 @@
 # Copyright 2014-2021 The aiosmtpd Developers
 # SPDX-License-Identifier: Apache-2.0
 
-import asyncio
 import logging
 import os
 import signal

--- a/aiosmtpd/main.py
+++ b/aiosmtpd/main.py
@@ -16,7 +16,7 @@ from typing import Optional, Sequence, Tuple
 
 from public import public
 
-from aiosmtpd import __version__
+from aiosmtpd import __version__, _get_or_new_eventloop
 from aiosmtpd.smtp import DATA_SIZE_DEFAULT, SMTP
 
 try:
@@ -252,7 +252,7 @@ def main(args: Optional[Sequence[str]] = None) -> None:
 
     logging.basicConfig(level=logging.ERROR)
     log = logging.getLogger("mail.log")
-    loop = asyncio.get_event_loop()
+    loop = _get_or_new_eventloop()
 
     if args.debug > 0:
         log.setLevel(logging.INFO)

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -34,7 +34,7 @@ from warnings import warn
 import attr
 from public import public
 
-from aiosmtpd import __version__
+from aiosmtpd import __version__, _get_or_new_eventloop
 from aiosmtpd.proxy_protocol import ProxyData, get_proxy
 
 
@@ -208,7 +208,7 @@ class Envelope:
 # unit test suite.  In that case, this function is mocked to set the debug
 # level on the loop (as if PYTHONASYNCIODEBUG=1 were set).
 def make_loop() -> asyncio.AbstractEventLoop:
-    return asyncio.get_event_loop()
+    return _get_or_new_eventloop()
 
 
 @public

--- a/aiosmtpd/tests/test_misc.py
+++ b/aiosmtpd/tests/test_misc.py
@@ -5,7 +5,7 @@
 
 import asyncio
 import warnings
-from typing import Optional
+from typing import Generator, Optional
 
 import pytest
 
@@ -13,7 +13,7 @@ from aiosmtpd import _get_or_new_eventloop
 
 
 @pytest.fixture(scope="module")
-def close_existing_loop() -> Optional[asyncio.AbstractEventLoop]:
+def close_existing_loop() -> Generator[Optional[asyncio.AbstractEventLoop], None, None]:
     loop: Optional[asyncio.AbstractEventLoop]
     with warnings.catch_warnings():
         warnings.filterwarnings("error")

--- a/aiosmtpd/tests/test_misc.py
+++ b/aiosmtpd/tests/test_misc.py
@@ -1,0 +1,44 @@
+# Copyright 2014-2021 The aiosmtpd Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test other aspects of the server implementation."""
+
+import asyncio
+import warnings
+from typing import Optional
+
+import pytest
+
+from aiosmtpd import _get_or_new_eventloop
+
+
+@pytest.fixture(scope="module")
+def close_existing_loop() -> None:
+    loop: Optional[asyncio.AbstractEventLoop]
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error")
+        try:
+            loop = asyncio.get_event_loop()
+        except (DeprecationWarning, RuntimeError):
+            loop = None
+    if loop:
+        loop.stop()
+        loop.close()
+        asyncio.set_event_loop(None)
+
+
+class TestInit:
+
+    def test_create_new_if_none(self, close_existing_loop):
+        loop: Optional[asyncio.AbstractEventLoop]
+        loop = _get_or_new_eventloop()
+        assert loop is not None
+        assert isinstance(loop, asyncio.AbstractEventLoop)
+
+    def test_not_create_new_if_exist(self, close_existing_loop):
+        loop: Optional[asyncio.AbstractEventLoop]
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        ret_loop = _get_or_new_eventloop()
+        assert ret_loop == loop
+        assert ret_loop is loop

--- a/examples/authenticated_relayer/server.py
+++ b/examples/authenticated_relayer/server.py
@@ -94,7 +94,8 @@ if __name__ == '__main__':
         print(f"Please create {DB_AUTH} first using make_user_db.py")
         sys.exit(1)
     logging.basicConfig(level=logging.DEBUG)
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
     loop.create_task(amain())
     try:
         loop.run_forever()

--- a/examples/basic/server.py
+++ b/examples/basic/server.py
@@ -15,7 +15,8 @@ async def amain(loop):
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
     loop.create_task(amain(loop=loop))
     try:
         loop.run_forever()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ source = [
 
 [tool.coverage.coverage_conditional_plugin.rules]
 # Here we specify our pragma rules:
+py-lt-312 = "sys_version_info < (3, 12)"
 py-lt-310 = "sys_version_info < (3, 10)"
 py-ge-38 = "sys_version_info >= (3, 8)"
 py-lt-38 = "sys_version_info < (3, 8)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ source = [
 
 [tool.coverage.coverage_conditional_plugin.rules]
 # Here we specify our pragma rules:
+py-lt-310 = "sys_version_info < (3, 10)"
 py-ge-38 = "sys_version_info >= (3, 8)"
 py-lt-38 = "sys_version_info < (3, 8)"
 py-gt-36 = "sys_version_info > (3, 6)"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Implement workaround due to the deprecation in ***behavior*** of asyncio.get_event_loop() (which will outright result in error with Python 3.12)

This change of behavior first appeared in Python 3.10: https://docs.python.org/3.10/library/asyncio-eventloop.html#asyncio.get_event_loop

And there has been some discussion on this, among others:
* https://github.com/python/cpython/issues/83710
* https://github.com/python/cpython/issues/93453
* https://github.com/python/cpython/pull/98440

## Are there changes in behavior for the user?

Should be minimal.
* If user creates their own event loop and feeds that to aiosmtpd, then nothing will be changed
* If user does not create their own event loop and let aiosmtpd generates one for them, then the behavior totally depends on how `get_event_loop_policy()` was in effect at time of instantiation.
  *  This might or might not be a problem. For asyncio, the behaviour should be similar. I am not sure about the behavior of other implementations (e.g., `uvloop`)

## Related issue number

Closes #353 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] tox testenvs have been executed in the following environments:
  - [x] Windows (10): `py311-{nocov,cov}`
- [x] Documentation reflects the changes
