### PR TITLE
tox docs: require Python 3.11 for Sphinx 8.2.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -117,7 +117,7 @@ deps =
     #pytype
 
 [testenv:docs]
-basepython = python3
+basepython = python3.11
 envdir = {toxworkdir}/docs
 commands =
     python housekeep.py prep


### PR DESCRIPTION
## What do these changes do?
Sphinx 8.2.0 requires Python 3.11+. Set basepython to python3.11 to prevent installation failures on older Python versions.
## Are there changes in behavior for the user?
No.
## Related issue number
Related https://github.com/aio-libs/aiosmtpd/issues/544.
## Checklist
- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [x] Linux (Ubuntu 18.04, Ubuntu 20.04, Arch): `docs`
  - [ ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- [ ] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file