### PR TITLE
Fix authentication

### DIFF
--- a/aiosmtpd/docs/auth.rst
+++ b/aiosmtpd/docs/auth.rst
@@ -14,6 +14,7 @@ Activating Authentication
 but attempts to authenticate will always be rejected
 unless the :attr:`authenticator` parameter of :class:`~aiosmtpd.smtp.SMTP`
 is set to a valid & working :ref:`authcallback`.
+The :attr:`auth_required` parameter can be set to ``True`` to reject clients that don't authenticate.
 
 
 AUTH API
@@ -145,6 +146,11 @@ Authenticator Callback
    of data will be :class:`aiosmtpd.smtp.LoginPassword`
 
    .. versionadded:: 1.3
+
+.. important::
+
+   Setting an authenticator on your server or controller is not sufficient to require authentication.
+   In addition to rejecting incorrect credentials in your authenticator, you should set :attr:`auth_required` to ``True`` to reject clients that don't authenticate at all.
 
 AuthResult API
 --------------

--- a/examples/authenticated_relayer/server.py
+++ b/examples/authenticated_relayer/server.py
@@ -81,7 +81,8 @@ async def amain():
         handler,
         hostname='',
         port=8025,
-        authenticator=Authenticator(DB_AUTH)
+        authenticator=Authenticator(DB_AUTH),
+        auth_required=True,
     )
     cont.start()
 

--- a/examples/authenticated_relayer/server.py
+++ b/examples/authenticated_relayer/server.py
@@ -30,9 +30,11 @@ class Authenticator:
             return fail_nothandled
         if not isinstance(auth_data, LoginPassword):
             return fail_nothandled
-        username = auth_data.login
+        try:
+            username = auth_data.login.decode('utf-8')
+        except UnicodeDecodeError:
+            return fail_nothandled
         password = auth_data.password
-        hashpass = self.ph.hash(password)
         conn = sqlite3.connect(self.auth_db)
         curs = conn.execute(
             "SELECT hashpass FROM userauth WHERE username=?", (username,)
@@ -41,7 +43,7 @@ class Authenticator:
         conn.close()
         if not hash_db:
             return fail_nothandled
-        if hashpass != hash_db[0]:
+        if not self.ph.verify(hash_db[0], password):
             return fail_nothandled
         return AuthResult(success=True)
 
@@ -83,6 +85,7 @@ async def amain():
         port=8025,
         authenticator=Authenticator(DB_AUTH),
         auth_required=True,
+        auth_require_tls=False,
     )
     cont.start()
 

--- a/examples/authenticated_relayer/server.py
+++ b/examples/authenticated_relayer/server.py
@@ -83,10 +83,7 @@ async def amain():
         port=8025,
         authenticator=Authenticator(DB_AUTH)
     )
-    try:
-        cont.start()
-    finally:
-        cont.stop()
+    cont.start()
 
 
 if __name__ == '__main__':
@@ -96,7 +93,7 @@ if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-    loop.create_task(amain())
+    loop.run_until_complete(loop.create_task(amain()))
     try:
         loop.run_forever()
     except KeyboardInterrupt:

--- a/examples/basic/server.py
+++ b/examples/basic/server.py
@@ -17,7 +17,7 @@ if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-    loop.create_task(amain(loop=loop))
+    loop.run_until_complete(loop.create_task(amain(loop=loop)))
     try:
         loop.run_forever()
     except KeyboardInterrupt:


### PR DESCRIPTION
## What do these changes do?

Update the documentation and example to mention that `auth_required=True` should be set when setting `authenticator`, otherwise clients can still send messages with no authentication.

## Are there changes in behavior for the user?

No

## Related issue number

#374

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [ ] Linux (Ubuntu 18.04, Ubuntu 20.04, Arch): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, qa, docs`
  - [ ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- ~~Documentation reflects the changes~~
- [ ] Add a news fragment into the `NEWS.rst` file