### PR TITLE
Upgrade flake8-import-order and flake8-requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,9 +11,9 @@ flake8-bugbear==24.8.19
 flake8-builtins==2.5.0
 flake8-comprehensions==3.16.0
 flake8-copyright==0.2.4
-flake8-import-order==0.18.2
+flake8-import-order==0.19.2
 flake8-pytest-style==2.0.0
-flake8-requirements==2.2.1
+flake8-requirements==2.3.0
 flake8-simplify==0.21.0
 mypy==1.10.1
 types-colorama==0.4.15.20240311


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

These packages were using the deprecated pkg_resources module which has been removed from setuptools in version 82.0.0, causing flake8 to fail with 'ModuleNotFoundError: No module named pkg_resources'.
- flake8-import-order: 0.18.2 -> 0.19.2
- flake8-requirements: 2.2.1 -> 2.3.0

## Are there changes in behavior for the user?

No

## Related issue number

Fixes the continuous integration failure in https://github.com/aio-libs/aiosmtpd/pull/568.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [x] Linux (Ubuntu 18.04, Ubuntu 20.04, Arch): `python -m flake8 aiosmtpd`
  - [ ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- [ ] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file
