### PR TITLE
Update UnixSocketMixin to disable socket cleanup on Py >= 3.13

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -66,7 +66,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        pyver: ['3.9', '3.10', '3.11', '3.12']
+        pyver: ['3.9', '3.10', '3.11', '3.12', '3.13']
         os: [ubuntu, macos, windows]
         include:
           - pyver: pypy-3.11

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -5,6 +5,7 @@ import asyncio
 import errno
 import os
 import ssl
+import sys
 import threading
 import time
 from abc import ABCMeta, abstractmethod
@@ -447,10 +448,18 @@ class UnixSocketMixin(BaseController, metaclass=ABCMeta):  # pragma: no-unixsock
         Does NOT actually start the protocol object itself;
         _factory_invoker() is only called upon fist connection attempt.
         """
+        kw = {}
+        if sys.version_info >= (3, 13, 0):
+            # Starting from python 3.13, the unix listener automatically
+            # cleans up its socket from the filesystem on shutdown. This can
+            # be disabled by passing in cleanup_socket=False. We do that here to keep
+            # the shutdown behavior consistent between Python versions.
+            kw["cleanup_socket"] = False
         return self.loop.create_unix_server(
             self._factory_invoker,
             path=self.unix_socket,
             ssl=self.ssl_context,
+            **kw
         )
 
     def _trigger_server(self):

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -459,7 +459,7 @@ class UnixSocketMixin(BaseController, metaclass=ABCMeta):  # pragma: no-unixsock
                 ssl=self.ssl_context,
                 # Silence mypy warning as cleanup_socket is not yet annotated in
                 # typeshed: https://github.com/python/typeshed/issues/15742
-                cleanup_socket=False, # type: ignore[call-arg]
+                cleanup_socket=False,  # type: ignore[call-arg]
             )
 
         return self.loop.create_unix_server(

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -448,18 +448,24 @@ class UnixSocketMixin(BaseController, metaclass=ABCMeta):  # pragma: no-unixsock
         Does NOT actually start the protocol object itself;
         _factory_invoker() is only called upon fist connection attempt.
         """
-        kw = {}
         if sys.version_info >= (3, 13, 0):
             # Starting from python 3.13, the unix listener automatically
             # cleans up its socket from the filesystem on shutdown. This can
             # be disabled by passing in cleanup_socket=False. We do that here to keep
             # the shutdown behavior consistent between Python versions.
-            kw["cleanup_socket"] = False
+            return self.loop.create_unix_server(
+                self._factory_invoker,
+                path=self.unix_socket,
+                ssl=self.ssl_context,
+                # Silence mypy warning as cleanup_socket is not yet annotated in
+                # typeshed: https://github.com/python/typeshed/issues/15742
+                cleanup_socket=False, # type: ignore[call-arg]
+            )
+
         return self.loop.create_unix_server(
             self._factory_invoker,
             path=self.unix_socket,
             ssl=self.ssl_context,
-            **kw
         )
 
     def _trigger_server(self):

--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -306,7 +306,10 @@ class TestController:
             cont.stop()
 
     def test_testconn_raises(self, mocker: MockFixture):
-        mocker.patch("socket.socket.recv", side_effect=RuntimeError("MockError"))
+        mocker.patch(
+            "aiosmtpd.controller.create_connection",
+            side_effect=RuntimeError("MockError"),
+        )
         cont = Controller(Sink(), hostname="")
         try:
             with pytest.raises(RuntimeError, match="MockError"):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This change fixes the only failing test on Python 3.13:

```
aiosmtpd/tests/test_server.py::TestUnthreaded::test_unixsocket
```

This test starts an Unix listener, exercises it, closes it and checks if the socket still exists on the filesystem. The socket does exist on Python 3.12 and below (the test passes), but does not exist on Python 3.13 (the test fails). 

This is because Python added automatic socket cleanup: https://github.com/python/cpython/issues/111246

There's a new `cleanup_socket=False` argument for `create_unix_server` which restores the old behavior ([docs](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.create_unix_server)). I think it makes sense for aiosmtpd to use it, to keep the shutdown behavior consistent between Python versions.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

Yes:

* before the change, on Python 3.13, if the library user starts and stops a unix socket listener, the socket is automatically cleaned up.
* after the change, on Python 3.13, if the library user starts and stops a unix socket listener, the socket is left on the filesystem (matching the Python 3.12 and below behavior).

There's no change when using Python 3.12 and below.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Use the "closing keywords" such as "Closes" or "Fixes" to automatically link to Issues. -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [x] Ubuntu 24.04, python 3.12 and python 3.13
- [ ] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file
