### PR TITLE
Fix _FakeServer to immediately close client connections

### DIFF
--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -99,14 +99,11 @@ class _FakeServer(asyncio.StreamReaderProtocol):
         # Imitate what SMTP does
         super().__init__(
             asyncio.StreamReader(loop=loop),
-            client_connected_cb=self._cb_client_connected,
             loop=loop,
         )
 
-    def _cb_client_connected(
-            self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
-    ) -> None:
-        pass
+    def connection_made(self, transport):
+        transport.close()
 
 
 @public

--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -541,7 +541,6 @@ class TestUnthreaded:
         assert temp_event_loop.is_closed() is False
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 12), reason="Hangs on 3.12")
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 class TestFactory:
     def test_normal_situation(self):


### PR DESCRIPTION
## What do these changes do?

This implements `_FakeServer.connection_made()` which immediately closes client connections.

Without this, if the SMTP server throws an exception during initialization, Controller.stop() gets stuck indefinitely waiting on active connections.

Note: this only happens in Python 3.12+. Earlier versions of Python allowed `wait_closed()` to complete regardless of active connections.

With this change the TestFactory testcases can again be enabled for Python 3.12+.

## Are there changes in behavior for the user?

No change for the happy path, as _FakeServer is only used if the SMTP server throws exception during initialization.

## Related issue number

Fixes: #394

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [x] Linux (Ubuntu 24.04): `{py312}`
  - [ ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- [ ] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file
