### PR TITLE
Remove unused NEWLINE global

### DIFF
--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -87,7 +87,6 @@ DATA_SIZE_DEFAULT = 2**25  # Where does this number come from, I wonder...
 EMPTY_BARR = bytearray()
 EMPTYBYTES = b''
 MISSING = _Missing.MISSING
-NEWLINE = '\r\n'
 VALID_AUTHMECH = re.compile(r"[A-Z0-9_-]+\Z")
 
 # https://tools.ietf.org/html/rfc3207.html#page-3


### PR DESCRIPTION
Removed NEWLINE global variable

<!-- Thank you for your contribution! -->

## What do these changes do?

Removed unused global NEWLINE variable.

## Are there changes in behavior for the user?

No

## Related issue number

No

## Checklist

- [X] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [ ] Linux (Ubuntu 18.04, Ubuntu 20.04, Arch): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, qa, docs`
  - [ ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- [ ] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file
  <!-- Delete the following bullet points prior to submitting the PR -->
  * Add under the "aiosmtpd-next" section, creating one if necessary
    * You may create subsections to group the changes, if you like
  * Use full sentences with correct case and punctuation
  * Refer to relevant Issue if applicable
