### PR TITLE
build: drop unnecessary wheel from build-system requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary

Remove `wheel` from `[build-system].requires` in `pyproject.toml`.

## Why

`wheel` is not needed as a build requirement per [PEP 517](https://peps.python.org/pep-0517/). Setuptools handles wheel creation internally and does not require the `wheel` package to be listed as a build dependency. This has been noted as unnecessary since the project's inception.

## Changes

- `pyproject.toml`: `requires = ["setuptools", "wheel"]` → `requires = ["setuptools"]`

Fixes #576