### PR TITLE
tox qa: add pytest-cov and --no-cov flag

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -104,7 +104,7 @@ commands =
     python -m flake8 --version
     python -m flake8 aiosmtpd setup.py housekeep.py release.py
     check-manifest -v
-    pytest -v --tb=short aiosmtpd/qa
+    pytest -v --no-cov --tb=short aiosmtpd/qa
     # Disabled for now because pytype blows up in Windows
     #pytype --keep-going --jobs auto .
 deps =
@@ -112,6 +112,7 @@ deps =
     flake8>=5.0.4
     {[flake8_plugins]deps}
     pytest
+    pytest-cov
     check-manifest
     # Disabled for now because pytype blows up in Windows
     #pytype


### PR DESCRIPTION
## What do these changes do?
The pytest.ini addopts include --cov which is unrecognized when pytest-cov is not installed. Add pytest-cov to deps and use --no-cov flag to disable coverage for qa tests.
## Are there changes in behavior for the user?
No.
## Related issue number
Related https://github.com/aio-libs/aiosmtpd/issues/544.
## Checklist
- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [x] Linux (Ubuntu 18.04, Ubuntu 20.04, Arch): `qa`
  - [ ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- [ ] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file