### PR TITLE
setDaemon() is deprecated, set the daemon attrib directly instead

### DIFF
--- a/aiosmtpd/docs/controller.rst
+++ b/aiosmtpd/docs/controller.rst
@@ -261,7 +261,7 @@ we'll also schedule an autostop so it won't hang:
     ...     loop.run_forever()
     >>> import threading
     >>> thread = threading.Thread(target=runner)
-    >>> thread.setDaemon(True)
+    >>> thread.daemon = True
     >>> thread.start()
     >>> import time
     >>> time.sleep(0.1)  # Allow the loop to begin

--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -403,7 +403,7 @@ class TestUnthreaded:
         def starter(loop: asyncio.AbstractEventLoop):
             nonlocal thread
             thread = Thread(target=_runner, args=(loop,))
-            thread.setDaemon(True)
+            thread.daemon = True
             thread.start()
             catchup_delay()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Replace call to `.setDaemon()` to direct setting of `.daemon` attribute, [as described in the documentation](https://docs.python.org/3/library/threading.html#threading.Thread.setDaemon).

## Are there changes in behavior for the user?

None.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
