### PR TITLE
Fix the authenticated_relayer example so authentication can succeed

### DIFF
--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -12,6 +12,8 @@ Fixed/Improved
 
 * Dropped Python 3.8, PyPy 3.8
 * Added PyPy 3.11, dropped PyPy 3.9
+* The ``authenticated_relayer`` example now stores a per-user salt and uses it
+  during verification, so authentication can succeed (`#475 <https://github.com/aio-libs/aiosmtpd/issues/475>`_)
 
 
 1.4.6 (2024-05-18)

--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -13,7 +13,9 @@ Fixed/Improved
 * Dropped Python 3.8, PyPy 3.8
 * Added PyPy 3.11, dropped PyPy 3.9
 * The ``authenticated_relayer`` example now stores a per-user salt and uses it
-  during verification, so authentication can succeed (`#475 <https://github.com/aio-libs/aiosmtpd/issues/475>`_)
+  during verification, so authentication can succeed. The user database gained a
+  ``salt`` column, so re-run ``make_user_db.py`` if you already have one.
+  (Closes #475)
 
 
 1.4.6 (2024-05-18)

--- a/aiosmtpd/tests/test_examples.py
+++ b/aiosmtpd/tests/test_examples.py
@@ -6,6 +6,7 @@
 import importlib.util
 import os
 import runpy
+import sqlite3
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -139,8 +140,6 @@ def test_stale_database_rejects_without_leaking(
     every attempt; letting sqlite3.OperationalError propagate turns it into
     a 500 quoting the schema back at an unauthenticated client.
     """
-    import sqlite3
-
     stale = tmp_path / "stale.db"
     conn = sqlite3.connect(stale)
     conn.execute("CREATE TABLE userauth (username text, hashpass text)")
@@ -150,6 +149,78 @@ def test_stale_database_rejects_without_leaking(
 
     result = server.Authenticator(stale)(
         None, None, None, "LOGIN", LoginPassword(A_USER.encode("utf-8"), A_PASSWORD)
+    )
+    assert result.success is False
+    assert result.handled is False
+
+
+def test_unknown_user_still_hashes(
+    authenticate: Authenticate, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A missing row must cost a hash, or rejection latency leaks usernames.
+
+    Asserted by counting the hash rather than timing it, so the test cannot
+    flake on a loaded machine.
+    """
+    calls: list[int] = []
+    real = server.pbkdf2_hmac
+
+    def counting(*args: Any, **kwargs: Any) -> bytes:
+        calls.append(1)
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(server, "pbkdf2_hmac", counting)
+    result = authenticate("LOGIN", LoginPassword(b"nonexistent", A_PASSWORD))
+
+    assert result.success is False
+    assert calls, "unknown user returned without hashing; timing reveals it exists"
+
+
+def test_corrupt_salt_rejects_without_raising(tmp_path: Path) -> None:
+    """A row whose salt is not hex is a data error, not a credential error."""
+    corrupt = tmp_path / "corrupt.db"
+    conn = sqlite3.connect(corrupt)
+    conn.execute("CREATE TABLE userauth (username text, salt text, hashpass text)")
+    conn.execute(
+        "INSERT INTO userauth VALUES (?, ?, ?)", (A_USER, "not-hex!", "deadbeef")
+    )
+    conn.commit()
+    conn.close()
+
+    result = server.Authenticator(corrupt)(
+        None, None, None, "LOGIN", LoginPassword(A_USER.encode("utf-8"), A_PASSWORD)
+    )
+    assert result.success is False
+    assert result.handled is False
+
+
+def test_undecodable_login_cannot_match_a_replacement_char_user(
+    tmp_path: Path,
+) -> None:
+    """Decoding with errors="replace" would let one login match another user.
+
+    Every invalid byte becomes U+FFFD, so a login of b"\\xff" would match a
+    stored user named U+FFFD. Strict decoding rejects it instead.
+    """
+    salt = bytes(32)
+    db = tmp_path / "replacement.db"
+    conn = sqlite3.connect(db)
+    conn.execute("CREATE TABLE userauth (username text, salt text, hashpass text)")
+    conn.execute(
+        "INSERT INTO userauth VALUES (?, ?, ?)",
+        (
+            "\ufffd",
+            salt.hex(),
+            server.pbkdf2_hmac(
+                "sha256", b"secret", salt, server.HASH_ITERATIONS
+            ).hex(),
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    result = server.Authenticator(db)(
+        None, None, None, "LOGIN", LoginPassword(b"\xff", b"secret")
     )
     assert result.success is False
     assert result.handled is False

--- a/aiosmtpd/tests/test_examples.py
+++ b/aiosmtpd/tests/test_examples.py
@@ -1,0 +1,155 @@
+# Copyright 2014-2026 The aiosmtpd Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""Behavioural tests for the ``examples/authenticated_relayer`` example."""
+
+import importlib.util
+import os
+import runpy
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Callable
+
+import pytest
+
+import aiosmtpd
+from aiosmtpd.smtp import AuthResult, LoginPassword
+
+# The examples are not part of the installed package; they only exist in a
+# repo checkout.  Skip cleanly when running from an installed aiosmtpd.
+_REPO_ROOT = Path(aiosmtpd.__file__).resolve().parent.parent
+RELAYER_DIR = _REPO_ROOT / "examples" / "authenticated_relayer"
+if not (RELAYER_DIR / "server.py").exists():
+    pytest.skip(
+        "examples/authenticated_relayer not present (not a repo checkout)",
+        allow_module_level=True,
+    )
+
+# server.py imports dns.resolver at module level (for the relaying half,
+# which these tests do not touch).
+pytest.importorskip("dns.resolver")
+
+
+def _load_example(name: str, filename: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, RELAYER_DIR / filename)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+make_user_db = _load_example("authrelay_make_user_db", "make_user_db.py")
+server = _load_example("authrelay_server", "server.py")
+
+USERS: dict = make_user_db.USER_AND_PASSWORD
+
+#: Calls the example Authenticator with a mechanism and auth_data.
+Authenticate = Callable[[str, Any], AuthResult]
+A_USER, A_PASSWORD = next(iter(USERS.items()))
+
+
+@pytest.fixture(scope="module")
+def user_db(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Build the user DB once, with the real make_user_db.py script."""
+    db_dir = tmp_path_factory.mktemp("authrelay")
+    prev_cwd = os.getcwd()
+    os.chdir(db_dir)
+    try:
+        runpy.run_path(str(RELAYER_DIR / "make_user_db.py"), run_name="__main__")
+    finally:
+        os.chdir(prev_cwd)
+    return db_dir / make_user_db.DB_FILE
+
+
+@pytest.fixture(scope="module")
+def authenticate(user_db: Path) -> Authenticate:
+    authenticator = server.Authenticator(user_db)
+
+    def do_auth(mechanism: str, auth_data: Any) -> AuthResult:
+        return authenticator(None, None, None, mechanism, auth_data)
+
+    return do_auth
+
+
+@pytest.mark.parametrize("mechanism", ["LOGIN", "PLAIN"])
+def test_correct_password_accepted(authenticate: Authenticate, mechanism: str) -> None:
+    result = authenticate(
+        mechanism, LoginPassword(A_USER.encode("utf-8"), A_PASSWORD)
+    )
+    assert result.success is True
+
+
+def test_all_created_users_can_authenticate(authenticate: Authenticate) -> None:
+    # The salt written by make_user_db.py must round-trip through the DB
+    # into verification for every user, not just the first row.
+    last_user, last_password = list(USERS.items())[-1]
+    result = authenticate(
+        "LOGIN", LoginPassword(last_user.encode("utf-8"), last_password)
+    )
+    assert result.success is True
+
+
+def test_wrong_password_rejected(authenticate: Authenticate) -> None:
+    result = authenticate(
+        "LOGIN", LoginPassword(A_USER.encode("utf-8"), b"hunter2")
+    )
+    assert result.success is False
+    assert result.handled is False
+
+
+def test_unknown_user_rejected(authenticate: Authenticate) -> None:
+    result = authenticate(
+        "LOGIN", LoginPassword(b"nonexistent", A_PASSWORD)
+    )
+    assert result.success is False
+    assert result.handled is False
+
+
+def test_unsupported_mechanism_rejected(authenticate: Authenticate) -> None:
+    result = authenticate(
+        "CRAM-MD5", LoginPassword(A_USER.encode("utf-8"), A_PASSWORD)
+    )
+    assert result.success is False
+    assert result.handled is False
+
+
+def test_non_loginpassword_auth_data_rejected(authenticate: Authenticate) -> None:
+    result = authenticate("LOGIN", (A_USER, A_PASSWORD))
+    assert result.success is False
+    assert result.handled is False
+
+
+def test_non_utf8_username_rejected_not_crashing(authenticate: Authenticate) -> None:
+    result = authenticate(
+        "LOGIN", LoginPassword(b"\xff\xfe" + A_USER.encode("utf-8"), A_PASSWORD)
+    )
+    assert result.success is False
+    assert result.handled is False
+
+
+def test_stale_database_rejects_without_leaking(
+    authenticate: Authenticate, tmp_path: Path
+) -> None:
+    """A DB predating the salt column must not escape as an exception.
+
+    The schema change means anyone with an existing mail.db~ hits this on
+    every attempt; letting sqlite3.OperationalError propagate turns it into
+    a 500 quoting the schema back at an unauthenticated client.
+    """
+    import sqlite3
+
+    stale = tmp_path / "stale.db"
+    conn = sqlite3.connect(stale)
+    conn.execute("CREATE TABLE userauth (username text, hashpass text)")
+    conn.execute("INSERT INTO userauth VALUES (?, ?)", (A_USER, "deadbeef"))
+    conn.commit()
+    conn.close()
+
+    result = server.Authenticator(stale)(
+        None, None, None, "LOGIN", LoginPassword(A_USER.encode("utf-8"), A_PASSWORD)
+    )
+    assert result.success is False
+    assert result.handled is False

--- a/aiosmtpd/tests/test_examples.py
+++ b/aiosmtpd/tests/test_examples.py
@@ -4,9 +4,8 @@
 """Behavioural tests for the ``examples/authenticated_relayer`` example."""
 
 import importlib.util
-import os
-import runpy
 import sqlite3
+import subprocess
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -56,12 +55,14 @@ A_USER, A_PASSWORD = next(iter(USERS.items()))
 def user_db(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """Build the user DB once, with the real make_user_db.py script."""
     db_dir = tmp_path_factory.mktemp("authrelay")
-    prev_cwd = os.getcwd()
-    os.chdir(db_dir)
-    try:
-        runpy.run_path(str(RELAYER_DIR / "make_user_db.py"), run_name="__main__")
-    finally:
-        os.chdir(prev_cwd)
+    # Run it the way the example tells you to, in its own process, so the
+    # suite never has to chdir out from under the tests that follow.
+    subprocess.run(
+        [sys.executable, str(RELAYER_DIR / "make_user_db.py")],
+        cwd=db_dir,
+        check=True,
+        capture_output=True,
+    )
     return db_dir / make_user_db.DB_FILE
 
 

--- a/examples/authenticated_relayer/make_user_db.py
+++ b/examples/authenticated_relayer/make_user_db.py
@@ -24,11 +24,12 @@ if __name__ == '__main__':
         dbfp.unlink()
     conn = sqlite3.connect(DB_FILE)
     curs = conn.cursor()
-    curs.execute("CREATE TABLE userauth (username text, hashpass text)")
-    insert_up = "INSERT INTO userauth VALUES (?, ?)"
+    curs.execute("CREATE TABLE userauth (username text, salt text, hashpass text)")
+    insert_up = "INSERT INTO userauth VALUES (?, ?, ?)"
     for u, p in USER_AND_PASSWORD.items():
-        h = pbkdf2_hmac("sha256", p, secrets.token_bytes(), 1000000).hex()
-        curs.execute(insert_up, (u, h))
+        salt = secrets.token_bytes()
+        h = pbkdf2_hmac("sha256", p, salt, 1000000).hex()
+        curs.execute(insert_up, (u, salt.hex(), h))
     conn.commit()
     conn.close()
     assert dbfp.exists()

--- a/examples/authenticated_relayer/make_user_db.py
+++ b/examples/authenticated_relayer/make_user_db.py
@@ -8,6 +8,9 @@ from pathlib import Path
 
 
 DB_FILE = "mail.db~"
+
+# Must match server.py, or nothing will ever verify.
+HASH_ITERATIONS = 1000000
 USER_AND_PASSWORD = {
     "user1": b"not@password",
     "user2": b"correctbatteryhorsestaple",
@@ -27,8 +30,8 @@ if __name__ == '__main__':
     curs.execute("CREATE TABLE userauth (username text, salt text, hashpass text)")
     insert_up = "INSERT INTO userauth VALUES (?, ?, ?)"
     for u, p in USER_AND_PASSWORD.items():
-        salt = secrets.token_bytes()
-        h = pbkdf2_hmac("sha256", p, salt, 1000000).hex()
+        salt = secrets.token_bytes(32)
+        h = pbkdf2_hmac("sha256", p, salt, HASH_ITERATIONS).hex()
         curs.execute(insert_up, (u, salt.hex(), h))
     conn.commit()
     conn.close()

--- a/examples/authenticated_relayer/server.py
+++ b/examples/authenticated_relayer/server.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import hmac
 import logging
-import secrets
 import sqlite3
 import sys
 from functools import lru_cache
@@ -31,18 +31,22 @@ class Authenticator:
             return fail_nothandled
         if not isinstance(auth_data, LoginPassword):
             return fail_nothandled
-        username = auth_data.login
+        # auth_data fields are bytes; the username is stored as text in the DB
+        username = auth_data.login.decode("utf-8", errors="replace")
         password = auth_data.password
-        hashpass = pbkdf2_hmac("sha256", password, secrets.token_bytes(), 1000000).hex()
         conn = sqlite3.connect(self.auth_db)
         curs = conn.execute(
-            "SELECT hashpass FROM userauth WHERE username=?", (username,)
+            "SELECT salt, hashpass FROM userauth WHERE username=?", (username,)
         )
-        hash_db = curs.fetchone()
+        row = curs.fetchone()
         conn.close()
-        if not hash_db:
+        if not row:
             return fail_nothandled
-        if hashpass != hash_db[0]:
+        salt, hash_db = row
+        hashpass = pbkdf2_hmac(
+            "sha256", password, bytes.fromhex(salt), 1000000
+        ).hex()
+        if not hmac.compare_digest(hashpass, hash_db):
             return fail_nothandled
         return AuthResult(success=True)
 

--- a/examples/authenticated_relayer/server.py
+++ b/examples/authenticated_relayer/server.py
@@ -6,6 +6,7 @@ import hmac
 import logging
 import sqlite3
 import sys
+from contextlib import closing
 from functools import lru_cache
 from hashlib import pbkdf2_hmac
 from pathlib import Path
@@ -20,6 +21,16 @@ from aiosmtpd.smtp import AuthResult, LoginPassword
 DEST_PORT = 25
 DB_AUTH = Path("mail.db~")
 
+log = logging.getLogger("mail.log")
+
+# Must match make_user_db.py, or nothing will ever verify.
+HASH_ITERATIONS = 1000000
+
+# Hashed against when the username is unknown, so that case costs the same as a
+# known username with the wrong password. Without it the early return is fast
+# enough to enumerate valid usernames by timing the rejection.
+DUMMY_SALT = bytes(32)
+
 
 class Authenticator:
     def __init__(self, auth_database):
@@ -31,22 +42,48 @@ class Authenticator:
             return fail_nothandled
         if not isinstance(auth_data, LoginPassword):
             return fail_nothandled
-        # auth_data fields are bytes; the username is stored as text in the DB
-        username = auth_data.login.decode("utf-8", errors="replace")
-        password = auth_data.password
-        conn = sqlite3.connect(self.auth_db)
-        curs = conn.execute(
-            "SELECT salt, hashpass FROM userauth WHERE username=?", (username,)
-        )
-        row = curs.fetchone()
-        conn.close()
-        if not row:
+        # auth_data fields are bytes; the username is stored as text in the DB.
+        # Reject a login that is not valid UTF-8 rather than mangling it, which
+        # would fold distinct logins onto one name.
+        try:
+            username = auth_data.login.decode("utf-8")
+        except UnicodeDecodeError:
             return fail_nothandled
-        salt, hash_db = row
-        hashpass = pbkdf2_hmac(
-            "sha256", password, bytes.fromhex(salt), 1000000
-        ).hex()
-        if not hmac.compare_digest(hashpass, hash_db):
+
+        try:
+            with closing(sqlite3.connect(self.auth_db)) as conn:
+                row = conn.execute(
+                    "SELECT salt, hashpass FROM userauth WHERE username=?",
+                    (username,),
+                ).fetchone()
+        except sqlite3.Error:
+            # A configuration problem, not a bad password. Say so in the log;
+            # the client still learns nothing beyond "rejected".
+            log.exception(
+                "cannot read %s. If it predates the salt column, recreate it "
+                "with make_user_db.py",
+                self.auth_db,
+            )
+            return fail_nothandled
+
+        salt, hash_db = row if row else (DUMMY_SALT.hex(), "")
+        try:
+            expected = bytes.fromhex(hash_db)
+            digest = pbkdf2_hmac(
+                "sha256", auth_data.password, bytes.fromhex(salt), HASH_ITERATIONS
+            )
+        except (ValueError, TypeError):
+            log.error(
+                "salt or hashpass stored for %r is not valid hex; recreate %s "
+                "with make_user_db.py",
+                username,
+                self.auth_db,
+            )
+            return fail_nothandled
+
+        # Compared after hashing either way, so the unknown-user path costs the
+        # same as a wrong password.
+        if row is None or not hmac.compare_digest(digest, expected):
             return fail_nothandled
         return AuthResult(success=True)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 atpublic==5.0
 attrs==24.2.0
 coverage==7.8.0
+dnspython==2.8.0  # examples/authenticated_relayer, exercised by test_examples.py
 pytest==8.3.4
 pytest-cov==6.1.1
 pytest-mock==3.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,10 @@
 atpublic==5.0
 attrs==24.2.0
 coverage==7.8.0
-dnspython==2.8.0  # examples/authenticated_relayer, exercised by test_examples.py
+# examples/authenticated_relayer, exercised by test_examples.py.
+# 2.8.0 requires Python >= 3.10, so 3.9 pins one back.
+dnspython==2.7.0; python_version < "3.10"
+dnspython==2.8.0; python_version >= "3.10"
 pytest==8.3.4
 pytest-cov==6.1.1
 pytest-mock==3.14.0

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,8 @@ usedevelop = True
 deps =
     bandit
     colorama
+    # examples/authenticated_relayer, exercised by test_examples.py
+    dnspython
     packaging
     pytest >= 6.0  # Require >= 6.0 for pyproject.toml support (PEP 517)
     pytest-mock


### PR DESCRIPTION
## What do these changes do?

Make the `examples/authenticated_relayer` example actually able to authenticate a user. Two defects made success impossible:

1. `make_user_db.py` hashed each password with `secrets.token_bytes()` but never stored the salt, and `server.py` verified the presented password with *another* fresh random salt, so the two hashes could never be equal (#475).
2. The username lookup passed the raw `bytes` from `LoginPassword` to sqlite, which never matches the `text` column the DB stores, so even the user row was never found.

Changes:

* `make_user_db.py`: store a per-user `salt` column (hex) next to the hash.
* `server.py`: fetch the stored salt, recompute the pbkdf2 hash with it, and compare via `hmac.compare_digest`; decode the username before the lookup.
* One NEWS.rst line under 1.4.7.

Verified end-to-end by generating the DB and driving `Authenticator` directly: correct password accepted; wrong password, unknown user, and unsupported mechanism rejected.

Fixes #475
