### PR TITLE
fix housekeep.py with Python 3.14

### DIFF
--- a/housekeep.py
+++ b/housekeep.py
@@ -235,9 +235,11 @@ def get_opts(argv):
     parser.add_argument(
         "cmd", metavar="COMMAND", choices=sorted(dispers.keys()), help="(See below)"
     )
-    cgrp = parser.add_argument_group(title="COMMAND is one of")
+    epilog_lines = ["COMMAND is one of"]
     for name, doc in sorted(dispers.items()):
-        cgrp.add_argument(name, help=doc, action="no_action")
+        epilog_lines.append(f"  {name:<15} {doc}")
+    parser.epilog = "\n".join(epilog_lines)
+    parser.formatter_class = argparse.RawDescriptionHelpFormatter
 
     return parser.parse_args(argv)
 


### PR DESCRIPTION
## What do these changes do?
Python 3.14 validates custom actions on positional arguments. Replace the argument group approach with epilog to display available commands.
## Are there changes in behavior for the user?
No. housekeep.py is not packaged.
## Related issue number
Fixes https://github.com/aio-libs/aiosmtpd/issues/594.
## Checklist
- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [x] Linux (Ubuntu 18.04, Ubuntu 20.04, Arch): `qa`
  - [ ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- [ ] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file