### PR TITLE
Silence bandit warnings about random usage in test_proxyprotocol.py

### DIFF
--- a/aiosmtpd/tests/test_proxyprotocol.py
+++ b/aiosmtpd/tests/test_proxyprotocol.py
@@ -518,8 +518,8 @@ class TestGetV1(_TestProxyProtocolCommon):
 
     def test_tcp4_random(self, setup_proxy_protocol):
         setup_proxy_protocol(self)
-        srcip = ".".join(f"{random.getrandbits(8)}" for _ in range(0, 4))
-        dstip = ".".join(f"{random.getrandbits(8)}" for _ in range(0, 4))
+        srcip = ".".join(f"{random.getrandbits(8)}" for _ in range(0, 4)) # nosec
+        dstip = ".".join(f"{random.getrandbits(8)}" for _ in range(0, 4)) # nosec
         srcport = random_port()
         dstport = random_port()
         prox_test = f"PROXY TCP4 {srcip} {dstip} {srcport} {dstport}\r\n"
@@ -539,8 +539,8 @@ class TestGetV1(_TestProxyProtocolCommon):
         )
 
     def test_tcp6_random(self, setup_proxy_protocol):
-        srcip = ":".join(f"{random.getrandbits(16):04x}" for _ in range(0, 8))
-        dstip = ":".join(f"{random.getrandbits(16):04x}" for _ in range(0, 8))
+        srcip = ":".join(f"{random.getrandbits(16):04x}" for _ in range(0, 8)) # nosec
+        dstip = ":".join(f"{random.getrandbits(16):04x}" for _ in range(0, 8)) # nosec
         srcport = random_port()
         dstport = random_port()
         prox_test = f"PROXY TCP6 {srcip} {dstip} {srcport} {dstport}\r\n"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

I added `# nosec` in `test_proxyprotocol.py` in the places where `random.getrandbits` is used.

Bandit warns that standard pseudo-random generators are not suitable for security/cryptographic purposes. The `random.getrandbits()` usage in the test case is questionable (it makes the test non-deterministic) but, in any case, it is not used for security/cryptographic purpose.

After applying these changes, bandit does not produce any warnings, and tox can proceed to running tests. Before, I could not get tox to run tests because it would exit early due to bandit warnings. The only environment I could run tests was py310 because `tox.ini` is configured to not run bandit on `py310`. 

As an alternative to adding `# nosec`, perhaps the  `test_tcp4_random` and `test_tcp6_random` test cases can be removed altogether?

## Are there changes in behavior for the user?

No, the only changes are in tests.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Use the "closing keywords" such as "Closes" or "Fixes" to automatically link to Issues. -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [x] Linux (Ubuntu 24.04)
  - [ ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- [ ] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file
  <!-- Delete the following bullet points prior to submitting the PR -->
  * Add under the "aiosmtpd-next" section, creating one if necessary
    * You may create subsections to group the changes, if you like
  * Use full sentences with correct case and punctuation
  * Refer to relevant Issue if applicable
