### PR TITLE
Update ci-cd.yml to fetch master branch

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -86,6 +86,11 @@ jobs:
       uses: py-actions/py-dependency-install@v4
       with:
         path: requirements.txt
+    - name: Fetch master branch 
+      # Needed for aiosmtpd.qa.test_0packaging.TestVersion.test_ge_master,
+      # it runs a "git show" command which will fail if the master branch
+      # does not exist locally
+      run: git fetch origin master:master        
     - name: Run unittests
       run: pytest
       env:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This change hopefully fixes test 
`aiosmtpd.qa.test_0packaging.TestVersion.test_ge_master`.

The test runs `git show master:aiosmtpd/__init__.py` command, and the command
fails if the master branch does not exist locally. 

## Are there changes in behavior for the user?

No, they just fixes CI to not skip a test.

