### PR TITLE
Speed up test_socket_error_dupe and test_socket_error_default tests

### DIFF
--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -213,7 +213,10 @@ class TestController:
     @pytest.mark.skipif(in_wsl(), reason="WSL prevents socket collision")
     def test_socket_error_dupe(self, plain_controller, client):
         contr2 = Controller(
-            Sink(), hostname=Global.SrvAddr.host, port=Global.SrvAddr.port
+            Sink(),
+            hostname=Global.SrvAddr.host,
+            port=Global.SrvAddr.port,
+            ready_timeout=0.5,
         )
         expectedre = r"error while attempting to bind on address"
         try:
@@ -225,7 +228,10 @@ class TestController:
     @pytest.mark.skipif(in_wsl(), reason="WSL prevents socket collision")
     def test_socket_error_default(self):
         contr1 = Controller(Sink())
-        contr2 = Controller(Sink())
+        contr2 = Controller(
+            Sink(),
+            ready_timeout=0.5,
+        )
         expectedre = r"error while attempting to bind on address"
         try:
             with pytest.raises(socket.error, match=expectedre):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Controller.start() starts a thread and waits for a ready event for 5 seconds (aiosmtpd.controller.DEFAULT_READY_TIMEOUT). If the thread hits an exception, the ready event never comes. The `test_socket_error_dupe` and `test_socket_error_default` tests exercise this scenario, and so each takes full 5 seconds to run. I updated these two tests to pass in a shorter ready_timeout value so they don't hang for as long. This saves ~9 seconds for a full test suite run, per environment.

## Are there changes in behavior for the user?

No, they just speed up tests.

## Related issue number

–

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [ ] Linux (Ubuntu 18.04, Ubuntu 20.04, Arch): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, qa, docs`
  - [ ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
  - [x] Ubuntu 24.04, py310 
- [ ] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file
