### PR TITLE
migrate config_test from pkg_resources to importlib_resources

### DIFF
--- a/aiosmtpd/tests/conftest.py
+++ b/aiosmtpd/tests/conftest.py
@@ -12,7 +12,7 @@ from smtplib import SMTP as SMTPClient
 from typing import Any, Callable, Generator, NamedTuple, Optional, Type, TypeVar
 
 import pytest
-from pkg_resources import resource_filename
+import importlib_resources
 from pytest_mock import MockFixture
 
 from aiosmtpd.controller import Controller
@@ -73,8 +73,15 @@ class Global:
 # If less than 1.0, might cause intermittent error if test system
 # is too busy/overloaded.
 AUTOSTOP_DELAY = 1.5
-SERVER_CRT = resource_filename("aiosmtpd.tests.certs", "server.crt")
-SERVER_KEY = resource_filename("aiosmtpd.tests.certs", "server.key")
+# https://importlib-resources.readthedocs.io/en/latest/migration.html
+# this assumes these files are already present in the filesystem so
+# it doesn't need to extract a tempfile for the context manager to clean up
+ref = importlib_resources.files("aiosmtpd.tests.certs") / "server.crt"
+with importlib_resources.as_file(ref) as path:
+    SERVER_CRT = str(path)
+ref = importlib_resources.files("aiosmtpd.tests.certs") / "server.key"
+with importlib_resources.as_file(ref) as path:
+    SERVER_KEY = str(path)
 
 # endregion
 

--- a/aiosmtpd/tests/conftest.py
+++ b/aiosmtpd/tests/conftest.py
@@ -12,7 +12,7 @@ from smtplib import SMTP as SMTPClient
 from typing import Any, Callable, Generator, NamedTuple, Optional, Type, TypeVar
 
 import pytest
-import importlib_resources
+import importlib.resources
 from pytest_mock import MockFixture
 
 from aiosmtpd.controller import Controller
@@ -76,11 +76,11 @@ AUTOSTOP_DELAY = 1.5
 # https://importlib-resources.readthedocs.io/en/latest/migration.html
 # this assumes these files are already present in the filesystem so
 # it doesn't need to extract a tempfile for the context manager to clean up
-ref = importlib_resources.files("aiosmtpd.tests.certs") / "server.crt"
-with importlib_resources.as_file(ref) as path:
+ref = importlib.resources.files("aiosmtpd.tests.certs") / "server.crt"
+with importlib.resources.as_file(ref) as path:
     SERVER_CRT = str(path)
-ref = importlib_resources.files("aiosmtpd.tests.certs") / "server.key"
-with importlib_resources.as_file(ref) as path:
+ref = importlib.resources.files("aiosmtpd.tests.certs") / "server.key"
+with importlib.resources.as_file(ref) as path:
     SERVER_KEY = str(path)
 
 # endregion

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,7 +15,6 @@ flake8-import-order==0.18.2
 flake8-pytest-style==2.0.0
 flake8-requirements==2.2.1
 flake8-simplify==0.21.0
-importlib_resources==6.5.2
 mypy==1.10.1
 types-colorama==0.4.15.20240311
 types-docutils==0.21.0.20241005

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,6 +15,7 @@ flake8-import-order==0.18.2
 flake8-pytest-style==2.0.0
 flake8-requirements==2.2.1
 flake8-simplify==0.21.0
+importlib_resources==6.5.2
 mypy==1.10.1
 types-colorama==0.4.15.20240311
 types-docutils==0.21.0.20241005


### PR DESCRIPTION
## What do these changes do?
migrate config_test from pkg_resources to importlib_resources

pkg_resources is now throwing a deprecation warning

this is only used to get the cert filenames

[](https://setuptools.pypa.io/en/latest/pkg_resources.html)

[](https://importlib-resources.readthedocs.io/en/latest/migration.html)

## Are there changes in behavior for the user?

no, test infra only

## Related issue number


## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [ ] Linux (Ubuntu 18.04, Ubuntu 20.04, Arch): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, qa, docs`
  - [ ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- [ ] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file
  <!-- Delete the following bullet points prior to submitting the PR -->
  * Add under the "aiosmtpd-next" section, creating one if necessary
    * You may create subsections to group the changes, if you like
  * Use full sentences with correct case and punctuation
  * Refer to relevant Issue if applicable
