### PR TITLE
Drop Python 3.8 and replace PyPy 3.8 with 3.9

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -66,10 +66,10 @@ jobs:
     name: Test
     strategy:
       matrix:
-        pyver: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        pyver: ['3.9', '3.10', '3.11', '3.12']
         os: [ubuntu, macos, windows]
         include:
-          - pyver: pypy-3.8
+          - pyver: pypy-3.9
             os: ubuntu
     runs-on: ${{ matrix.os }}-latest
     timeout-minutes: 15

--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ Requirements
 Supported Platforms
 -----------------------
 
-``aiosmtpd`` has been tested on **CPython**>=3.8 and |PyPy|_>=3.8
+``aiosmtpd`` has been tested on **CPython**>=3.9 and |PyPy|_>=3.9
 for the following platforms (in alphabetical order):
 
 * Cygwin (as of 2022-12-22, only for CPython 3.8, and 3.9)

--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -4,6 +4,16 @@
 
 .. towncrier release notes start
 
+1.4.7 (aiosmtpd-next)
+=====================
+
+Fixed/Improved
+--------------
+
+* Dropped Python 3.8, PyPy 3.8
+* Added PyPy 3.9
+
+
 1.4.6 (2024-05-18)
 ==================
 

--- a/aiosmtpd/tests/test_main.py
+++ b/aiosmtpd/tests/test_main.py
@@ -158,15 +158,7 @@ class TestMain:
         with pytest.raises(SystemExit) as excinfo:
             main(args=())
         assert excinfo.value.code == 1
-        # On Python 3.8 on Linux, a bunch of "RuntimeWarning: coroutine
-        # 'AsyncMockMixin._execute_mock_call' was never awaited" messages
-        # gets mixed up into stderr causing test fail.
-        # Therefore, we use assertIn instead of assertEqual here, because
-        # the string DOES appear in stderr, just buried.
-        assert (
-            'Cannot import module "pwd"; try running with -n option.\n'
-            in capsys.readouterr().err
-        )
+        assert capsys.readouterr().err == 'Cannot import module "pwd"; try running with -n option.\n'
 
     def test_n(self, setuid):
         with pytest.raises(RuntimeError):

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -1036,10 +1036,9 @@ class TestAuthMechanisms(_CommonMethods):
         client.password = PW
         auth_meth = getattr(client, "auth_" + mechanism)
         if (mechanism, init_resp) == ("login", False) and (
-                sys.version_info < (3, 8, 9)
-                or (3, 9, 0) < sys.version_info < (3, 9, 4)):
+                (3, 9, 0) < sys.version_info < (3, 9, 4)):
             # The bug with SMTP.auth_login was fixed in Python 3.10 and backported
-            # to 3.9.4 and and 3.8.9.
+            # to 3.9.4
             # See https://github.com/python/cpython/pull/24118 for the fixes.:
             with pytest.raises(SMTPAuthenticationError):
                 client.auth(mechanism, auth_meth, initial_response_ok=init_resp)

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ classifiers =
     Operating System :: POSIX :: BSD :: FreeBSD
     Operating System :: POSIX :: Linux
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
@@ -33,7 +32,7 @@ classifiers =
 
 [options]
 zip_safe = false
-python_requires = >=3.8
+python_requires = >=3.9
 packages = find:
 include_package_data = true
 setup_requires =


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Drop Python 3.8 and replace PyPy 3.8 with 3.9.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

Security Support for Python 3.8 ended 6 months ago (07 Oct 2024), so users should avoid using Python 3.8 and won't see the changes.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Use the "closing keywords" such as "Closes" or "Fixes" to automatically link to Issues. -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [x] Linux (openSUSE Tumbleweed): `{py311}-{cov}`
- [x] Documentation reflects the changes
- [x] Add a news fragment into the `NEWS.rst` file
