### PR TITLE
Fix tests to support parallel execution with pytest-xdist

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -100,7 +100,7 @@ jobs:
         git fetch origin
         "${GITHUB_REPOSITORY_DEFAULT_BRANCH}:${GITHUB_REPOSITORY_DEFAULT_BRANCH}" 
     - name: Run unittests
-      run: pytest -n auto
+      run: pytest
       env:
         COLOR: 'yes'
     - run: python -m coverage xml

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -100,7 +100,7 @@ jobs:
         git fetch origin
         "${GITHUB_REPOSITORY_DEFAULT_BRANCH}:${GITHUB_REPOSITORY_DEFAULT_BRANCH}" 
     - name: Run unittests
-      run: pytest
+      run: pytest -n auto
       env:
         COLOR: 'yes'
     - run: python -m coverage xml

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -467,7 +467,7 @@ class InetMixin(BaseController, metaclass=ABCMeta):
         # addresses). In such case, it should be safe to connect to localhost)
         hostname = self.hostname or self._localhost
         with ExitStack() as stk:
-            assert self.port
+            assert self.port is not None
             s = stk.enter_context(create_connection((hostname, self.port), 1.0))
             if self.ssl_context:
                 client_ctx = _server_to_client_ssl_ctx(self.ssl_context)

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -397,7 +397,7 @@ class InetMixin(BaseController, metaclass=ABCMeta):
         self.requested_port = port
 
     @property
-    def hostname(self) -> Optional[str]:
+    def hostname(self) -> Union[str, None]:
         """Return the hostname the server is listening on.
 
         If the server is not currently listening on any sockets, return None.
@@ -419,7 +419,7 @@ class InetMixin(BaseController, metaclass=ABCMeta):
         return None
 
     @property
-    def port(self) -> Optional[int]:
+    def port(self) -> Union[int, None]:
         """Return the port the server is listening on.
 
         If the server is not currently listening on any sockets, return None.

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -393,8 +393,55 @@ class InetMixin(BaseController, metaclass=ABCMeta):
             **kwargs,
         )
         self._localhost = get_localhost()
-        self.hostname = self._localhost if hostname is None else hostname
-        self.port = port
+        self.requested_hostname = self._localhost if hostname is None else hostname
+        self.requested_port = port
+
+    @property
+    def hostname(self) -> Optional[str]:
+        """Return the hostname the server is listening on.
+
+        If the server is not currently listening on any sockets, return None.
+
+        If an empty hostname parameter was passed to the controller's constuctor
+        then the server is running on all available interfaces, that may have
+        different hostnames. For example, "127.0.0.1" and "::". This property
+        returns the hostname of the first listening socket, but the order of
+        listening sockets is not defined.
+
+        To access the hostname parameter that was passed in to controller's
+        constructor, use `self.requested_hostname`.
+
+        """
+        if isinstance(self.server, asyncio.Server):
+            socket = self.server.sockets[0]
+            addr = socket.getsockname()
+            return addr[0]
+        return None
+
+    @property
+    def port(self) -> Optional[int]:
+        """Return the port the server is listening on.
+
+        If the server is not currently listening on any sockets, return None.
+
+        If port=0 was passed to the controller's constuctor then the server picks
+        a random unused port. This property will return the port that was picked.
+
+        If port=0 *and* an empty hostname parameter was passed to the controller's
+        constuctor then the server is running on all available interfaces, and
+        on a different randomly chosen port on each. This property returns the
+        port of the first listening socket, but the order of listening sockets is
+        not defined.
+
+        To access the port parameter that was passed in to controller's
+        constructor, use `self.requested_port`.
+
+        """
+        if isinstance(self.server, asyncio.Server):
+            socket = self.server.sockets[0]
+            addr = socket.getsockname()
+            return addr[1]
+        return None
 
     def _create_server(self) -> Awaitable[asyncio.AbstractServer]:
         """
@@ -404,8 +451,8 @@ class InetMixin(BaseController, metaclass=ABCMeta):
         """
         return self.loop.create_server(
             self._factory_invoker,
-            host=self.hostname,
-            port=self.port,
+            host=self.requested_hostname,
+            port=self.requested_port,
             ssl=self.ssl_context,
         )
 
@@ -419,6 +466,7 @@ class InetMixin(BaseController, metaclass=ABCMeta):
         # addresses). In such case, it should be safe to connect to localhost)
         hostname = self.hostname or self._localhost
         with ExitStack() as stk:
+            assert self.port
             s = stk.enter_context(create_connection((hostname, self.port), 1.0))
             if self.ssl_context:
                 client_ctx = _server_to_client_ssl_ctx(self.ssl_context)

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -397,7 +397,12 @@ class InetMixin(BaseController, metaclass=ABCMeta):
         self.requested_port = port
 
     @property
-    def hostname(self) -> Union[str, None]:
+    def _active_addr(self) -> tuple[str, int]:
+        socket = self.server.sockets[0]
+        return socket.getsockname()
+
+    @property
+    def hostname(self) -> Optional[str]:
         """Return the hostname the server is listening on.
 
         If the server is not currently listening on any sockets, return None.
@@ -412,15 +417,15 @@ class InetMixin(BaseController, metaclass=ABCMeta):
         constructor, use `self.requested_hostname`.
 
         """
+
         if not isinstance(self.server, asyncio.Server):
             return None
 
-        socket = self.server.sockets[0]
-        addr = socket.getsockname()
-        return addr[0]
+
+        return self._active_addr[0]
 
     @property
-    def port(self) -> Union[int, None]:
+    def port(self) -> Optional[int]:
         """Return the port the server is listening on.
 
         If the server is not currently listening on any sockets, return None.
@@ -438,12 +443,11 @@ class InetMixin(BaseController, metaclass=ABCMeta):
         constructor, use `self.requested_port`.
 
         """
+
         if not isinstance(self.server, asyncio.Server):
             return None
 
-        socket = self.server.sockets[0]
-        addr = socket.getsockname()
-        return addr[1]
+        return self._active_addr[1]
 
     def _create_server(self) -> Awaitable[asyncio.AbstractServer]:
         """

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -437,11 +437,12 @@ class InetMixin(BaseController, metaclass=ABCMeta):
         constructor, use `self.requested_port`.
 
         """
-        if isinstance(self.server, asyncio.Server):
-            socket = self.server.sockets[0]
-            addr = socket.getsockname()
-            return addr[1]
-        return None
+        if not isinstance(self.server, asyncio.Server):
+            return None
+
+        socket = self.server.sockets[0]
+        addr = socket.getsockname()
+        return addr[1]
 
     def _create_server(self) -> Awaitable[asyncio.AbstractServer]:
         """

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -412,11 +412,12 @@ class InetMixin(BaseController, metaclass=ABCMeta):
         constructor, use `self.requested_hostname`.
 
         """
-        if isinstance(self.server, asyncio.Server):
-            socket = self.server.sockets[0]
-            addr = socket.getsockname()
-            return addr[0]
-        return None
+        if not isinstance(self.server, asyncio.Server):
+            return None
+
+        socket = self.server.sockets[0]
+        addr = socket.getsockname()
+        return addr[0]
 
     @property
     def port(self) -> Union[int, None]:

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -397,7 +397,10 @@ class InetMixin(BaseController, metaclass=ABCMeta):
         self.requested_port = port
 
     @property
-    def _active_addr(self) -> tuple[str, int]:
+    def _active_addr(self) -> Union[tuple[str, int], tuple[None, None]]:
+        if not isinstance(self.server, asyncio.Server):
+            return (None, None)
+
         socket = self.server.sockets[0]
         return socket.getsockname()
 
@@ -417,10 +420,6 @@ class InetMixin(BaseController, metaclass=ABCMeta):
         constructor, use `self.requested_hostname`.
 
         """
-
-        if not isinstance(self.server, asyncio.Server):
-            return None
-
 
         return self._active_addr[0]
 
@@ -443,9 +442,6 @@ class InetMixin(BaseController, metaclass=ABCMeta):
         constructor, use `self.requested_port`.
 
         """
-
-        if not isinstance(self.server, asyncio.Server):
-            return None
 
         return self._active_addr[1]
 

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -399,7 +399,7 @@ class InetMixin(BaseController, metaclass=ABCMeta):
     @property
     def _active_addr(self) -> tuple[str, int]:
         if not isinstance(self.server, asyncio.Server):
-            raise ConnectionError("The server is currently not listening on any port")
+            raise RuntimeError("The server is currently not listening on any port")
 
         socket = self.server.sockets[0]
         return socket.getsockname()
@@ -409,7 +409,7 @@ class InetMixin(BaseController, metaclass=ABCMeta):
         """Return the hostname the server is listening on.
 
         If the server is not currently listening on any sockets,
-        raise ConnectionError.
+        raise RuntimeError.
 
         If an empty hostname parameter was passed to the controller's constuctor
         then the server is running on all available interfaces, that may have
@@ -429,7 +429,7 @@ class InetMixin(BaseController, metaclass=ABCMeta):
         """Return the port the server is listening on.
 
         If the server is not currently listening on any sockets,
-        raise ConnectionError.
+        raise RuntimeError.
 
         If port=0 was passed to the controller's constuctor then the server picks
         a random unused port. This property will return the port that was picked.

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -399,7 +399,7 @@ class InetMixin(BaseController, metaclass=ABCMeta):
     @property
     def _active_addr(self) -> tuple[str, int]:
         if not isinstance(self.server, asyncio.Server):
-            raise RuntimeError("The server is currently not listening on any socket")
+            raise RuntimeError("The server is currently not listening to any socket")
 
         socket = self.server.sockets[0]
         return socket.getsockname()

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -399,7 +399,7 @@ class InetMixin(BaseController, metaclass=ABCMeta):
     @property
     def _active_addr(self) -> tuple[str, int]:
         if not isinstance(self.server, asyncio.Server):
-            raise RuntimeError("The server is currently not listening on any port")
+            raise RuntimeError("The server is currently not listening on any socket")
 
         socket = self.server.sockets[0]
         return socket.getsockname()

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -397,18 +397,19 @@ class InetMixin(BaseController, metaclass=ABCMeta):
         self.requested_port = port
 
     @property
-    def _active_addr(self) -> Union[tuple[str, int], tuple[None, None]]:
+    def _active_addr(self) -> tuple[str, int]:
         if not isinstance(self.server, asyncio.Server):
-            return (None, None)
+            raise ConnectionError("The server is currently not listening on any port")
 
         socket = self.server.sockets[0]
         return socket.getsockname()
 
     @property
-    def hostname(self) -> Optional[str]:
+    def hostname(self) -> str:
         """Return the hostname the server is listening on.
 
-        If the server is not currently listening on any sockets, return None.
+        If the server is not currently listening on any sockets,
+        raise ConnectionError.
 
         If an empty hostname parameter was passed to the controller's constuctor
         then the server is running on all available interfaces, that may have
@@ -424,10 +425,11 @@ class InetMixin(BaseController, metaclass=ABCMeta):
         return self._active_addr[0]
 
     @property
-    def port(self) -> Optional[int]:
+    def port(self) -> int:
         """Return the port the server is listening on.
 
-        If the server is not currently listening on any sockets, return None.
+        If the server is not currently listening on any sockets,
+        raise ConnectionError.
 
         If port=0 was passed to the controller's constuctor then the server picks
         a random unused port. This property will return the port that was picked.
@@ -468,7 +470,6 @@ class InetMixin(BaseController, metaclass=ABCMeta):
         # addresses). In such case, it should be safe to connect to localhost)
         hostname = self.hostname or self._localhost
         with ExitStack() as stk:
-            assert self.port is not None
             s = stk.enter_context(create_connection((hostname, self.port), 1.0))
             if self.ssl_context:
                 client_ctx = _server_to_client_ssl_ctx(self.ssl_context)

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -413,7 +413,7 @@ class InetMixin(BaseController, metaclass=ABCMeta):
 
         If an empty hostname parameter was passed to the controller's constuctor
         then the server is running on all available interfaces, that may have
-        different hostnames. For example, "127.0.0.1" and "::". This property
+        different hostnames. For example, "127.0.0.1" and "::1". This property
         returns the hostname of the first listening socket, but the order of
         listening sockets is not defined.
 

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -429,7 +429,7 @@ class InetMixin(BaseController, metaclass=ABCMeta):
         """Return the port the server is listening on.
 
         If the server is not currently listening on any sockets,
-        raise RuntimeError.
+        raise :exc:`RuntimeError`.
 
         If port=0 was passed to the controller's constuctor then the server picks
         a random unused port. This property will return the port that was picked.

--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -441,7 +441,7 @@ class InetMixin(BaseController, metaclass=ABCMeta):
         not defined.
 
         To access the port parameter that was passed in to controller's
-        constructor, use `self.requested_port`.
+        constructor, use ``self.requested_port``.
 
         """
 

--- a/aiosmtpd/docs/controller.rst
+++ b/aiosmtpd/docs/controller.rst
@@ -138,13 +138,14 @@ When you're done with the SMTP server, stop it via the controller.
 
 .. doctest::
 
+    >>> old_port = controller.port
     >>> controller.stop()
 
 The server is guaranteed to be stopped.
 
 .. doctest::
 
-    >>> client.connect(controller.hostname, controller.port)
+    >>> client.connect(controller.hostname, old_port)
     Traceback (most recent call last):
     ...
     ConnectionRefusedError: ...

--- a/aiosmtpd/docs/controller.rst
+++ b/aiosmtpd/docs/controller.rst
@@ -500,7 +500,8 @@ Controller API
     :param hostname: Will be given to the event loop's :meth:`~asyncio.loop.create_server` method
        as the ``host`` parameter, with a slight processing (see below)
     :type hostname: Optional[str]
-    :param port: Will be passed-through to :meth:`~asyncio.loop.create_server` method
+    :param port: Will be passed-through to :meth:`~asyncio.loop.create_server` method.
+        If ``0``, a random unused (ephemeral) port will be selected.
     :type port: int
     :param ready_timeout: How long to wait until server starts.
         The :envvar:`AIOSMTPD_CONTROLLER_TIMEOUT` takes precedence over this parameter.
@@ -548,10 +549,43 @@ Controller API
     In addition to those provided by :class:`BaseController`,
     this class provides the following:
 
-    .. attribute:: hostname: str
-                   port: int
+    .. attribute:: hostname
+        :type: str
 
-        The values of the *hostname* and *port* arguments.
+        The *hostname* of the socket the server is listening on.
+
+        If the server is not running (because it has not been started yet, or has
+        already been stopped), accessing this attribute will raise
+        a :class:`RuntimeError`.
+
+        If an empty hostname parameter was passed to the controller's constuctor
+        then the server is running on all available interfaces, that may have
+        different hostnames. This property returns the hostname of the first listening
+        socket, but the order of listening sockets is not defined.
+
+        To access the hostname parameter that was passed in to this controller's
+        constructor, use :attr:`requested_hostname`.
+
+    .. attribute:: port
+        :type: int
+
+        The *port* of the socket the server is listening on.
+
+        If the server is not running (because it has not been started yet, or has
+        already been stopped), accessing this attribute will raise
+        a :class:`RuntimeError`.
+
+        If ``port=0`` was passed to the controller's constuctor then the server itself
+        picks a random unused port. This property will return the port that was picked.
+
+        If ``port=0`` *and* an empty hostname parameter was passed to the controller's
+        constuctor then the server is running on all available interfaces, and
+        on a different randomly chosen port on each. This property returns the
+        port of the first listening socket, but the order of listening sockets is
+        not defined.
+
+        To access the port parameter that was passed in to this controller's
+        constructor, use :attr:`requested_port`.
 
     .. attribute:: ready_timeout
         :type: float
@@ -568,6 +602,12 @@ Controller API
         so you don't have to wait too long for an exception, if problem arises.
 
         If this timeout is breached, a :class:`TimeoutError` exception will be raised.
+
+    .. attribute:: requested_hostname
+                   requested_port
+
+        The original *hostname* and *port* arguments that were passed to this
+        controller's constructor.
 
     |
     | :part:`Methods`

--- a/aiosmtpd/docs/controller.rst
+++ b/aiosmtpd/docs/controller.rst
@@ -501,7 +501,8 @@ Controller API
        as the ``host`` parameter, with a slight processing (see below)
     :type hostname: Optional[str]
     :param port: Will be passed-through to :meth:`~asyncio.loop.create_server` method.
-        If ``0``, a random unused (ephemeral) port will be selected.
+        If ``0``, the OS kernel will select a random unused (ephemeral) port
+        when the server starts listening to the socket.
     :type port: int
     :param ready_timeout: How long to wait until server starts.
         The :envvar:`AIOSMTPD_CONTROLLER_TIMEOUT` takes precedence over this parameter.

--- a/aiosmtpd/docs/controller.rst
+++ b/aiosmtpd/docs/controller.rst
@@ -138,14 +138,14 @@ When you're done with the SMTP server, stop it via the controller.
 
 .. doctest::
 
-    >>> old_port = controller.port
+    >>> old_hostname, old_port = controller.hostname, controller.port
     >>> controller.stop()
 
 The server is guaranteed to be stopped.
 
 .. doctest::
 
-    >>> client.connect(controller.hostname, old_port)
+    >>> client.connect(old_hostname, old_port)
     Traceback (most recent call last):
     ...
     ConnectionRefusedError: ...

--- a/aiosmtpd/docs/controller.rst
+++ b/aiosmtpd/docs/controller.rst
@@ -557,7 +557,7 @@ Controller API
 
         If the server is not running (because it has not been started yet, or has
         already been stopped), accessing this attribute will raise
-        a :class:`RuntimeError`.
+        a :exc:`RuntimeError`.
 
         If an empty hostname parameter was passed to the controller's constuctor
         then the server is running on all available interfaces, that may have
@@ -574,7 +574,7 @@ Controller API
 
         If the server is not running (because it has not been started yet, or has
         already been stopped), accessing this attribute will raise
-        a :class:`RuntimeError`.
+        a :exc:`RuntimeError`.
 
         If ``port=0`` was passed to the controller's constuctor then the server itself
         picks a random unused port. This property will return the port that was picked.

--- a/aiosmtpd/tests/conftest.py
+++ b/aiosmtpd/tests/conftest.py
@@ -47,8 +47,9 @@ handler_data = pytest.mark.handler_data
 
 
 class HostPort(NamedTuple):
-    host: str = "localhost"
-    port: int = 8025
+    host: str = "127.0.0.1"
+    # port 0 means "pick a random unused port"
+    port: int = 0
 
 
 RT = TypeVar("RT")  # "ReturnType"

--- a/aiosmtpd/tests/conftest.py
+++ b/aiosmtpd/tests/conftest.py
@@ -48,7 +48,7 @@ handler_data = pytest.mark.handler_data
 
 class HostPort(NamedTuple):
     host: str = "127.0.0.1"
-    # port 0 means "pick a random unused port"
+    # port 0 means "pick a random unused (ephemeral) port"
     port: int = 0
 
 

--- a/aiosmtpd/tests/test_lmtp.py
+++ b/aiosmtpd/tests/test_lmtp.py
@@ -24,7 +24,7 @@ class LMTPController(Controller):
 
 @pytest.fixture(scope="module", autouse=True)
 def lmtp_controller() -> Generator[LMTPController, None, None]:
-    controller = LMTPController(Sink)
+    controller = LMTPController(Sink, port=0)
     controller.start()
     Global.set_addr_from(controller)
     #

--- a/aiosmtpd/tests/test_main.py
+++ b/aiosmtpd/tests/test_main.py
@@ -5,6 +5,7 @@ import asyncio
 import logging
 import multiprocessing as MP
 import os
+import random
 import sys
 import time
 from contextlib import contextmanager
@@ -80,6 +81,11 @@ def setuid(mocker: MockFixture):
 
 
 def watch_for_tls(ready_flag: MP_Event, retq: MP.Queue):
+    # Rather than using a hardcoded port, pick a random port,
+    # and send it over the return queue, so the test case can
+    # start a listening socket on this port.
+    port = pick_random_port()
+    retq.put(port)
     has_tls = False
     req_tls = False
     ready_flag.set()
@@ -87,7 +93,7 @@ def watch_for_tls(ready_flag: MP_Event, retq: MP.Queue):
     delay = AUTOSTOP_DELAY * 4
     while (time.monotonic() - start) <= delay:
         try:
-            with SMTPClient("localhost", 8025, timeout=0.1) as client:
+            with SMTPClient("localhost", port, timeout=0.1) as client:
                 resp = client.docmd("HELP", "HELO")
                 if resp == S.S530_STARTTLS_FIRST:
                     req_tls = True
@@ -102,13 +108,18 @@ def watch_for_tls(ready_flag: MP_Event, retq: MP.Queue):
 
 
 def watch_for_smtps(ready_flag: MP_Event, retq: MP.Queue):
+    # Rather than using a hardcoded port, pick a random port,
+    # and send it over the return queue, so the test case can
+    # start a listening socket on this port.
+    port = pick_random_port()
+    retq.put(port)
     has_smtps = False
     ready_flag.set()
     start = time.monotonic()
     delay = AUTOSTOP_DELAY * 1.5
     while (time.monotonic() - start) <= delay:
         try:
-            with SMTP_SSL("localhost", 8025, timeout=0.1) as client:
+            with SMTP_SSL("localhost", port, timeout=0.1) as client:
                 client.ehlo("exemple.org")
                 has_smtps = True
                 break
@@ -132,6 +143,9 @@ def watcher_process(func):
     proc.join()
 
 
+def pick_random_port():
+    return random.randint(32768, 49152)
+
 # endregion
 
 
@@ -139,13 +153,13 @@ def watcher_process(func):
 class TestMain:
     def test_setuid(self, nobody_uid, mocker):
         mock = mocker.patch("os.setuid")
-        main(args=())
+        main(args=("-l", ":0"))
         mock.assert_called_with(nobody_uid)
 
     def test_setuid_permission_error(self, nobody_uid, mocker, capsys):
         mock = mocker.patch("os.setuid", side_effect=PermissionError)
         with pytest.raises(SystemExit) as excinfo:
-            main(args=())
+            main(args=("-l", ":0"))
         assert excinfo.value.code == 1
         mock.assert_called_with(nobody_uid)
         assert (
@@ -156,35 +170,35 @@ class TestMain:
     def test_setuid_no_pwd_module(self, nobody_uid, mocker, capsys):
         mocker.patch("aiosmtpd.main.pwd", None)
         with pytest.raises(SystemExit) as excinfo:
-            main(args=())
+            main(args=("-l", ":0"))
         assert excinfo.value.code == 1
         assert capsys.readouterr().err == 'Cannot import module "pwd"; try running with -n option.\n'
 
     def test_n(self, setuid):
         with pytest.raises(RuntimeError):
-            main_n()
+            main_n("-l", ":0")
 
     def test_nosetuid(self, setuid):
         with pytest.raises(RuntimeError):
-            main(("--nosetuid",))
+            main(("--nosetuid", "-l", ":0"))
 
     def test_debug_0(self):
         # For this test, the test runner likely has already set the log level
         # so it may not be logging.ERROR.
         default_level = MAIL_LOG.getEffectiveLevel()
-        main_n()
+        main_n("-l", ":0")
         assert MAIL_LOG.getEffectiveLevel() == default_level
 
     def test_debug_1(self):
-        main_n("-d")
+        main_n("-d", "-l", ":0")
         assert MAIL_LOG.getEffectiveLevel() == logging.INFO
 
     def test_debug_2(self):
-        main_n("-dd")
+        main_n("-dd", "-l", ":0")
         assert MAIL_LOG.getEffectiveLevel() == logging.DEBUG
 
     def test_debug_3(self):
-        main_n("-ddd")
+        main_n("-ddd", "-l", ":0")
         assert MAIL_LOG.getEffectiveLevel() == logging.DEBUG
         assert asyncio.get_event_loop().get_debug()
 
@@ -193,8 +207,16 @@ class TestMain:
 class TestMainByWatcher:
     def test_tls(self, temp_event_loop, tls_cert_pem_path, tls_key_pem_path):
         with watcher_process(watch_for_tls) as retq:
+            port = retq.get()
             temp_event_loop.call_later(AUTOSTOP_DELAY, temp_event_loop.stop)
-            main_n("--tlscert", tls_cert_pem_path, "--tlskey", tls_key_pem_path)
+            main_n(
+                "--tlscert",
+                tls_cert_pem_path,
+                "--tlskey",
+                tls_key_pem_path,
+                "-l",
+                f":{port}",
+            )
             catchup_delay()
         has_starttls = retq.get()
         assert has_starttls is True
@@ -203,6 +225,7 @@ class TestMainByWatcher:
 
     def test_tls_noreq(self, temp_event_loop, tls_cert_pem_path, tls_key_pem_path):
         with watcher_process(watch_for_tls) as retq:
+            port = retq.get()
             temp_event_loop.call_later(AUTOSTOP_DELAY, temp_event_loop.stop)
             main_n(
                 "--tlscert",
@@ -210,6 +233,8 @@ class TestMainByWatcher:
                 "--tlskey",
                 tls_key_pem_path,
                 "--no-requiretls",
+                "-l",
+                f":{port}",
             )
             catchup_delay()
         has_starttls = retq.get()
@@ -219,8 +244,16 @@ class TestMainByWatcher:
 
     def test_smtps(self, temp_event_loop, tls_cert_pem_path, tls_key_pem_path):
         with watcher_process(watch_for_smtps) as retq:
+            port = retq.get()
             temp_event_loop.call_later(AUTOSTOP_DELAY, temp_event_loop.stop)
-            main_n("--smtpscert", tls_cert_pem_path, "--smtpskey", tls_key_pem_path)
+            main_n(
+                "--smtpscert",
+                tls_cert_pem_path,
+                "--smtpskey",
+                tls_key_pem_path,
+                "-l",
+                f":{port}",
+            )
             catchup_delay()
         has_smtps = retq.get()
         assert has_smtps is True
@@ -355,7 +388,7 @@ class TestSigint:
 
         temp_event_loop.call_later(1.0, interrupt)
         try:
-            main_n()
+            main_n("-l", ":0")
         except Exception:
             pytest.fail("main() should've closed cleanly without exceptions!")
         else:

--- a/aiosmtpd/tests/test_main.py
+++ b/aiosmtpd/tests/test_main.py
@@ -153,13 +153,13 @@ def pick_random_port():
 class TestMain:
     def test_setuid(self, nobody_uid, mocker):
         mock = mocker.patch("os.setuid")
-        main(args=("-l", ":0"))
+        main(args=("--listen=:0",))
         mock.assert_called_with(nobody_uid)
 
     def test_setuid_permission_error(self, nobody_uid, mocker, capsys):
         mock = mocker.patch("os.setuid", side_effect=PermissionError)
         with pytest.raises(SystemExit) as excinfo:
-            main(args=("-l", ":0"))
+            main(args=("--listen=:0",))
         assert excinfo.value.code == 1
         mock.assert_called_with(nobody_uid)
         assert (
@@ -170,35 +170,35 @@ class TestMain:
     def test_setuid_no_pwd_module(self, nobody_uid, mocker, capsys):
         mocker.patch("aiosmtpd.main.pwd", None)
         with pytest.raises(SystemExit) as excinfo:
-            main(args=("-l", ":0"))
+            main(args=("--listen=:0",))
         assert excinfo.value.code == 1
         assert capsys.readouterr().err == 'Cannot import module "pwd"; try running with -n option.\n'
 
     def test_n(self, setuid):
         with pytest.raises(RuntimeError):
-            main_n("-l", ":0")
+            main_n("--listen=:0")
 
     def test_nosetuid(self, setuid):
         with pytest.raises(RuntimeError):
-            main(("--nosetuid", "-l", ":0"))
+            main(("--nosetuid", "--listen=:0"))
 
     def test_debug_0(self):
         # For this test, the test runner likely has already set the log level
         # so it may not be logging.ERROR.
         default_level = MAIL_LOG.getEffectiveLevel()
-        main_n("-l", ":0")
+        main_n("--listen=:0")
         assert MAIL_LOG.getEffectiveLevel() == default_level
 
     def test_debug_1(self):
-        main_n("-d", "-l", ":0")
+        main_n("--debug", "--listen=:0")
         assert MAIL_LOG.getEffectiveLevel() == logging.INFO
 
     def test_debug_2(self):
-        main_n("-dd", "-l", ":0")
+        main_n("-dd", "--listen=:0")
         assert MAIL_LOG.getEffectiveLevel() == logging.DEBUG
 
     def test_debug_3(self):
-        main_n("-ddd", "-l", ":0")
+        main_n("-ddd", "--listen=:0")
         assert MAIL_LOG.getEffectiveLevel() == logging.DEBUG
         assert asyncio.get_event_loop().get_debug()
 
@@ -379,7 +379,7 @@ class TestSigint:
 
         temp_event_loop.call_later(1.0, interrupt)
         try:
-            main_n("-l", ":0")
+            main_n("--listen=:0")
         except Exception:
             pytest.fail("main() should've closed cleanly without exceptions!")
         else:

--- a/aiosmtpd/tests/test_main.py
+++ b/aiosmtpd/tests/test_main.py
@@ -210,12 +210,9 @@ class TestMainByWatcher:
             port = retq.get()
             temp_event_loop.call_later(AUTOSTOP_DELAY, temp_event_loop.stop)
             main_n(
-                "--tlscert",
-                tls_cert_pem_path,
-                "--tlskey",
-                tls_key_pem_path,
-                "-l",
-                f":{port}",
+                f"--tlscert={tls_cert_pem_path}",
+                f"--tlskey={tls_key_pem_path}",
+                f"--listen=:{port}",
             )
             catchup_delay()
         has_starttls = retq.get()
@@ -228,13 +225,10 @@ class TestMainByWatcher:
             port = retq.get()
             temp_event_loop.call_later(AUTOSTOP_DELAY, temp_event_loop.stop)
             main_n(
-                "--tlscert",
-                tls_cert_pem_path,
-                "--tlskey",
-                tls_key_pem_path,
+                f"--tlscert={tls_cert_pem_path}",
+                f"--tlskey={tls_key_pem_path}",
                 "--no-requiretls",
-                "-l",
-                f":{port}",
+                f"--listen=:{port}",
             )
             catchup_delay()
         has_starttls = retq.get()
@@ -247,12 +241,9 @@ class TestMainByWatcher:
             port = retq.get()
             temp_event_loop.call_later(AUTOSTOP_DELAY, temp_event_loop.stop)
             main_n(
-                "--smtpscert",
-                tls_cert_pem_path,
-                "--smtpskey",
-                tls_key_pem_path,
-                "-l",
-                f":{port}",
+                f"--smtpscert={tls_cert_pem_path}",
+                f"--smtpskey={tls_key_pem_path}",
+                f"--listen=:{port}",
             )
             catchup_delay()
         has_smtps = retq.get()

--- a/aiosmtpd/tests/test_main.py
+++ b/aiosmtpd/tests/test_main.py
@@ -5,7 +5,7 @@ import asyncio
 import logging
 import multiprocessing as MP
 import os
-import random
+import socket
 import sys
 import time
 from contextlib import contextmanager
@@ -84,7 +84,7 @@ def watch_for_tls(ready_flag: MP_Event, retq: MP.Queue):
     # Rather than using a hardcoded port, pick a random port,
     # and send it over the return queue, so the test case can
     # start a listening socket on this port.
-    port = pick_random_port()
+    port = pick_available_port()
     retq.put(port)
     has_tls = False
     req_tls = False
@@ -111,7 +111,7 @@ def watch_for_smtps(ready_flag: MP_Event, retq: MP.Queue):
     # Rather than using a hardcoded port, pick a random port,
     # and send it over the return queue, so the test case can
     # start a listening socket on this port.
-    port = pick_random_port()
+    port = pick_available_port()
     retq.put(port)
     has_smtps = False
     ready_flag.set()
@@ -143,8 +143,11 @@ def watcher_process(func):
     proc.join()
 
 
-def pick_random_port():
-    return random.randint(32768, 49152)
+def pick_available_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
 
 # endregion
 

--- a/aiosmtpd/tests/test_main.py
+++ b/aiosmtpd/tests/test_main.py
@@ -72,7 +72,7 @@ def setuid(mocker: MockFixture):
         pytest.skip("setuid is unavailable")
     mocker.patch("aiosmtpd.main.pwd", None)
     mocker.patch("os.setuid", side_effect=PermissionError)
-    mocker.patch("aiosmtpd.main.partial", side_effect=RuntimeError)
+    mocker.patch("aiosmtpd.main.partial", side_effect=RuntimeError("testing"))
 
 
 # endregion
@@ -175,7 +175,7 @@ class TestMain:
         assert capsys.readouterr().err == 'Cannot import module "pwd"; try running with -n option.\n'
 
     def test_n(self, setuid):
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError, match="^testing$"):
             main_n("--listen=:0")
 
     def test_nosetuid(self, setuid):

--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -38,6 +38,12 @@ from aiosmtpd.testing.helpers import catchup_delay
 from .conftest import Global, AUTOSTOP_DELAY
 
 
+class RandomPortController(Controller):
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("port", 0)
+        super().__init__(*args, **kwargs)
+
+
 class SlowStartController(Controller):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault("ready_timeout", 0.5)
@@ -175,7 +181,7 @@ class TestController:
 
     @pytest.mark.filterwarnings("ignore")
     def test_ready_timeout(self):
-        cont = SlowStartController(Sink())
+        cont = SlowStartController(Sink(), port=0)
         expectre = (
             "SMTP server failed to start within allotted time. "
             "This might happen if the system is too busy. "
@@ -189,7 +195,7 @@ class TestController:
 
     @pytest.mark.filterwarnings("ignore")
     def test_factory_timeout(self):
-        cont = SlowFactoryController(Sink())
+        cont = SlowFactoryController(Sink(), port=0)
         expectre = (
             r"SMTP server started, but not responding within allotted time. "
             r"This might happen if the system is too busy. "
@@ -202,7 +208,7 @@ class TestController:
             cont.stop()
 
     def test_reuse_loop(self, temp_event_loop):
-        cont = Controller(Sink(), loop=temp_event_loop)
+        cont = RandomPortController(Sink(), loop=temp_event_loop)
         assert cont.loop is temp_event_loop
         try:
             cont.start()
@@ -227,6 +233,8 @@ class TestController:
 
     @pytest.mark.skipif(in_wsl(), reason="WSL prevents socket collision")
     def test_socket_error_default(self):
+        # Don't specify port so both controllers will try to bind on
+        # the default port, 8025:
         contr1 = Controller(Sink())
         contr2 = Controller(
             Sink(),
@@ -242,7 +250,7 @@ class TestController:
             contr1.stop()
 
     def test_server_attribute(self):
-        controller = Controller(Sink())
+        controller = RandomPortController(Sink())
         assert controller.server is None
         try:
             controller.start()
@@ -256,30 +264,38 @@ class TestController:
     )
     def test_enablesmtputf8_flag(self):
         # Default is True
-        controller = Controller(Sink())
+        controller = RandomPortController(Sink())
         assert controller.SMTP_kwargs["enable_SMTPUTF8"]
         # Explicit set must be reflected in server_kwargs
-        controller = Controller(Sink(), enable_SMTPUTF8=True)
+        controller = RandomPortController(Sink(), enable_SMTPUTF8=True)
         assert controller.SMTP_kwargs["enable_SMTPUTF8"]
-        controller = Controller(Sink(), enable_SMTPUTF8=False)
+        controller = RandomPortController(Sink(), enable_SMTPUTF8=False)
         assert not controller.SMTP_kwargs["enable_SMTPUTF8"]
         # Explicit set must override server_kwargs
         kwargs = dict(enable_SMTPUTF8=False)
-        controller = Controller(Sink(), enable_SMTPUTF8=True, server_kwargs=kwargs)
+        controller = RandomPortController(
+            Sink(),
+            enable_SMTPUTF8=True,
+            server_kwargs=kwargs,
+        )
         assert controller.SMTP_kwargs["enable_SMTPUTF8"]
         kwargs = dict(enable_SMTPUTF8=True)
-        controller = Controller(Sink(), enable_SMTPUTF8=False, server_kwargs=kwargs)
+        controller = RandomPortController(
+            Sink(),
+            enable_SMTPUTF8=False,
+            server_kwargs=kwargs,
+        )
         assert not controller.SMTP_kwargs["enable_SMTPUTF8"]
         # Set through server_kwargs must not be overridden if no explicit set
         kwargs = dict(enable_SMTPUTF8=False)
-        controller = Controller(Sink(), server_kwargs=kwargs)
+        controller = RandomPortController(Sink(), server_kwargs=kwargs)
         assert not controller.SMTP_kwargs["enable_SMTPUTF8"]
 
     @pytest.mark.filterwarnings(
         "ignore:server_kwargs will be removed:DeprecationWarning"
     )
     def test_serverhostname_arg(self):
-        contsink = partial(Controller, Sink())
+        contsink = partial(RandomPortController, Sink())
         controller = contsink()
         assert "hostname" not in controller.SMTP_kwargs
         controller = contsink(server_hostname="testhost1")
@@ -292,14 +308,14 @@ class TestController:
 
     def test_hostname_empty(self):
         # WARNING: This test _always_ succeeds in Windows.
-        cont = Controller(Sink(), hostname="")
+        cont = RandomPortController(Sink(), hostname="")
         try:
             cont.start()
         finally:
             cont.stop()
 
     def test_hostname_none(self):
-        cont = Controller(Sink())
+        cont = RandomPortController(Sink())
         try:
             cont.start()
         finally:
@@ -310,7 +326,7 @@ class TestController:
             "aiosmtpd.controller.create_connection",
             side_effect=RuntimeError("MockError"),
         )
-        cont = Controller(Sink(), hostname="")
+        cont = RandomPortController(Sink(), hostname="")
         try:
             with pytest.raises(RuntimeError, match="MockError"):
                 cont.start()
@@ -363,17 +379,17 @@ class TestController:
         mock_makesock.assert_called_with(socket.AF_INET6, socket.SOCK_STREAM)
 
     def test_stop_default(self):
-        controller = Controller(Sink())
+        controller = RandomPortController(Sink())
         with pytest.raises(AssertionError, match="SMTP daemon not running"):
             controller.stop()
 
     def test_stop_assert(self):
-        controller = Controller(Sink())
+        controller = RandomPortController(Sink())
         with pytest.raises(AssertionError, match="SMTP daemon not running"):
             controller.stop(no_assert=False)
 
     def test_stop_noassert(self):
-        controller = Controller(Sink())
+        controller = RandomPortController(Sink())
         controller.stop(no_assert=True)
 
 
@@ -470,7 +486,7 @@ class TestUnthreaded:
         Verify behavior when the loop is stopped before controller is stopped
         """
         autostop_loop.set_debug(True)
-        cont = UnthreadedController(Sink(), loop=autostop_loop)
+        cont = UnthreadedController(Sink(), loop=autostop_loop, port=0)
         cont.begin()
         # Make sure event loop is not running (will be started in thread)
         assert autostop_loop.is_running() is False
@@ -491,6 +507,11 @@ class TestUnthreaded:
         # SMTPServerDisconnected
         with pytest.raises(SMTPServerDisconnected):
             SMTPClient(cont.hostname, cont.port, timeout=0.1)
+
+        # Take note of the hostname and port, as they will not be available
+        # after controller.end().
+        hostname, port = cont.hostname, cont.port
+
         cont.end()
         catchup_delay()
         cont.ended.wait()
@@ -498,7 +519,7 @@ class TestUnthreaded:
         # or ConnectionError (depending on OS)
         # noinspection PyTypeChecker
         with pytest.raises((socket.timeout, ConnectionError)):
-            SMTPClient(cont.hostname, cont.port, timeout=0.1)
+            SMTPClient(hostname, port, timeout=0.1)
 
     @pytest.mark.filterwarnings(
         "ignore::pytest.PytestUnraisableExceptionWarning"
@@ -507,7 +528,7 @@ class TestUnthreaded:
         """
         Verify behavior when the controller is stopped before loop is stopped
         """
-        cont = UnthreadedController(Sink(), loop=temp_event_loop)
+        cont = UnthreadedController(Sink(), loop=temp_event_loop, port=0)
         cont.begin()
         # Make sure event loop is not running (will be started in thread)
         assert temp_event_loop.is_running() is False
@@ -521,6 +542,11 @@ class TestUnthreaded:
                 assert code == 250
                 client.quit()
             catchup_delay()
+
+            # Take note of the hostname and port, as they will not be available
+            # after controller.end().
+            hostname, port = cont.hostname, cont.port
+
             temp_event_loop.call_soon_threadsafe(cont.end)
             for _ in range(10):  # 10 is arbitrary
                 catchup_delay()  # effectively yield to other threads/event loop
@@ -533,7 +559,7 @@ class TestUnthreaded:
             expect_errs = (socket.timeout, ConnectionError, SMTPServerDisconnected)
             # noinspection PyTypeChecker
             with pytest.raises(expect_errs):
-                SMTPClient(cont.hostname, cont.port, timeout=0.1)
+                SMTPClient(hostname, port, timeout=0.1)
         finally:
             # Wrap up, or else we'll hang
             temp_event_loop.call_soon_threadsafe(cont.cancel_tasks)
@@ -547,7 +573,7 @@ class TestUnthreaded:
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 class TestFactory:
     def test_normal_situation(self):
-        cont = Controller(Sink())
+        cont = RandomPortController(Sink())
         try:
             cont.start()
             catchup_delay()
@@ -558,7 +584,7 @@ class TestFactory:
 
     def test_unknown_args_direct(self, silence_event_loop_closed: bool):
         unknown = "this_is_an_unknown_kwarg"
-        cont = Controller(Sink(), ready_timeout=0.3, **{unknown: True})
+        cont = RandomPortController(Sink(), ready_timeout=0.3, **{unknown: True})
         expectedre = r"__init__.. got an unexpected keyword argument '" + unknown + r"'"
         try:
             with pytest.raises(TypeError, match=expectedre):
@@ -573,7 +599,7 @@ class TestFactory:
     )
     def test_unknown_args_inkwargs(self, silence_event_loop_closed: bool):
         unknown = "this_is_an_unknown_kwarg"
-        cont = Controller(Sink(), ready_timeout=0.3, server_kwargs={unknown: True})
+        cont = RandomPortController(Sink(), ready_timeout=0.3, server_kwargs={unknown: True})
         expectedre = r"__init__.. got an unexpected keyword argument '" + unknown + r"'"
         try:
             with pytest.raises(TypeError, match=expectedre):
@@ -586,7 +612,7 @@ class TestFactory:
         # Hypothetical situation where factory() did not raise an Exception
         # but returned None instead
         mocker.patch("aiosmtpd.controller.SMTP", return_value=None)
-        cont = Controller(Sink(), ready_timeout=0.3)
+        cont = RandomPortController(Sink(), ready_timeout=0.3)
         expectedre = r"factory\(\) returned None"
         try:
             with pytest.raises(RuntimeError, match=expectedre):
@@ -600,7 +626,7 @@ class TestFactory:
     ):
         # Hypothetical situation where factory() failed but no
         # Exception was generated.
-        cont = Controller(Sink())
+        cont = RandomPortController(Sink())
 
         def hijacker(*args, **kwargs):
             cont._thread_exception = None

--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -520,6 +520,10 @@ class TestUnthreaded:
         # noinspection PyTypeChecker
         with pytest.raises((socket.timeout, ConnectionError)):
             SMTPClient(hostname, port, timeout=0.1)
+        # Since the listening socket is closed, cont.port and cont.hostname should
+        # report None
+        assert cont.port is None
+        assert cont.hostname is None
 
     @pytest.mark.filterwarnings(
         "ignore::pytest.PytestUnraisableExceptionWarning"
@@ -560,6 +564,10 @@ class TestUnthreaded:
             # noinspection PyTypeChecker
             with pytest.raises(expect_errs):
                 SMTPClient(hostname, port, timeout=0.1)
+            # Since the listening socket is closed, cont.port and cont.hostname should
+            # report None
+            assert cont.port is None
+            assert cont.hostname is None
         finally:
             # Wrap up, or else we'll hang
             temp_event_loop.call_soon_threadsafe(cont.cancel_tasks)

--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -525,13 +525,13 @@ class TestUnthreaded:
         # raise ConnectionError
         with pytest.raises(
             RuntimeError,
-            match="The server is currently not listening on any socket",
+            match="The server is currently not listening to any socket",
         ):
             _ = cont.port
 
         with pytest.raises(
             RuntimeError,
-            match="The server is currently not listening on any socket",
+            match="The server is currently not listening to any socket",
         ):
             _ = cont.hostname
 
@@ -578,13 +578,13 @@ class TestUnthreaded:
             # raise ConnectionError
             with pytest.raises(
                 RuntimeError,
-                match="The server is currently not listening on any socket",
+                match="The server is currently not listening to any socket",
             ):
                 _ = cont.port
 
             with pytest.raises(
                 RuntimeError,
-                match="The server is currently not listening on any socket",
+                match="The server is currently not listening to any socket",
             ):
                 _ = cont.hostname
         finally:

--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -40,8 +40,8 @@ from .conftest import Global, AUTOSTOP_DELAY
 
 class RandomPortController(Controller):
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault("port", 0)
-        super().__init__(*args, **kwargs)
+        assert "port" not in kwargs
+        super().__init__(*args, port=0, **kwargs)
 
 
 class SlowStartController(Controller):

--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -521,13 +521,13 @@ class TestUnthreaded:
         # Since the listening socket is closed, cont.port and cont.hostname should
         # raise ConnectionError
         with pytest.raises(
-            ConnectionError,
+            RuntimeError,
             match="The server is currently not listening on any port",
         ):
             _ = cont.port
 
         with pytest.raises(
-            ConnectionError,
+            RuntimeError,
             match="The server is currently not listening on any port",
         ):
             _ = cont.hostname
@@ -572,13 +572,13 @@ class TestUnthreaded:
             # Since the listening socket is closed, cont.port and cont.hostname should
             # raise ConnectionError
             with pytest.raises(
-                ConnectionError,
+                RuntimeError,
                 match="The server is currently not listening on any port",
             ):
                 _ = cont.port
 
             with pytest.raises(
-                ConnectionError,
+                RuntimeError,
                 match="The server is currently not listening on any port",
             ):
                 _ = cont.hostname

--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -576,19 +576,6 @@ class TestUnthreaded:
             # noinspection PyTypeChecker
             with pytest.raises(expect_errs):
                 SMTPClient(hostname, port, timeout=0.1)
-            # Since the listening socket is closed, cont.port and cont.hostname should
-            # raise ConnectionError
-            with pytest.raises(
-                RuntimeError,
-                match=r"^The server is currently not listening to any socket$",
-            ):
-                _ = cont.port
-
-            with pytest.raises(
-                RuntimeError,
-                match=r"^The server is currently not listening to any socket$",
-            ):
-                _ = cont.hostname
         finally:
             # Wrap up, or else we'll hang
             temp_event_loop.call_soon_threadsafe(cont.cancel_tasks)
@@ -597,6 +584,19 @@ class TestUnthreaded:
         assert runner.is_alive() is False
         assert temp_event_loop.is_running() is False
         assert temp_event_loop.is_closed() is False
+        # Since the listening socket is closed, cont.port and cont.hostname should
+        # raise ConnectionError
+        with pytest.raises(
+            RuntimeError,
+            match=r"^The server is currently not listening to any socket$",
+        ):
+            _ = cont.port
+
+        with pytest.raises(
+            RuntimeError,
+            match=r"^The server is currently not listening to any socket$",
+        ):
+            _ = cont.hostname
 
 
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")

--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -218,6 +218,9 @@ class TestController:
 
     @pytest.mark.skipif(in_wsl(), reason="WSL prevents socket collision")
     def test_socket_error_dupe(self, plain_controller, client):
+        # The plain_controller fixture calls `Global.set_addr_from(),
+        # this is how contr2 will be passed the same hostname and port
+        # as the already running plain_controller.
         contr2 = Controller(
             Sink(),
             hostname=Global.SrvAddr.host,

--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -478,9 +478,7 @@ class TestUnthreaded:
         with pytest.raises((socket.timeout, ConnectionError)):
             assert_smtp_socket(cont)
 
-    @pytest.mark.filterwarnings(
-        "ignore::pytest.PytestUnraisableExceptionWarning"
-    )
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
     def test_inet_loopstop(self, autostop_loop, runner):
         """
         Verify behavior when the loop is stopped before controller is stopped
@@ -521,13 +519,20 @@ class TestUnthreaded:
         with pytest.raises((socket.timeout, ConnectionError)):
             SMTPClient(hostname, port, timeout=0.1)
         # Since the listening socket is closed, cont.port and cont.hostname should
-        # report None
-        assert cont.port is None
-        assert cont.hostname is None
+        # raise ConnectionError
+        with pytest.raises(
+            ConnectionError,
+            match="The server is currently not listening on any port",
+        ):
+            _ = cont.port
 
-    @pytest.mark.filterwarnings(
-        "ignore::pytest.PytestUnraisableExceptionWarning"
-    )
+        with pytest.raises(
+            ConnectionError,
+            match="The server is currently not listening on any port",
+        ):
+            _ = cont.hostname
+
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
     def test_inet_contstop(self, temp_event_loop, runner):
         """
         Verify behavior when the controller is stopped before loop is stopped
@@ -565,9 +570,18 @@ class TestUnthreaded:
             with pytest.raises(expect_errs):
                 SMTPClient(hostname, port, timeout=0.1)
             # Since the listening socket is closed, cont.port and cont.hostname should
-            # report None
-            assert cont.port is None
-            assert cont.hostname is None
+            # raise ConnectionError
+            with pytest.raises(
+                ConnectionError,
+                match="The server is currently not listening on any port",
+            ):
+                _ = cont.port
+
+            with pytest.raises(
+                ConnectionError,
+                match="The server is currently not listening on any port",
+            ):
+                _ = cont.hostname
         finally:
             # Wrap up, or else we'll hang
             temp_event_loop.call_soon_threadsafe(cont.cancel_tasks)

--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -535,7 +535,9 @@ class TestUnthreaded:
         ):
             _ = cont.hostname
 
-    @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+    @pytest.mark.filterwarnings(
+        "ignore::pytest.PytestUnraisableExceptionWarning"
+    )
     def test_inet_contstop(self, temp_event_loop, runner):
         """
         Verify behavior when the controller is stopped before loop is stopped

--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -585,7 +585,7 @@ class TestUnthreaded:
         assert temp_event_loop.is_running() is False
         assert temp_event_loop.is_closed() is False
         # Since the listening socket is closed, cont.port and cont.hostname should
-        # raise ConnectionError
+        # raise RuntimeError
         with pytest.raises(
             RuntimeError,
             match=r"^The server is currently not listening to any socket$",

--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -525,13 +525,13 @@ class TestUnthreaded:
         # raise ConnectionError
         with pytest.raises(
             RuntimeError,
-            match="The server is currently not listening to any socket",
+            match=r"^The server is currently not listening to any socket$",
         ):
             _ = cont.port
 
         with pytest.raises(
             RuntimeError,
-            match="The server is currently not listening to any socket",
+            match=r"^The server is currently not listening to any socket$",
         ):
             _ = cont.hostname
 
@@ -578,13 +578,13 @@ class TestUnthreaded:
             # raise ConnectionError
             with pytest.raises(
                 RuntimeError,
-                match="The server is currently not listening to any socket",
+                match=r"^The server is currently not listening to any socket$",
             ):
                 _ = cont.port
 
             with pytest.raises(
                 RuntimeError,
-                match="The server is currently not listening to any socket",
+                match=r"^The server is currently not listening to any socket$",
             ):
                 _ = cont.hostname
         finally:

--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -525,13 +525,13 @@ class TestUnthreaded:
         # raise ConnectionError
         with pytest.raises(
             RuntimeError,
-            match="The server is currently not listening on any port",
+            match="The server is currently not listening on any socket",
         ):
             _ = cont.port
 
         with pytest.raises(
             RuntimeError,
-            match="The server is currently not listening on any port",
+            match="The server is currently not listening on any socket",
         ):
             _ = cont.hostname
 
@@ -576,13 +576,13 @@ class TestUnthreaded:
             # raise ConnectionError
             with pytest.raises(
                 RuntimeError,
-                match="The server is currently not listening on any port",
+                match="The server is currently not listening on any socket",
             ):
                 _ = cont.port
 
             with pytest.raises(
                 RuntimeError,
-                match="The server is currently not listening on any port",
+                match="The server is currently not listening on any socket",
             ):
                 _ = cont.hostname
         finally:

--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -481,7 +481,9 @@ class TestUnthreaded:
         with pytest.raises((socket.timeout, ConnectionError)):
             assert_smtp_socket(cont)
 
-    @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+    @pytest.mark.filterwarnings(
+        "ignore::pytest.PytestUnraisableExceptionWarning"
+    )
     def test_inet_loopstop(self, autostop_loop, runner):
         """
         Verify behavior when the loop is stopped before controller is stopped

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -386,7 +386,7 @@ def decoding_authnotls_controller(
 @pytest.fixture
 def error_controller(get_handler: Callable) -> Generator[ErrorController, None, None]:
     handler = get_handler()
-    controller = ErrorController(handler)
+    controller = ErrorController(handler, port=0)
     controller.start()
     Global.set_addr_from(controller)
     #
@@ -1564,22 +1564,31 @@ class TestSMTPWithController(_CommonMethods):
 
     @handler_data(class_=ReceivingHandler)
     def test_bad_encodings(self, decoding_authnotls_controller, client):
-        handler: ReceivingHandler = decoding_authnotls_controller.handler
-        self._helo(client)
-        mail_from = b"anne\xFF@example.com"
-        mail_to = b"bart\xFF@example.com"
-        self._ehlo(client, "test")
-        client.send(b"MAIL FROM:" + mail_from + b"\r\n")
-        assert client.getreply() == S.S250_OK
-        client.send(b"RCPT TO:" + mail_to + b"\r\n")
-        assert client.getreply() == S.S250_OK
-        client.data("Test mail")
-        assert len(handler.box) == 1
-        envelope = handler.box[0]
-        mail_from2 = envelope.mail_from.encode("utf-8", errors="surrogateescape")
-        assert mail_from2 == mail_from
-        mail_to2 = envelope.rcpt_tos[0].encode("utf-8", errors="surrogateescape")
-        assert mail_to2 == mail_to
+        # Disable DEBUG logging temporarily to avoid baly encoded strings in the logs.
+        # Otherwise, running tests in parallel with pytest-xdist will blow up
+        # when trying to serialize the captured logs.
+        prev_level = MAIL_LOG.getEffectiveLevel()
+        MAIL_LOG.setLevel(logging.WARNING)
+
+        try:
+            handler: ReceivingHandler = decoding_authnotls_controller.handler
+            self._helo(client)
+            mail_from = b"anne\xFF@example.com"
+            mail_to = b"bart\xFF@example.com"
+            self._ehlo(client, "test")
+            client.send(b"MAIL FROM:" + mail_from + b"\r\n")
+            assert client.getreply() == S.S250_OK
+            client.send(b"RCPT TO:" + mail_to + b"\r\n")
+            assert client.getreply() == S.S250_OK
+            client.data("Test mail")
+            assert len(handler.box) == 1
+            envelope = handler.box[0]
+            mail_from2 = envelope.mail_from.encode("utf-8", errors="surrogateescape")
+            assert mail_from2 == mail_from
+            mail_to2 = envelope.rcpt_tos[0].encode("utf-8", errors="surrogateescape")
+            assert mail_to2 == mail_to
+        finally:
+            MAIL_LOG.setLevel(prev_level)
 
     @controller_data(decode_data=False)
     def test_data_line_too_long(self, plain_controller, client):

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -90,6 +90,13 @@ class ErrorSMTP(Server):
     async def smtp_HELO(self, hostname: str):
         raise self.exception_type("test")
 
+@pytest.fixture
+def _set_log_level_warning():
+    prev_level = MAIL_LOG.getEffectiveLevel()
+    MAIL_LOG.setLevel(logging.WARNING)
+    yield True
+    MAIL_LOG.setLevel(prev_level)
+
 
 # endregion
 
@@ -1563,32 +1570,28 @@ class TestSMTPWithController(_CommonMethods):
         assert resp == S.S250_OK
 
     @handler_data(class_=ReceivingHandler)
+    @pytest.mark.usefixtures('_set_log_level_warning')
     def test_bad_encodings(self, decoding_authnotls_controller, client):
-        # Disable DEBUG logging temporarily to avoid baly encoded strings in the logs.
-        # Otherwise, running tests in parallel with pytest-xdist will blow up
-        # when trying to serialize the captured logs.
-        prev_level = MAIL_LOG.getEffectiveLevel()
-        MAIL_LOG.setLevel(logging.WARNING)
+        # _set_log_level_warning disables DEBUG logging temporarily to avoid badly
+        # encoded strings in the logs. Otherwise, running tests in parallel with
+        # pytest-xdist will blow up when trying to serialize the captured logs.
 
-        try:
-            handler: ReceivingHandler = decoding_authnotls_controller.handler
-            self._helo(client)
-            mail_from = b"anne\xFF@example.com"
-            mail_to = b"bart\xFF@example.com"
-            self._ehlo(client, "test")
-            client.send(b"MAIL FROM:" + mail_from + b"\r\n")
-            assert client.getreply() == S.S250_OK
-            client.send(b"RCPT TO:" + mail_to + b"\r\n")
-            assert client.getreply() == S.S250_OK
-            client.data("Test mail")
-            assert len(handler.box) == 1
-            envelope = handler.box[0]
-            mail_from2 = envelope.mail_from.encode("utf-8", errors="surrogateescape")
-            assert mail_from2 == mail_from
-            mail_to2 = envelope.rcpt_tos[0].encode("utf-8", errors="surrogateescape")
-            assert mail_to2 == mail_to
-        finally:
-            MAIL_LOG.setLevel(prev_level)
+        handler: ReceivingHandler = decoding_authnotls_controller.handler
+        self._helo(client)
+        mail_from = b"anne\xFF@example.com"
+        mail_to = b"bart\xFF@example.com"
+        self._ehlo(client, "test")
+        client.send(b"MAIL FROM:" + mail_from + b"\r\n")
+        assert client.getreply() == S.S250_OK
+        client.send(b"RCPT TO:" + mail_to + b"\r\n")
+        assert client.getreply() == S.S250_OK
+        client.data("Test mail")
+        assert len(handler.box) == 1
+        envelope = handler.box[0]
+        mail_from2 = envelope.mail_from.encode("utf-8", errors="surrogateescape")
+        assert mail_from2 == mail_from
+        mail_to2 = envelope.rcpt_tos[0].encode("utf-8", errors="surrogateescape")
+        assert mail_to2 == mail_to
 
     @controller_data(decode_data=False)
     def test_data_line_too_long(self, plain_controller, client):

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -90,6 +90,7 @@ class ErrorSMTP(Server):
     async def smtp_HELO(self, hostname: str):
         raise self.exception_type("test")
 
+
 @pytest.fixture
 def _set_log_level_warning() -> None:
     prev_level = MAIL_LOG.getEffectiveLevel()

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -91,10 +91,10 @@ class ErrorSMTP(Server):
         raise self.exception_type("test")
 
 @pytest.fixture
-def _set_log_level_warning():
+def _set_log_level_warning() -> None:
     prev_level = MAIL_LOG.getEffectiveLevel()
     MAIL_LOG.setLevel(logging.WARNING)
-    yield True
+    yield
     MAIL_LOG.setLevel(prev_level)
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,7 @@
 [pytest]
 addopts =
+    # `pytest-xdist`:
+    --numprocesses=auto
     # show 10 slowest invocations:
     --durations=10
     # a bit of verbosity doesn't hurt:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ coverage==7.8.0
 pytest==8.3.4
 pytest-cov==6.1.1
 pytest-mock==3.14.0
+pytest-xdist==3.8.0
 trustme==1.2.1


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This is a follow-up to #524 where @webknjaz noted:

> We'll need however to find places with the hardcoded port — they are most likely to happen on Windows, but things like pytest-xdist would induce these races too.

This PR updates tests (and has some supporting changes in Controller too) to allow tests to complete with `pytest-xdist`. Hopefully it fixes the flaky tests in Windows too.

The test suite uses a hard-coded port for listening sockets: 8025. When running tests in parallel this is a problem, as tests will race to bind to the same port. One solution would be to hardcode a different port in each test case. This would require test writers to keep track which ports have already been "used", and could create annoying issues when copy-pasting code and forgetting to change the port number. An IMHO nicer alternative is to use a special port "0" which tells `asyncio.create_server` to [pick a random unused port](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.create_server). This is what this PR does. 

There were a few complications.

If `asyncio.create_server` picks the port, there needs some mechanism for the testcase to figure out what port was chosen, so it can connect to it as a client. I changed the InetMixin class to:

* store the `hostname` and `port` constructor arguments in the `requested_hostname` and `requested_port` instance attributes
* change the `hostname` and `port` instance attributes to properties that read the hostname and port from `self.server.sockets`. 

This way, clients and test cases can pass `port=0` to the controller constructor, and then read the chosen port from `controller.port` property and its corresponding hostname from the `controller.hostname` property. The testing code accesses `controller.port` in several places, and these parts don't need to change.

---

The other complication was with tests in `test_main.py`. Here, if we pass `-l :0` arguments to `main()` then it *will* pick a random port, but there's no convenient way to communicate the port back to the testing code. What I chose to do instead is to generate a random port in the test code and pass it to `main` using the `-l` argument. There's a small chance of multiple test cases randomly choosing the same port number, but there are only 3 test cases that need to do this, and each picks from ~16K ports so the probability of collision is tiny.

---

There's one change that is related to making `pytest-xdist` work, but not related to hardcoded ports. It is in `test_smtp.py`, `test_bad_encodings` test case. The test was blowing up because pytest-xdist was trying to serialize logs which contain badly encoded strings. The least intrusive fix I could think of was to, temporarily for this test case, reduce the log level to WARNING, so the bad strings don't end up in logs.

## Are there changes in behavior for the user?

Yes: the behavior of `Controller.port` and `Controller.hostname` has changed:

* If user specifies port "0", `Controller.port` will contain the randomly chosen port, not value 0
* After calling `controller.end()`, both `Controller.port` and `Controller.hostname` will return None (because the listening sockets are closed and we cannot consult them any more)
* There are new `Controller.requested_port` and `Controller.requested_hostname` instance attributes, containing the values that were passed to the constructor

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Use the "closing keywords" such as "Closes" or "Fixes" to automatically link to Issues. -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - I have not run tox, tut GHA ci-cd workflow passes
- [x] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file
