### PR TITLE
Resolve all flake8 errors

### DIFF
--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -419,12 +419,10 @@ class TestUnthreaded:
             catchup_delay()
 
         def joiner(timeout: Optional[float] = None):
-            nonlocal thread
             assert isinstance(thread, Thread)
             thread.join(timeout=timeout)
 
         def is_alive():
-            nonlocal thread
             assert isinstance(thread, Thread)
             return thread.is_alive()
 

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -1917,7 +1917,7 @@ class TestTimeout(_CommonMethods):
 
 class TestAuthArgs:
     def test_warn_authreqnotls(self, caplog):
-        with pytest.warns(UserWarning) as record:
+        with pytest.warns(UserWarning, match="Requiring AUTH") as record:
             _ = Server(Sink(), auth_required=True, auth_require_tls=False)
         for warning in record:
             if warning.message.args and (

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -1036,7 +1036,8 @@ class TestAuthMechanisms(_CommonMethods):
         client.password = PW
         auth_meth = getattr(client, "auth_" + mechanism)
         if (mechanism, init_resp) == ("login", False) and (
-                (3, 9, 0) < sys.version_info < (3, 9, 4)):
+            (3, 9, 0) < sys.version_info < (3, 9, 4)
+        ):
             # The bug with SMTP.auth_login was fixed in Python 3.10 and backported
             # to 3.9.4
             # See https://github.com/python/cpython/pull/24118 for the fixes.:

--- a/aiosmtpd/tests/test_smtpsmuggling.py
+++ b/aiosmtpd/tests/test_smtpsmuggling.py
@@ -5,6 +5,7 @@
 
 import smtplib
 import re
+import typing as _t
 
 from aiosmtpd.testing.helpers import ReceivingHandler
 from aiosmtpd.testing.statuscodes import SMTP_STATUS_CODES as S
@@ -12,7 +13,7 @@ from aiosmtpd.testing.statuscodes import SMTP_STATUS_CODES as S
 from .conftest import handler_data
 
 
-def new_data(self, msg):
+def new_data(self: object, msg: bytes) -> tuple[int, bytes]:
     self.putcmd("data")
     (code, repl) = self.getreply()
     if self.debuglevel > 0:
@@ -28,7 +29,7 @@ def new_data(self, msg):
         return (code, msg)
 
 
-def orig_data(self, msg):
+def orig_data(self: object, msg: _t.Union[str, bytes]) -> tuple[int, bytes]:
     self.putcmd("data")
     (code, repl) = self.getreply()
     if self.debuglevel > 0:
@@ -50,21 +51,21 @@ def orig_data(self, msg):
         return (code, msg)
 
 
-def _fix_eols(data):
+def _fix_eols(data: str) -> str:
     return re.sub(r'(?:\r\n|\n|\r(?!\n))', smtplib.CRLF, data)
 
 
-def _quote_periods(bindata):
+def _quote_periods(bindata: bytes) -> bytes:
     return re.sub(br'(?m)^\.', b'..', bindata)
 
 
-def return_unchanged(data):
+def return_unchanged(data: bytes) -> bytes:
     return data
 
 
 class TestSmuggling:
     @handler_data(class_=ReceivingHandler)
-    def test_smtp_smuggling(self, plain_controller, client):
+    def test_smtp_smuggling(self: object, plain_controller: _t.Any, client: _t.Any) -> None:
         smtplib._fix_eols = return_unchanged
         smtplib._quote_periods = return_unchanged
         smtplib.SMTP.data = new_data

--- a/setup.cfg
+++ b/setup.cfg
@@ -96,6 +96,12 @@ ignore =
     PT004
     # Sometimes exception needs to be explicitly raised in special circumstances, needing additional lines of code
     PT012
+    # I still can't grok the need to annotate "self" or "cls" ...
+    ANN101
+    ANN102
+    # I don't think forcing annotation for *args and **kwargs is a wise idea...
+    ANN002
+    ANN003
     # We have too many "if..elif..else: raise" structures that does not convert well to "error-first" design
     SIM106
     # We have too many 'Any' type annotations.
@@ -111,9 +117,12 @@ ignore =
     # Explicit is better than implicit, range(0, val) is more explicit than range(val).
     PIE808
 per-file-ignores =
+    # FIXME add the 45 missing type annotations
+    aiosmtpd/tests/test_*:ANN001
     # S101: Pytest uses assert
     aiosmtpd/tests/*:S101
     aiosmtpd/tests/test_proxyprotocol.py:DUO102
+    aiosmtpd/qa/*:TAE001
     aiosmtpd/docs/_exts/autoprogramm.py:C801
 # flake8-coding
 no-accept-encodings = True
@@ -124,6 +133,12 @@ copyright-min-file-size = 44
 copyright-author = The aiosmtpd Developers
 # flake8-annotations-complexity
 max-annotations-complexity = 4
+# flake8-annotations-coverage
+min-coverage-percents = 12
+# flake8-annotations
+suppress-none-returning = True
+suppress-dummy-args = True
+allow-untyped-defs = True
 
 # flake8-import-order
 application-import-names = aiosmtpd


### PR DESCRIPTION
## What do these changes do?
Restore flake8 related settings removed in commit https://github.com/aio-libs/aiosmtpd/commit/8d81f96f3d91de995ecbcae01805f21a71410790 reducing the number of flake8 errors from 1775 to 4. The remaining 4 flake8 errors are each fixed in their own commit.

## Are there changes in behavior for the user?
No.
## Related issue number
Related https://github.com/aio-libs/aiosmtpd/issues/544.
## Checklist
- [x] I think the code is well written
- [] Unit tests for the changes exist
- [x] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [x] Linux (Ubuntu 18.04, Ubuntu 20.04, Arch): `qa`
  - [ ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- [ ] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file
  <!-- Delete the following bullet points prior to submitting the PR -->
  * Add under the "aiosmtpd-next" section, creating one if necessary
    * You may create subsections to group the changes, if you like
  * Use full sentences with correct case and punctuation
  * Refer to relevant Issue if applicable
