### PR TITLE
Block release if git unclean

### DIFF
--- a/aiosmtpd/__init__.py
+++ b/aiosmtpd/__init__.py
@@ -4,7 +4,7 @@ import asyncio
 import warnings
 
 
-__version__ = "1.4.4.post1"
+__version__ = "1.4.4.post2"
 
 
 def _get_or_new_eventloop() -> asyncio.AbstractEventLoop:

--- a/aiosmtpd/__init__.py
+++ b/aiosmtpd/__init__.py
@@ -4,7 +4,7 @@ import asyncio
 import warnings
 
 
-__version__ = "1.4.4"
+__version__ = "1.4.4.post1"
 
 
 def _get_or_new_eventloop() -> asyncio.AbstractEventLoop:

--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -16,12 +16,13 @@ Fixed/Improved
 * A whole bunch of annotations
 
 
-1.4.4.post1 (2023-01-19)
+1.4.4.post2 (2023-01-19)
 ========================
 
 Fixed/Improved
 --------------
-* A packaging mishap results in a buggy test case (Closes #365)
+* Prevent unclean repo from being built (Closes #365)
+* Reduce chance of not-ready-for-release packages from being uploaded
 
 
 1.4.4 (2023-01-17)

--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -16,6 +16,14 @@ Fixed/Improved
 * A whole bunch of annotations
 
 
+1.4.4.post1 (2023-01-19)
+========================
+
+Fixed/Improved
+--------------
+* A packaging mishap results in a buggy test case (Closes #365)
+
+
 1.4.4 (2023-01-17)
 ==================
 

--- a/aiosmtpd/qa/test_0packaging.py
+++ b/aiosmtpd/qa/test_0packaging.py
@@ -17,7 +17,7 @@ from packaging import version
 from aiosmtpd import __version__
 
 RE_DUNDERVER = re.compile(r"__version__\s*?=\s*?(['\"])(?P<ver>[^'\"]+)\1\s*$")
-RE_VERHEADING = re.compile(r"(?P<ver>[0-9.]+)\s*\((?P<date>[^)]+)\)")
+RE_VERHEADING = re.compile(r"(?P<ver>([0-9.]+)\S*)\s*\((?P<date>[^)]+)\)")
 
 
 @pytest.fixture

--- a/release.py
+++ b/release.py
@@ -19,6 +19,12 @@ from aiosmtpd import __version__ as ver_str
 printfl = partial(print, flush=True)
 run_hidden = partial(subprocess.run, stdout=subprocess.PIPE)
 
+result = run_hidden(shlex.split("git status --porcelain"))
+if result.stdout:
+    print("git is not clean!")
+    print("Please commit/shelf first before releasing!")
+    sys.exit(1)
+
 TWINE_CONFIG = Path(os.environ.get("TWINE_CONFIG", "~/.pypirc")).expanduser()
 TWINE_REPO = os.environ.get("TWINE_REPOSITORY", "aiosmtpd")
 UPSTREAM_REMOTE = os.environ.get("UPSTREAM_REMOTE", "upstream")

--- a/release.py
+++ b/release.py
@@ -107,7 +107,16 @@ try:
     # Assuming twine is installed.
     print("### twine check")
     subprocess.run(["twine", "check"] + DISTFILES, check=True)
+except subprocess.CalledProcessError as e:
+    print("ERROR: Last step returned exitcode != 0")
+    sys.exit(e.returncode)
 
+choice = input("Ready to upload to PyPI? [y/N]: ")
+if choice.casefold() not in ("y", "yes"):
+    print("Okay.")
+    sys.exit(0)
+
+try:
     # You should have an aiosmtpd bit setup in your ~/.pypirc - for twine
     twine_up = f"twine upload --config-file {TWINE_CONFIG} -r {TWINE_REPO}".split()
     if GPG_SIGNING_ID:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Makes `release.py` block release process if git is unclean, preventing snippets that one forgot to shelf from tainting the release sdist & wheel

## Are there changes in behavior for the user?

None. This is purely a packaging issue.

## Related issue number

Prevents #365 from happening again.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [x] Windows (10): `qa`
- [x] Add a news fragment into the `NEWS.rst` file
