### PR TITLE
Drop testing for PyPy3.6, add PyPy3.9

### DIFF
--- a/.github/workflows/unit-testing-and-coverage.yml
+++ b/.github/workflows/unit-testing-and-coverage.yml
@@ -90,17 +90,8 @@ jobs:
       # If a matrix fail, do NOT stop other matrix, let them run to completion
       fail-fast: false
       matrix:
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.6", "pypy3.7", "pypy3.8" ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.7", "pypy3.8", "pypy3.9" ]
         os: [ "macos-11", "macos-12", "ubuntu-18.04", "ubuntu-20.04", "ubuntu-22.04", "windows-2019", "windows-2022" ]
-        exclude:
-          - os: windows-2019
-            python-version: pypy3.6
-          - os: windows-2022
-            python-version: pypy3.6
-          - os: macos-11
-            python-version: pypy3.6
-          - os: macos-12
-            python-version: pypy3.6
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15  # Slowest so far is pypy3 on MacOS, taking almost 7m
     steps:
@@ -117,7 +108,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         # Test deps
-        pip install colorama coverage[toml] "coverage-conditional-plugin>=0.5.0" packaging pytest pytest-cov pytest-mock
+        pip install colorama "coverage>=7.0.1" coverage[toml] "coverage-conditional-plugin>=0.5.0" packaging pytest pytest-cov pytest-mock
         # Package deps
         python setup.py develop
     - name: "Security checking"
@@ -128,6 +119,8 @@ jobs:
 
     # IMPORTANT: pypy3.8 is currently excluded from coverage testing because coverage seems to be unstable when
     # running on PyPy 3.8. This is still under investigation (See issue #325)
+    # Edit: This is due to change in behavior in PyPy v7.3.10, and coverage.py needs to adapt.
+    # See: https://github.com/nedbat/coveragepy/issues/1515
 
     - name: "Execute testing with coverage"
       if: matrix.python-version != 'pypy3.8'

--- a/README.rst
+++ b/README.rst
@@ -155,11 +155,11 @@ option::
 
 You can also add the ``-s``/``--capture=no`` option to show output, e.g.::
 
-    $ tox -e py36-nocov -- -s
+    $ tox -e py37-nocov -- -s
 
 and these options can be combined::
 
-    $ tox -e py36-nocov -- -x -s <testname>
+    $ tox -e py37-nocov -- -x -s <testname>
 
 (The ``-e`` parameter is explained in the next section about 'testenvs'.
 In general, you'll want to choose the ``nocov`` testenvs if you want to show output,

--- a/README.rst
+++ b/README.rst
@@ -173,7 +173,7 @@ In general, the ``-e`` parameter to tox specifies one (or more) **testenv**
 to run (separate using comma if more than one testenv). The following testenvs
 have been configured and tested:
 
-* ``{py37,py38,py39,py310,py311,pypy3}-{nocov,cov,diffcov,profile}``
+* ``{py37,py38,py39,py310,py311,pypy3,pypy37,pypy38,pypy39}-{nocov,cov,diffcov,profile}``
 
   Specifies the interpreter to run and the kind of testing to perform.
 


### PR DESCRIPTION
## What do these changes do?

No longer test with PyPy3.6.

PyPy3.6 has been EOL-ed for quite some time, and not available on non-Ubuntu runners anyways.

## Are there changes in behavior for the user?

None.

## Related issue number

None

## Checklist

- [x] I think the code is well written
