### PR TITLE
Speed up test_starttls.py::TestTLSEnding::test_eof_received

### DIFF
--- a/aiosmtpd/tests/test_starttls.py
+++ b/aiosmtpd/tests/test_starttls.py
@@ -218,25 +218,20 @@ class TestTLSEnding:
         # I suspect it's a race condition, but with what, and how to prevent that from
         # happening, that's ... a mystery.
 
-        # Entering portion of code where hang is possible (upon assertion fail), so
-        # we must wrap with "try..finally".
-        try:
-            code, mesg = client.ehlo("example.com")
-            assert code == 250
-            resp = client.starttls()
-            assert resp == S.S220_READY_TLS
-            # Need this to make SMTP update its internal session variable
-            code, mesg = client.ehlo("example.com")
-            assert code == 250
-            sess: Sess_ = tls_controller.smtpd.session
-            assert sess.ssl is not None
-            client.noop()
-            catchup_delay()
-            handler: EOFingHandler = tls_controller.handler
-            assert handler.ssl_existed is True
-            assert handler.result is False
-        finally:
-            tls_controller.stop()
+        code, mesg = client.ehlo("example.com")
+        assert code == 250
+        resp = client.starttls()
+        assert resp == S.S220_READY_TLS
+        # Need this to make SMTP update its internal session variable
+        code, mesg = client.ehlo("example.com")
+        assert code == 250
+        sess: Sess_ = tls_controller.smtpd.session
+        assert sess.ssl is not None
+        client.noop()
+        catchup_delay()
+        handler: EOFingHandler = tls_controller.handler
+        assert handler.ssl_existed is True
+        assert handler.result is False
 
     @handler_data(class_=ExceptionCaptureHandler)
     def test_tls_handshake_failing(self, tls_controller, client):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

It fixes a 30 second delay in `aiosmtpd/tests/test_starttls.py::TestTLSEnding::test_eof_received`.

The contents of the test case was wrapped in `try ... finally`, and the `finally` block runs `  tls_controller.stop()`. The `finally` block is where the 30 seconds were spent. 

The `tls_controller` is prepared by a pytest fixture which also takes care of closing it so I suspect the `finally` block was not doing anything useful anyway. 

After removing `try .. finally` tests on all platforms still pass, and the 30 second delay is gone.

## Are there changes in behavior for the user?

No, it speeds up a single slow test.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Use the "closing keywords" such as "Closes" or "Fixes" to automatically link to Issues. -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [ ] Linux (Ubuntu 18.04, Ubuntu 20.04, Arch): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, qa, docs`
  - [ ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- [ ] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file
