### PR TITLE
Fix `Session.peer` type annotation to support IPv6 and UNIX sockets

### DIFF
--- a/aiosmtpd/handlers.py
+++ b/aiosmtpd/handlers.py
@@ -27,6 +27,7 @@ from public import public
 from aiosmtpd import _get_or_new_eventloop
 from aiosmtpd.smtp import SMTP as SMTPServer
 from aiosmtpd.smtp import Envelope as SMTPEnvelope
+from aiosmtpd.smtp import PeerType
 from aiosmtpd.smtp import Session as SMTPSession
 
 T = TypeVar("T")
@@ -38,7 +39,7 @@ NLCRE = re.compile(br"\r\n|\r|\n")
 log = logging.getLogger("mail.debug")
 
 
-def _format_peer(peer: str) -> str:
+def _format_peer(peer: PeerType) -> str:
     # This is a separate function mostly so the test suite can craft a
     # reproducible output.
     return "X-Peer: {!r}".format(peer)
@@ -76,7 +77,7 @@ class Debugging:
             parser.error("Debugging usage: [stdout|stderr]")
         return cls(stream)  # type: ignore[call-arg]
 
-    def _print_message_content(self, peer: str, data: Union[str, bytes]) -> None:
+    def _print_message_content(self, peer: PeerType, data: Union[str, bytes]) -> None:
         in_headers = True
         for line in data.splitlines():
             # Dump the RFC 2822 headers first.

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -65,6 +65,8 @@ _TriStateType = Union[None, _Missing, bytes]
 RT = TypeVar("RT")  # "ReturnType"
 DecoratorType = Callable[[Callable[..., RT]], Callable[..., RT]]
 
+# IPv4, IPv6, UNIX socket, not set
+PeerType = Union[Tuple[str, int], Tuple[str, int, int, int], str, None]
 
 # endregion
 
@@ -155,7 +157,7 @@ class LoginPassword(NamedTuple):
 @public
 class Session:
     def __init__(self, loop: asyncio.AbstractEventLoop):
-        self.peer: Optional[Tuple[str, int]] = None
+        self.peer: PeerType = None
         self.ssl: Optional[dict[str, Any]] = None
         self.host_name: Optional[str] = None
         self.extended_smtp = False

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -155,7 +155,7 @@ class LoginPassword(NamedTuple):
 @public
 class Session:
     def __init__(self, loop: asyncio.AbstractEventLoop):
-        self.peer: Optional[str] = None
+        self.peer: Optional[Tuple[str, int]] = None
         self.ssl: Optional[dict[str, Any]] = None
         self.host_name: Optional[str] = None
         self.extended_smtp = False

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -66,7 +66,7 @@ RT = TypeVar("RT")  # "ReturnType"
 DecoratorType = Callable[[Callable[..., RT]], Callable[..., RT]]
 
 # IPv4, IPv6, UNIX socket, not set
-PeerType = Union[Tuple[str, int], Tuple[str, int, int, int], str, None]
+PeerType = Union[tuple[str, int], tuple[str, int, int, int], str, None]
 
 # endregion
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Updates the type annotation for the `Session.peer` field. 

The annotation was "str or None".

I think the correct annotation should be "tuple[str, int] or None" (more in #518)

## Are there changes in behavior for the user?

Type annotation changes should not affect code at runtime.

Dependent code *could* see new mypy warnings if it also uses the old, now incompatible, type annotation.

## Related issue number

Fixes: #518

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [x] Linux (Ubuntu 24.04) `{py312}`
  - [ ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- [ ] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file
