### PR TITLE
starttls: Clear unencrypted commands from buffer

### DIFF
--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -4,6 +4,10 @@
 
 .. towncrier release notes start
 
+1.4.6 (2024-05-06)
+==================
+
+* STARTTLS is now fully enforced if used.
 
 1.4.5 (2024-03-02)
 ==================

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -506,7 +506,7 @@ class SMTP(asyncio.StreamReaderProtocol):
             self.transport = transport
             # Discard any leftover unencrypted data
             # See https://tools.ietf.org/html/rfc3207#page-7
-            self._reader._buffer.clear()
+            self._reader._buffer.clear()  # type: ignore[attr-defined]
             # Do SSL certificate checking as rfc3207 part 4.1 says.  Why is
             # _extra a protected attribute?
             assert self._tls_protocol is not None

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -504,6 +504,9 @@ class SMTP(asyncio.StreamReaderProtocol):
             self._reader._transport = transport  # type: ignore[attr-defined]
             self._writer._transport = transport  # type: ignore[attr-defined]
             self.transport = transport
+            # Discard any leftover unencrypted data
+            # See https://tools.ietf.org/html/rfc3207#page-7
+            self._reader._buffer.clear()
             # Do SSL certificate checking as rfc3207 part 4.1 says.  Why is
             # _extra a protected attribute?
             assert self._tls_protocol is not None


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

When a STARTTLS command is not the last one in a pipeline, extra unencrypted commands may treated as part of the encrypted communication, effectively allowing to bypass the `ALLOWED_BEFORE_STARTTLS` list used when `require_starttls=True`.  This PR adds a buffer flush to ensure it does not happen.

## Are there changes in behavior for the user?

No behaviour change.  Documentation reflects the changes already.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [x] Linux (Ubuntu 18.04, Ubuntu 20.04, Arch): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, qa, docs`
  - [ ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- [x] Documentation reflects the changes
- [x] Add a news fragment into the `NEWS.rst` file