### PR TITLE
Fix "Fetch master branch" workflow step (followup to #545)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -91,7 +91,7 @@ jobs:
       # it runs a "git show" command which will fail if the master branch
       # does not exist locally
       if: >-
-        github.ref_type == 'branch' and
+        github.ref_type == 'branch' &&
         github.ref_name != github.event.repository.default_branch
       env:
         GITHUB_REPOSITORY_DEFAULT_BRANCH: >-

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -90,10 +90,8 @@ jobs:
       # Needed for aiosmtpd.qa.test_0packaging.TestVersion.test_ge_master,
       # it runs a "git show" command which will fail if the master branch
       # does not exist locally
-      run: |
-        if [[ $GITHUB_REF != refs/heads/master ]]; then
-          git fetch origin master:master
-        fi
+      if: github.ref != 'refs/heads/master'
+      run: git fetch origin master:master
     - name: Run unittests
       run: pytest
       env:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -90,7 +90,10 @@ jobs:
       # Needed for aiosmtpd.qa.test_0packaging.TestVersion.test_ge_master,
       # it runs a "git show" command which will fail if the master branch
       # does not exist locally
-      run: git fetch origin master:master        
+      run: |
+        if [[ $GITHUB_REF != refs/heads/master ]]; then
+          git fetch origin master:master
+        fi
     - name: Run unittests
       run: pytest
       env:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -90,8 +90,15 @@ jobs:
       # Needed for aiosmtpd.qa.test_0packaging.TestVersion.test_ge_master,
       # it runs a "git show" command which will fail if the master branch
       # does not exist locally
-      if: github.ref != 'refs/heads/master'
-      run: git fetch origin master:master
+      if: >-
+        github.ref_type == 'branch' and
+        github.ref_name != github.event.repository.default_branch
+      env:
+        GITHUB_REPOSITORY_DEFAULT_BRANCH: >-
+        ${{ github.event.repository.default_branch }}
+      run: >-
+        git fetch origin
+        "${GITHUB_REPOSITORY_DEFAULT_BRANCH}:${GITHUB_REPOSITORY_DEFAULT_BRANCH}" 
     - name: Run unittests
       run: pytest
       env:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -95,7 +95,7 @@ jobs:
         github.ref_name != github.event.repository.default_branch
       env:
         GITHUB_REPOSITORY_DEFAULT_BRANCH: >-
-        ${{ github.event.repository.default_branch }}
+          ${{ github.event.repository.default_branch }}
       run: >-
         git fetch origin
         "${GITHUB_REPOSITORY_DEFAULT_BRANCH}:${GITHUB_REPOSITORY_DEFAULT_BRANCH}" 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

PR #545 unfortunately broke CI when pushing to master. If the master branch is already checked out, then running

```
git fetch origin master:master
```

results in an error. I added a conditional, borrowed from the same workflow, lint task:

```
      run: |
        if [[ $GITHUB_REF != refs/heads/master ]]; then
          git fetch origin master:master
        fi
```

## Are there changes in behavior for the user?

No, it hopefully fixes CI but does not affect user-facing code.

## Related issue number

#545 

## Checklist

- [ ] I think the code is well written (but I thought so the last time too :-/)
