### PR TITLE
Drop py38 references from tox.ini and README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ Supported Platforms
 ``aiosmtpd`` has been tested on **CPython**>=3.9 and |PyPy|_>=3.9
 for the following platforms (in alphabetical order):
 
-* Cygwin (as of 2022-12-22, only for CPython 3.8, and 3.9)
+* Cygwin (as of 2022-12-22, only for CPython 3.9)
 * MacOS 11 and 12
 * Ubuntu 18.04
 * Ubuntu 20.04
@@ -170,7 +170,7 @@ In general, the ``-e`` parameter to tox specifies one (or more) **testenv**
 to run (separate using comma if more than one testenv). The following testenvs
 have been configured and tested:
 
-* ``{py38,py39,py310,py311,py312,pypy3,pypy311}-{nocov,cov,diffcov,profile}``
+* ``{py39,py310,py311,py312,pypy3,pypy311}-{nocov,cov,diffcov,profile}``
 
   Specifies the interpreter to run and the kind of testing to perform.
 
@@ -183,7 +183,7 @@ have been configured and tested:
     This must be **invoked manually** using the ``-e`` parameter
 
   **Note 1:** As of 2021-02-23,
-  only the ``{py38,py39}-{nocov,cov}`` combinations work on **Cygwin**.
+  only the ``{py39}-{nocov,cov}`` combinations work on **Cygwin**.
 
   **Note 2:** It is also possible to use whatever Python version is used when
   invoking ``tox`` by using the ``py`` target, but you must explicitly include

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.9.0
-envlist = qa, static, docs, py{38,39,310,311,312,py3}-{nocov,cov,diffcov}
+envlist = qa, static, docs, py{39,310,311,312,py3}-{nocov,cov,diffcov}
 skip_missing_interpreters = True
 
 [testenv]
@@ -36,7 +36,6 @@ deps =
 setenv =
     cov: COVERAGE_FILE={toxinidir}/_dump/.coverage
     nocov: PYTHONASYNCIODEBUG=1
-    py38: INTERP=py38
     py39: INTERP=py39
     py310: INTERP=py310
     py311: INTERP=py311


### PR DESCRIPTION
## What do these changes do?

Now that Python 3.8 support is removed, remove it from the tox.ini testing matrix, and its mentions from README.

## Are there changes in behavior for the user?

No.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Use the "closing keywords" such as "Closes" or "Fixes" to automatically link to Issues. -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [ ] Linux (Ubuntu 18.04, Ubuntu 20.04, Arch): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, qa, docs`
  - [ ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- [ ] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file
  <!-- Delete the following bullet points prior to submitting the PR -->
  * Add under the "aiosmtpd-next" section, creating one if necessary
    * You may create subsections to group the changes, if you like
  * Use full sentences with correct case and punctuation
  * Refer to relevant Issue if applicable
