### PR TITLE
Change auth mechanism to upper

### DIFF
--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -963,7 +963,7 @@ class SMTP(asyncio.StreamReaderProtocol):
             await self.push('501 Too many values')
             return
 
-        mechanism = args[0]
+        mechanism = args[0].upper()
         if mechanism not in self._auth_methods:
             await self.push('504 5.5.4 Unrecognized authentication type')
             return


### PR DESCRIPTION
## What do these changes do?

Changes authentication mechanism to uppercase, so that auth_XYZ also handles "AUTH xyz" requests ([RFC 4954 Section 8](https://www.rfc-editor.org/rfc/rfc4954#section-8)  compliant).

## Are there changes in behavior for the user?

User doesn't have to implement `auth_XYZ` and `auth_xyz` anymore.

## Related issue number

Fixes #542 

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Add a news fragment into the `NEWS.rst` file