### PR TITLE
Python 3.16 compat: use `inspect.iscoroutinefunction()`

### DIFF
--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -1526,7 +1526,7 @@ class SMTP(asyncio.StreamReaderProtocol):
                 assert self.session is not None
                 args = (self.session.peer, self.envelope.mail_from,
                         self.envelope.rcpt_tos, self.envelope.content)
-                if asyncio.iscoroutinefunction(
+                if inspect.iscoroutinefunction(
                         self.event_handler.process_message):
                     status = await self.event_handler.process_message(*args)
                 else:


### PR DESCRIPTION
## What do these changes do?

Use inspect.iscoroutinefunction to replace asyncio.iscoroutinefunction deprecated in Python 3.14 and scheduled for deletion in Python 3.16. inspect.iscoroutinefunction has been available since Python 3.9.

## Are there changes in behavior for the user?

No.
## Related issue number

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [ ] Linux (Ubuntu 18.04, Ubuntu 20.04, Arch): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, qa, docs`
  - [ ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- [ ] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file
  <!-- Delete the following bullet points prior to submitting the PR -->
  * Add under the "aiosmtpd-next" section, creating one if necessary
    * You may create subsections to group the changes, if you like
  * Use full sentences with correct case and punctuation
  * Refer to relevant Issue if applicable
