### PR TITLE
Update test_smtpsmuggling.py

### DIFF
--- a/aiosmtpd/tests/test_smtpsmuggling.py
+++ b/aiosmtpd/tests/test_smtpsmuggling.py
@@ -3,29 +3,16 @@
 
 """Test SMTP smuggling."""
 
-from email.mime.text import MIMEText
-from typing import Generator, Union
-
-import pytest
 import smtplib
 import re
 
-from aiosmtpd.controller import Controller
 from aiosmtpd.testing.helpers import ReceivingHandler
 from aiosmtpd.testing.statuscodes import SMTP_STATUS_CODES as S
 
-from aiosmtpd.smtp import SMTP as Server
-from aiosmtpd.smtp import Session as ServerSession
-from aiosmtpd.smtp import Envelope
+from .conftest import handler_data
 
-from .conftest import Global, controller_data, handler_data
-
-from aiosmtpd.testing.helpers import (
-    ReceivingHandler
-)
 
 def new_data(self, msg):
-
     self.putcmd("data")
     (code, repl) = self.getreply()
     if self.debuglevel > 0:
@@ -33,14 +20,6 @@ def new_data(self, msg):
     if code != 354:
         raise SMTPDataError(code, repl)
     else:
-        ##### Patching input encoding so we can send raw messages
-        #if isinstance(msg, str):
-        #    msg = smtplib._fix_eols(msg).encode('ascii')
-        #q = smtplib._quote_periods(msg)
-        #if q[-2:] != smtplib.bCRLF:
-        #    q = q + smtplib.bCRLF
-        #q = q + b"." + smtplib.bCRLF
-
         q = msg
         self.send(q)
         (code, msg) = self.getreply()
@@ -48,14 +27,14 @@ def new_data(self, msg):
             self._print_debug('data:', (code, msg))
         return (code, msg)
 
-def orig_data(self, msg):
 
+def orig_data(self, msg):
     self.putcmd("data")
     (code, repl) = self.getreply()
     if self.debuglevel > 0:
         self._print_debug('data:', (code, repl))
     if code != 354:
-        raise SMTPDataError(code, repl)
+        raise smtplib.SMTPDataError(code, repl)
     else:
         if isinstance(msg, str):
             msg = _fix_eols(msg).encode('ascii')
@@ -72,13 +51,16 @@ def orig_data(self, msg):
 
 
 def _fix_eols(data):
-    return  re.sub(r'(?:\r\n|\n|\r(?!\n))', smtplib.CRLF, data)
+    return re.sub(r'(?:\r\n|\n|\r(?!\n))', smtplib.CRLF, data)
+
 
 def _quote_periods(bindata):
     return re.sub(br'(?m)^\.', b'..', bindata)
 
+
 def return_unchanged(data):
     return data
+
 
 class TestSmuggling:
     @handler_data(class_=ReceivingHandler)
@@ -104,7 +86,7 @@ Testing\
 NO SMUGGLING
 \r\n.\r\n\
 """
-        results = client.sendmail(sender, recipients, message_data)
+        client.sendmail(sender, recipients, message_data)
         client.quit()
         smtplib._fix_eols = _fix_eols
         smtplib._quote_periods = _quote_periods

--- a/aiosmtpd/tests/test_smtpsmuggling.py
+++ b/aiosmtpd/tests/test_smtpsmuggling.py
@@ -18,7 +18,7 @@ def new_data(self, msg):
     if self.debuglevel > 0:
         self._print_debug('data:', (code, repl))
     if code != 354:
-        raise SMTPDataError(code, repl)
+        raise smtplib.SMTPDataError(code, repl)
     else:
         q = msg
         self.send(q)


### PR DESCRIPTION
Fixed SMTP smuggling test

<!-- Thank you for your contribution! -->

## What do these changes do?

The SMTP smuggling test was previously breaking further test cases (e.g., test_starttls). This was fixed and now all tests pass.

## Are there changes in behavior for the user?

No

## Related issue number

No

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [ ] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [ ] Linux (Ubuntu 18.04, Ubuntu 20.04, Arch): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, qa, docs`
  - [ ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- [ ] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file
  <!-- Delete the following bullet points prior to submitting the PR -->
  * Add under the "aiosmtpd-next" section, creating one if necessary
    * You may create subsections to group the changes, if you like
  * Use full sentences with correct case and punctuation
  * Refer to relevant Issue if applicable
