### PR TITLE
tox static: fix platform regex for fullmatch

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -131,7 +131,7 @@ deps:
 [testenv:static]
 basepython = python3
 # (?!...) is a negative-lookahead, means that it must NOT match
-platform = ^(?!win32)(?!cygwin)
+platform = ^(?!win32)(?!cygwin).*$
 envdir = {toxworkdir}/static
 commands =
     python housekeep.py prep


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
- Fix platform match to fix skipping tox static environment on all platforms.

## Are there changes in behavior for the user?

No.

## Related issue number

Related https://github.com/aio-libs/aiosmtpd/issues/544.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [x] Linux (Ubuntu 18.04, Ubuntu 20.04, Arch): `static`
  - [ ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- [ ] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file
