### PR TITLE
housekeep.py: Fix possible TypeError

### DIFF
--- a/housekeep.py
+++ b/housekeep.py
@@ -110,7 +110,7 @@ def move_prof(verbose: bool = False):
         for filepath in profpath.glob(fileglob)
     ]
     # fmt: on
-    if not prof_files:
+    if not prof_files or not TOX_ENV_NAME:
         return
     targpath = profpath / TOX_ENV_NAME
     if verbose:


### PR DESCRIPTION
## What do these changes do?
Prevent a possible TypeError when running housekeep.py gather outside of tox by returning if TOX_ENV_NAME is not set.
## Are there changes in behavior for the user?
No.
## Related issue number
Fixes https://github.com/aio-libs/aiosmtpd/issues/597.
## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [x] Linux (Ubuntu 18.04, Ubuntu 20.04, Arch): `qa`
  - [ ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- [ ] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file