### PR TITLE
Add compatibility for Python 3.13

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -66,7 +66,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        pyver: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        pyver: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         os: [ubuntu, macos, windows]
         include:
           - pyver: pypy-3.8
@@ -82,6 +82,7 @@ jobs:
         python-version: ${{ matrix.pyver }}
         cache: 'pip'
         cache-dependency-path: '**/requirements*.txt'
+        allow-prereleases: true
     - name: Install dependencies
       uses: py-actions/py-dependency-install@v4
       with:

--- a/README.rst
+++ b/README.rst
@@ -179,7 +179,6 @@ have been configured and tested:
     (showing a single character per test run)
   - ``diffcov`` = with diff-coverage report (showing difference in
     coverage compared to previous commit). Tests will run in brief mode
-  - ``profile`` = no coverage testing, but code profiling instead.
     This must be **invoked manually** using the ``-e`` parameter
 
   **Note 1:** As of 2021-02-23,

--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -4,6 +4,14 @@
 
 .. towncrier release notes start
 
+1.4.7 (aiosmtpd-next)
+=====================
+
+Fixed/Improved
+--------------
+
+* Added compatibility for Python 3.13 (Closes #403)
+
 1.4.6 (2024-05-18)
 ==================
 

--- a/aiosmtpd/docs/testing.rst
+++ b/aiosmtpd/docs/testing.rst
@@ -30,9 +30,6 @@ Other plugins that are used, to various degrees, in the ``aiosmtpd`` test suite 
 * |pytest-cov|_ to integrate with |coverage-py|_
 * |pytest-sugar|_ to provide better ux
 * |pytest-print|_ to give some progress indicator and to assist test troubleshooting
-* |pytest-profiling|_ to implement ``*-profile`` testenv,
-  although to be honest this is not really useful as the profiling gets 'muddied' by
-  pytest runner.
 
 .. _`pytest-mock`: https://pypi.org/project/pytest-mock/
 .. |pytest-mock| replace:: ``pytest-mock``
@@ -44,8 +41,6 @@ Other plugins that are used, to various degrees, in the ``aiosmtpd`` test suite 
 .. |pytest-sugar| replace:: ``pytest-sugar``
 .. _`pytest-print`: https://pypi.org/project/pytest-print/
 .. |pytest-print| replace:: ``pytest-print``
-.. _`pytest-profiling`: https://pypi.org/project/pytest-profiling/
-.. |pytest-profiling| replace:: ``pytest-profiling``
 
 
 Fixtures

--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -448,10 +448,17 @@ class TestUnthreaded:
         # Stop the task
         cont.end()
         catchup_delay()
-        # Now the listener has gone away
-        # noinspection PyTypeChecker
-        with pytest.raises((socket.timeout, ConnectionError)):
-            assert_smtp_socket(cont)
+        if sys.version_info < (3, 13):
+            # Now the listener has gone away
+            # noinspection PyTypeChecker
+            with pytest.raises((socket.timeout, ConnectionError)):
+                assert_smtp_socket(cont)
+        else:
+            # Starting from Python 3.13, listening asyncio Unix socket is
+            # removed on close, see:
+            # https://github.com/python/cpython/issues/111246
+            # https://github.com/python/cpython/pull/111483
+            assert not Path(cont.unix_socket).exists()
 
     @pytest.mark.filterwarnings(
         "ignore::pytest.PytestUnraisableExceptionWarning"

--- a/pytest.ini
+++ b/pytest.ini
@@ -13,8 +13,6 @@ addopts =
 asyncio_mode = auto
 filterwarnings =
     error
-    # TODO: Replace pkg_resources
-    ignore:pkg_resources is deprecated as an API:DeprecationWarning
     # TODO: Fix resource warnings
     ignore:unclosed transport:ResourceWarning
     ignore:unclosed <socket.socket:ResourceWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,7 +10,6 @@ addopts =
     --showlocals
     # coverage reports
     --cov=aiosmtpd/ --cov-report term
-asyncio_mode = auto
 filterwarnings =
     error
     # TODO: Fix resource warnings

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,5 @@ atpublic==5.0
 attrs==24.2.0
 coverage==7.6.1
 pytest==8.3.4
-pytest-asyncio==0.24.0
 pytest-cov==5.0.0
 pytest-mock==3.14.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Communications :: Email :: Mail Transport Agents

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,6 @@ deps =
     pytest >= 6.0  # Require >= 6.0 for pyproject.toml support (PEP 517)
     pytest-mock
     pytest-print
-    pytest-profiling
     pytest-sugar
     py # needed for pytest-sugar as it doesn't declare dependency on it.
     !nocov: coverage>=7.0.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.9.0
-envlist = qa, static, docs, py{38,39,310,311,312,py3}-{nocov,cov,diffcov}
+envlist = qa, static, docs, py{38,39,310,311,312,313,py3}-{nocov,cov,diffcov}
 skip_missing_interpreters = True
 
 [testenv]
@@ -40,6 +40,7 @@ setenv =
     py310: INTERP=py310
     py311: INTERP=py311
     py312: INTERP=py312
+    py313: INTERP=py313
     pypy3: INTERP=pypy3
     pypy38: INTERP=pypy38
     pypy39: INTERP=pypy39


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- Fix tox for Python >= 3.12
- Remove `pytest-profiling`
- Remove `pytest-asyncio` traces
- Add compatibility for Python 3.13

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

* Add compatibility for Python 3.13

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Use the "closing keywords" such as "Closes" or "Fixes" to automatically link to Issues. -->

Closes #403.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [x] Linux (Fedora 40): `{py38,py39,py310,py311,py312,py313}-{cov}`
- [x] Documentation reflects the changes
- [x] Add a news fragment into the `NEWS.rst` file
  <!-- Delete the following bullet points prior to submitting the PR -->
  * Add under the "aiosmtpd-next" section, creating one if necessary
    * You may create subsections to group the changes, if you like
  * Use full sentences with correct case and punctuation
  * Refer to relevant Issue if applicable
