### PR TITLE
Preserve proxy_data after starttls

### DIFF
--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -461,7 +461,11 @@ class SMTP(asyncio.StreamReaderProtocol):
                 raise TypeError("command_call_limit must be int or Dict[str, int]")
 
     def _create_session(self) -> Session:
-        return Session(self.loop)
+        prev_session: Optional[Session] = getattr(self, 'session', None)
+        session = Session(self.loop)
+        if prev_session is not None:
+            session.proxy_data = prev_session.proxy_data
+        return session
 
     def _create_envelope(self) -> Envelope:
         return Envelope()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No

## Related issue number

None

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [ ] Linux (Ubuntu 18.04, Ubuntu 20.04, Arch): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, qa, docs`
  - [ ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- [ ] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file
  <!-- Delete the following bullet points prior to submitting the PR -->
  * Add under the "aiosmtpd-next" section, creating one if necessary
    * You may create subsections to group the changes, if you like
  * Use full sentences with correct case and punctuation
  * Refer to relevant Issue if applicable
