### PR TITLE
Fix tox diffcover

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ commands =
     # So, run only if "not (310 or diffcov)" ==> "(not 310) and (not diffcov)"
     !py310-!diffcov: bandit -c bandit.yml -r aiosmtpd
     nocov: pytest --verbose -p no:cov --tb=short {posargs}
-    cov: pytest --cov --cov-report=xml --cov-report=html --cov-report=term --tb=short {posargs}
+    cov: pytest --cov --cov-report=xml:_dump/coverage-{env:INTERP}.xml --cov-report=html --cov-report=term --tb=short {posargs}
     diffcov: diff-cover _dump/coverage-{env:INTERP}.xml --html-report htmlcov/diffcov-{env:INTERP}.html
     diffcov: diff-cover _dump/coverage-{env:INTERP}.xml --fail-under=100
     profile: pytest --profile {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,8 @@ commands =
     !py310-!diffcov: bandit -c bandit.yml -r aiosmtpd
     nocov: pytest --verbose -p no:cov --tb=short {posargs}
     cov: pytest --cov --cov-report=xml:_dump/coverage-{env:INTERP}.xml --cov-report=html --cov-report=term --tb=short {posargs}
-    diffcov: diff-cover _dump/coverage-{env:INTERP}.xml --html-report htmlcov/diffcov-{env:INTERP}.html
-    diffcov: diff-cover _dump/coverage-{env:INTERP}.xml --fail-under=100
+    diffcov: diff-cover --compare-branch master _dump/coverage-{env:INTERP}.xml --html-report htmlcov/diffcov-{env:INTERP}.html
+    diffcov: diff-cover --compare-branch master _dump/coverage-{env:INTERP}.xml --fail-under=100
     profile: pytest --profile {posargs}
     python housekeep.py --afterbar --afterbar gather
 #sitepackages = True

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,8 @@ commands =
     !py310-!diffcov: bandit -c bandit.yml -r aiosmtpd
     nocov: pytest --verbose --no-cov --tb=short {posargs}
     cov: pytest --cov --cov-report=xml --cov-report=xml:_dump/coverage-{env:INTERP}.xml --cov-report=html --cov-report=term --tb=short {posargs}
-    diffcov: diff-cover _dump/coverage-{env:INTERP}.xml --html-report htmlcov/diffcov-{env:INTERP}.html
-    diffcov: diff-cover _dump/coverage-{env:INTERP}.xml --fail-under=100
+    diffcov: diff-cover --compare-branch master _dump/coverage-{env:INTERP}.xml --html-report htmlcov/diffcov-{env:INTERP}.html
+    diffcov: diff-cover --compare-branch master _dump/coverage-{env:INTERP}.xml --fail-under=100
     profile: pytest --profile {posargs}
     python housekeep.py --afterbar --afterbar gather
 #sitepackages = True

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ commands =
     # So, run only if "not (310 or diffcov)" ==> "(not 310) and (not diffcov)"
     !py310-!diffcov: bandit -c bandit.yml -r aiosmtpd
     nocov: pytest --verbose --no-cov --tb=short {posargs}
-    cov: pytest --cov --cov-report=xml --cov-report=html --cov-report=term --tb=short {posargs}
+    cov: pytest --cov --cov-report=xml --cov-report=xml:_dump/coverage-{env:INTERP}.xml --cov-report=html --cov-report=term --tb=short {posargs}
     diffcov: diff-cover _dump/coverage-{env:INTERP}.xml --html-report htmlcov/diffcov-{env:INTERP}.html
     diffcov: diff-cover _dump/coverage-{env:INTERP}.xml --fail-under=100
     profile: pytest --profile {posargs}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
Fix tox diffcover failure by:
- set cov-report output location to the location expected by diffcover.
- use --compare-branch master for diff-cover to match the project's branch.
## Are there changes in behavior for the user?

No.

## Related issue number
Related https://github.com/aio-libs/aiosmtpd/issues/544.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [x] Linux (Ubuntu 18.04, Ubuntu 20.04, Arch): `{py36,py37,py38,py39}-diffcov`
  - [ ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- [ ] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file

