### PR TITLE
tox docs: Change deps path to use `requirements.txt`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -126,7 +126,7 @@ commands =
     sphinx-build --color -b man     -d build/.doctree aiosmtpd/docs build/man
 deps:
     colorama
-    -raiosmtpd/docs/RTD-requirements.txt
+    -raiosmtpd/docs/requirements.txt
 
 [testenv:static]
 basepython = python3


### PR DESCRIPTION
RTD-requirements.txt was removed in 8d81f96f3d91de995ecbcae01805f21a71410790.

<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No

## Related issue number

Related https://github.com/aio-libs/aiosmtpd/issues/544.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [x] Linux (Ubuntu 18.04, Ubuntu 20.04, Arch): `docs`
  - [ ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- [ ] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file

