### PR TITLE
docs/_exts/autoprogramm: replace imp

### DIFF
--- a/aiosmtpd/docs/_exts/autoprogramm.py
+++ b/aiosmtpd/docs/_exts/autoprogramm.py
@@ -160,14 +160,14 @@ def import_object(import_name: str) -> Any:
         # an ImportError as it did before.
         import glob
         import sys
-        import imp
+        import types
 
         for p in sys.path:
             f = glob.glob(os.path.join(p, module_name))
             if len(f) > 0:
                 with open(f[0]) as fobj:
                     codestring = fobj.read()
-                foo = imp.new_module("foo")
+                foo = types.ModuleType("foo")
                 # noinspection BuiltinExec
                 exec(codestring, foo.__dict__)  # noqa: DUO105  # nosec
 


### PR DESCRIPTION
## What do these changes do?
The imp module was removed in python 3.12. Replace use of imp.new_module with types.ModuleTypeApply. This is the same change as upstream sphinx-contib/autoprogram used in https://github.com/sphinx-contrib/autoprogram/commit/79cfb42f5dc3a57ff9cac249f98fe3577cea4d8c.
## Are there changes in behavior for the user?
No.
## Related issue number
Related https://github.com/aio-libs/aiosmtpd/issues/544.
## Checklist
- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [x] Linux (Ubuntu 18.04, Ubuntu 20.04, Arch): `docs`
  - [ ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- [ ] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file