### PR TITLE
Remove `pytest-asyncio` traces

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -10,7 +10,6 @@ addopts =
     --showlocals
     # coverage reports
     --cov=aiosmtpd/ --cov-report term
-asyncio_mode = auto
 filterwarnings =
     error
     # TODO: Replace pkg_resources

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,5 @@ atpublic==5.0
 attrs==24.2.0
 coverage==7.6.1
 pytest==8.3.4
-pytest-asyncio==0.24.0
 pytest-cov==5.0.0
 pytest-mock==3.14.0


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Currently, `tox` fails because of `pytest-asyncio` missing in dependencies in `tox.ini`:
```
$ tox -e py311-cov --recreate
...
INTERNALERROR> pytest.PytestConfigWarning: Unknown config option: asyncio_mode
```

One way is to add it there, however it looks like it is not necessary at
all:
* After removing all the traces tests pass without raising  `PytestUnhandledCoroutineWarning`.
* Introduction of `pytest-asyncio` in https://github.com/aio-libs/aiosmtpd/pull/395 was not justified.
  Apparently, it was added, because it was present in other aio-libs packages.
* The output of `rg 'async def ' aiosmtpd/tests aiosmtpd/testing` shows no instances of tests.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

No changes for the user.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Use the "closing keywords" such as "Closes" or "Fixes" to automatically link to Issues. -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [x] Linux (openSUSE Tumbleweed): `py311-cov`
- [ ] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file
  <!-- Delete the following bullet points prior to submitting the PR -->
  * Add under the "aiosmtpd-next" section, creating one if necessary
    * You may create subsections to group the changes, if you like
  * Use full sentences with correct case and punctuation
  * Refer to relevant Issue if applicable
