### PR TITLE
Allow setting port=0 to use OS-assigned port.

### DIFF
--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -440,6 +440,10 @@ class InetMixin(BaseController, metaclass=ABCMeta):
         # At this point, if self.hostname is Falsy, it most likely is "" (bind to all
         # addresses). In such case, it should be safe to connect to localhost)
         hostname = self.hostname or self._localhost
+        # If port is 0, we need to get the port that the OS assigned so that we
+        # can connect.
+        if self.port == 0:
+            self.port = self.server.sockets[0].getsockname()[1]
         with ExitStack() as stk:
             s = stk.enter_context(create_connection((hostname, self.port), 1.0))
             if self.ssl_context:

--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -14,6 +14,7 @@ Fixed/Improved
 --------------
 * All Controllers now have more rationale design, as they are now composited from a Base + a Mixin
 * A whole bunch of annotations
+* Allow using port=0 with TCP controllers to use an OS-assigned port (Closes #276).
 
 
 1.4.4.post2 (2023-01-19)

--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -297,6 +297,15 @@ class TestController:
         finally:
             cont.stop()
 
+    def test_port_zero(self):
+        cont = Controller(Sink(), port=0)
+        try:
+            cont.start()
+            # Ensure port on controller has been populated with the OS-assigned port
+            assert cont.port != 0
+        finally:
+            cont.stop()
+
     def test_testconn_raises(self, mocker: MockFixture):
         mocker.patch("socket.socket.recv", side_effect=RuntimeError("MockError"))
         cont = Controller(Sink(), hostname="")


### PR DESCRIPTION
## What do these changes do?

Allow using `port=0` when creating a Controller to use an OS-assigned port. Using `port=0` is useful for ephemeral servers (eg for tests) where a given port can't necessarily be guaranteed to be available.

## Are there changes in behavior for the user?

No changes to existing behaviour (when specifying a non-zero port, or leaving it at the default).

## Related issue number

Closes: #276 (this implements the changes described in the comments on that issue)

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] tox testenvs have been executed in the following environments:
  - [x] Linux (Ubuntu 22.04): `py310-nocov` (`test_server.py` only)
- [ ] Documentation reflects the changes
- [x] Add a news fragment into the `NEWS.rst` file
