### PR TITLE
Remove trailing NUL byte from AUTH LOGIN challenges (Fixes #566)

### DIFF
--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -12,6 +12,9 @@ Fixed/Improved
 
 * Dropped Python 3.8, PyPy 3.8
 * Added PyPy 3.11, dropped PyPy 3.9
+* Removed the trailing NUL byte (``\x00``) from the ``AUTH LOGIN`` username and
+  password challenges, which broke strict clients such as Go's ``net/smtp``
+  (used by Prometheus Alertmanager) and curl (Closes #566)
 
 
 1.4.6 (2024-05-18)

--- a/aiosmtpd/smtp.py
+++ b/aiosmtpd/smtp.py
@@ -310,8 +310,8 @@ class SMTP(asyncio.StreamReaderProtocol):
     If 0 or Falsey, local part length is unlimited.
     """
 
-    AuthLoginUsernameChallenge = "User Name\x00"
-    AuthLoginPasswordChallenge = "Password\x00"
+    AuthLoginUsernameChallenge = "User Name"
+    AuthLoginPasswordChallenge = "Password"
 
     def __init__(
             self,

--- a/aiosmtpd/testing/statuscodes.py
+++ b/aiosmtpd/testing/statuscodes.py
@@ -98,8 +98,8 @@ class SMTP_STATUS_CODES:
     )
 
     S334_AUTH_EMPTYPROMPT = StatusCode(334, b"")
-    S334_AUTH_USERNAME = StatusCode(334, b"VXNlciBOYW1lAA==")
-    S334_AUTH_PASSWORD = StatusCode(334, b"UGFzc3dvcmQA")
+    S334_AUTH_USERNAME = StatusCode(334, b"VXNlciBOYW1l")
+    S334_AUTH_PASSWORD = StatusCode(334, b"UGFzc3dvcmQ=")
 
     S354_DATA_ENDWITH = StatusCode(354, b"End data with <CR><LF>.<CR><LF>")
 

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -11,7 +11,7 @@ import sys
 import time
 import warnings
 from asyncio.transports import Transport
-from base64 import b64encode
+from base64 import b64decode, b64encode
 from contextlib import suppress
 from smtplib import (
     SMTP as SMTPClient,
@@ -1217,6 +1217,23 @@ class TestAuthMechanisms(_CommonMethods):
         assert resp == S.S334_AUTH_PASSWORD
         resp = do_auth_login3("*")
         assert resp == S.S501_AUTH_ABORTED
+
+    def test_login_challenges_have_no_nul_byte(self, do_auth_login3):
+        # GH#566: The AUTH LOGIN 334 challenges must not carry a trailing NUL
+        # byte. Strict clients (e.g. Go's net/smtp, used by Prometheus
+        # Alertmanager, and curl) do an exact compare on the decoded challenge
+        # and abort AUTH when it contains an embedded '\x00'.
+        # do_auth_login3 already sent "AUTH LOGIN" and asserted the username
+        # 334 challenge; decode it and check for an embedded NUL.
+        username_challenge = b64decode(S.S334_AUTH_USERNAME.mesg)
+        assert b"\x00" not in username_challenge
+        resp = do_auth_login3(b64encode(b"goodlogin").decode())
+        assert resp == S.S334_AUTH_PASSWORD
+        password_challenge = b64decode(S.S334_AUTH_PASSWORD.mesg)
+        assert b"\x00" not in password_challenge
+        # Complete the exchange so the connection returns to a clean state.
+        resp = do_auth_login3(b64encode(b"goodpasswd").decode())
+        assert resp == S.S235_AUTH_SUCCESS
 
     def test_DENYFALSE(self, client):
         self._ehlo(client)


### PR DESCRIPTION
## What do these changes do?

The `AUTH LOGIN` username and password challenge constants in `SMTP` carried a trailing NUL byte:

```python
AuthLoginUsernameChallenge = "User Name\x00"
AuthLoginPasswordChallenge = "Password\x00"
```

Base64-encoded and sent as the `334` challenge, these produce `VXNlciBOYW1lAA==` / `UGFzc3dvcmQA`, whose decoded value contains an embedded `\x00` (`User Name\x00` / `Password\x00`).

Strict SMTP clients do an exact string compare on the decoded challenge and abort AUTH when it contains the NUL byte. This breaks:

- **Go `net/smtp`** (used by Prometheus Alertmanager v0.27+), which errors with `unexpected server challenge`
- **curl**

Observed on the wire:

```
<< challenge: b'334 VXNlciBOYW1lAA=='
client aborted AUTH with '*'
<< b'501 5.7.0 Auth aborted'
```

## Fix

Remove the trailing `\x00` from both class constants so the challenges decode to `User Name` / `Password`:

```python
AuthLoginUsernameChallenge = "User Name"
AuthLoginPasswordChallenge = "Password"
```

The `challenge_auth()` call sites need no change. The base64 challenge values in the `SMTP_STATUS_CODES` test-support module (`S334_AUTH_USERNAME`, `S334_AUTH_PASSWORD`) are updated to match the new, NUL-free encoding.

This is the minimal correctness fix for the null-byte problem reported in the issue. Changing the challenge *text* to `Username:` / `Password:` (the issue's second, optional suggestion) is intentionally left out, as that is a separate behavioral/design decision.

## Are there changes in behavior for the user?

The `334 AUTH LOGIN` challenges no longer contain a trailing NUL byte, so strict clients (Go `net/smtp`, curl) can complete `AUTH LOGIN`. The plaintext prompts remain `User Name` / `Password`.

## Related issue number

Fixes #566

## Tests

- Added `test_login_challenges_have_no_nul_byte`, which performs an `AUTH LOGIN` exchange and asserts the base64-decoded username and password challenges contain no `\x00`. It fails on the pristine code (`assert b'\x00' not in b'User Name\x00'`) and passes with the fix.
- Existing AUTH/LOGIN tests updated via the shared status constants; full test suite passes locally (555 passed, 3 pre-existing skips).
- A `NEWS.rst` entry was added under `1.4.7 (aiosmtpd-next)`.

Disclosure: prepared with AI assistance; reviewed and verified locally.
