### PR TITLE
tox nocov: fix by overriding pytest.ini addopts

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ commands =
     # Bandit is not needed on diffcov, and seems to be incompatible with 310
     # So, run only if "not (310 or diffcov)" ==> "(not 310) and (not diffcov)"
     !py310-!diffcov: bandit -c bandit.yml -r aiosmtpd
-    nocov: pytest --verbose -p no:cov --tb=short {posargs}
+    nocov: pytest --verbose --no-cov --tb=short {posargs}
     cov: pytest --cov --cov-report=xml --cov-report=html --cov-report=term --tb=short {posargs}
     diffcov: diff-cover _dump/coverage-{env:INTERP}.xml --html-report htmlcov/diffcov-{env:INTERP}.html
     diffcov: diff-cover _dump/coverage-{env:INTERP}.xml --fail-under=100
@@ -31,7 +31,7 @@ deps =
     !nocov: coverage>=7.0.1
     !nocov: coverage[toml]
     !nocov: coverage-conditional-plugin
-    !nocov: pytest-cov
+    pytest-cov
     diffcov: diff_cover
 setenv =
     cov: COVERAGE_FILE={toxinidir}/_dump/.coverage


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The nocov environments were failing because pytest.ini added in 8d81f96f3d91de995ecbcae01805f21a71410790 includes --cov options in addopts, which pytest treats as unrecognized arguments when the cov plugin is disabled with -p no:cov.

Adding --override-ini='addopts=' to the nocov command in tox.ini, clears the conflicting pytest.ini settings while keeping the GitHub CI workflow intact (which runs pytest directly without tox).

## Are there changes in behavior for the user?

No.

## Related issue number

Related https://github.com/aio-libs/aiosmtpd/issues/544.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [x] Linux (Ubuntu 18.04, Ubuntu 20.04, Arch): `{py36,py37,py38,py39}-nocov`
  - [ ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- [ ] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file
  <!-- Delete the following bullet points prior to submitting the PR -->
  * Add under the "aiosmtpd-next" section, creating one if necessary
    * You may create subsections to group the changes, if you like
  * Use full sentences with correct case and punctuation
  * Refer to relevant Issue if applicable
