### PR TITLE
Change tox behavior

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,8 @@ envdir =
     py310: {toxworkdir}/3.10
     py311: {toxworkdir}/3.11
     pypy3: {toxworkdir}/pypy3
+    pypy37: {toxworkdir}/pypy37
+    pypy38: {toxworkdir}/pypy38
     py: {toxworkdir}/py
 commands =
     python housekeep.py prep
@@ -50,6 +52,8 @@ setenv =
     py310: INTERP=py310
     py311: INTERP=py311
     pypy3: INTERP=pypy3
+    pypy37: INTERP=pypy37
+    pypy38: INTERP=pypy38
     py: INTERP=py
 passenv =
     PYTHON*

--- a/tox.ini
+++ b/tox.ini
@@ -4,17 +4,7 @@ envlist = qa, static, docs, py{37,38,39,310,311,py3}-{nocov,cov,diffcov}
 skip_missing_interpreters = True
 
 [testenv]
-# One virtualenv per Python version
-envdir =
-    py37: {toxworkdir}/3.7
-    py38: {toxworkdir}/3.8
-    py39: {toxworkdir}/3.9
-    py310: {toxworkdir}/3.10
-    py311: {toxworkdir}/3.11
-    pypy3: {toxworkdir}/pypy3
-    pypy37: {toxworkdir}/pypy37
-    pypy38: {toxworkdir}/pypy38
-    py: {toxworkdir}/py
+envdir = {toxworkdir}/{envname}
 commands =
     python housekeep.py prep
     # Bandit is not needed on diffcov, and seems to be incompatible with 310
@@ -29,20 +19,19 @@ commands =
 #sitepackages = True
 usedevelop = True
 deps =
-    # do NOT make these conditional, that way we can reuse same envdir for nocov+cov+diffcov
     bandit
     colorama
-    coverage[toml]
-    coverage-conditional-plugin
     packaging
     pytest >= 6.0  # Require >= 6.0 for pyproject.toml support (PEP 517)
-    pytest-cov
     pytest-mock
     pytest-print
     pytest-profiling
     pytest-sugar
     py # needed for pytest-sugar as it doesn't declare dependency on it.
-    diff_cover
+    !nocov: coverage[toml]
+    !nocov: coverage-conditional-plugin
+    !nocov: pytest-cov
+    diffcov: diff_cover
 setenv =
     cov: COVERAGE_FILE={toxinidir}/_dump/.coverage
     nocov: PYTHONASYNCIODEBUG=1

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ deps =
     pytest-profiling
     pytest-sugar
     py # needed for pytest-sugar as it doesn't declare dependency on it.
+    !nocov: coverage>=7.0.1
     !nocov: coverage[toml]
     !nocov: coverage-conditional-plugin
     !nocov: pytest-cov


### PR DESCRIPTION
## What do these changes do?

I had just managed to b0rk my cloned repo _completely_ when I specify tox to run `pypy38-nocov`.

That is due to `envdir` not specified explicitly so `tox` decides to 'clean up' my cloned repo and build its environment _right there_.

After recloning, I found out that tox now will recreate environment if the envname changes, so `py37-nocov` and `py37-cov` (for instance) can no longer share same packages. Meaning that previous "common deps" list is useless.

So I decided to just specify a specific envdir for all envname (i.e., combination of Pyton version + what test), and use conditionals on the deps installation.

## Are there changes in behavior for the user?

Not really. However developers might find that hard disk usage balloons. Use `housekeep.py superclean`, it's there for a reason 😉

## Related issue number

None

## Checklist

- [x] I think the code is well written
- [x] tox testenvs have been executed in the following environments:
  - [x] Windows (10): `pypy38-{nocov,cov}`
