### PR TITLE
Add missing type annotations for function arguments

### DIFF
--- a/aiosmtpd/tests/test_handlers.py
+++ b/aiosmtpd/tests/test_handlers.py
@@ -203,7 +203,9 @@ class AsyncDeprecatedHandler:
 
 
 @pytest.fixture
-def debugging_controller(get_controller) -> Generator[Controller, None, None]:
+def debugging_controller(
+    get_controller: Callable[..., Controller],
+) -> Generator[Controller, None, None]:
     # Cannot use plain_controller fixture because we need to first create the
     # Debugging handler before creating the controller.
     stream = StringIO()
@@ -225,7 +227,7 @@ def temp_maildir(tmp_path: Path) -> Path:
 
 @pytest.fixture
 def mailbox_controller(
-    temp_maildir, get_controller
+    temp_maildir: Path, get_controller: Callable[..., Controller]
 ) -> Generator[Controller, None, None]:
     handler = Mailbox(temp_maildir)
     controller = get_controller(handler)
@@ -263,7 +265,9 @@ def with_fake_parser() -> Callable:
 
 
 @pytest.fixture
-def upstream_controller(get_controller) -> Generator[Controller, None, None]:
+def upstream_controller(
+    get_controller: Callable[..., Controller],
+) -> Generator[Controller, None, None]:
     upstream_handler = DataHandler()
     upstream_controller = get_controller(upstream_handler, port=9025)
     upstream_controller.start()
@@ -276,7 +280,7 @@ def upstream_controller(get_controller) -> Generator[Controller, None, None]:
 
 @pytest.fixture
 def proxy_nodecode_controller(
-    upstream_controller, get_controller
+    upstream_controller: Controller, get_controller: Callable[..., Controller]
 ) -> Generator[Union[Controller, KnowsUpstream], None, None]:
     proxy_handler = Proxy(upstream_controller.hostname, upstream_controller.port)
     proxy_controller = get_controller(proxy_handler)
@@ -291,7 +295,7 @@ def proxy_nodecode_controller(
 
 @pytest.fixture
 def proxy_decoding_controller(
-    upstream_controller, get_controller
+    upstream_controller: Controller, get_controller: Callable[..., Controller]
 ) -> Generator[Union[Controller, KnowsUpstream], None, None]:
     proxy_handler = Proxy(upstream_controller.hostname, upstream_controller.port)
     proxy_controller = get_controller(proxy_handler, decode_data=True)

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -21,7 +21,7 @@ from smtplib import (
     SMTPServerDisconnected,
 )
 from textwrap import dedent
-from typing import cast, Any, Callable, Generator, List, Tuple, Union
+from typing import cast, Any, Callable, Generator, List, Optional, Tuple, Union
 
 import pytest
 from pytest_mock import MockFixture
@@ -47,7 +47,7 @@ from aiosmtpd.testing.helpers import (
     reset_connection,
     send_recv,
 )
-from aiosmtpd.testing.statuscodes import SMTP_STATUS_CODES as S
+from aiosmtpd.testing.statuscodes import StatusCode, SMTP_STATUS_CODES as S
 
 CRLF = "\r\n"
 BCRLF = b"\r\n"
@@ -64,7 +64,7 @@ B64EQUALS = b64encode(b"=").decode()
 # region #### Test Helpers ############################################################
 
 
-def auth_callback(mechanism, login, password) -> bool:
+def auth_callback(mechanism: str, login: bytes, password: bytes) -> bool:
     return login and login.decode() == "goodlogin"
 
 
@@ -152,7 +152,7 @@ class PeekerHandler:
     async def auth_DENYFALSE(self, server, args):
         return False
 
-    async def auth_NONE(self, server: Server, args):
+    async def auth_NONE(self, server: Server, args: List[str]):
         await server.push(S.S235_AUTH_SUCCESS.to_str())
         return None
 
@@ -162,7 +162,7 @@ class PeekerHandler:
     async def auth_DONT(self, server, args):
         return MISSING
 
-    async def auth_WITH_UNDERSCORE(self, server: Server, args) -> str:
+    async def auth_WITH_UNDERSCORE(self, server: Server, args: List[str]) -> str:
         """
         Be careful when using this AUTH mechanism; log_client_response is set to
         True, and this will raise some severe warnings.
@@ -196,10 +196,12 @@ class ErroringHandler:
     error = None
     custom_response = False
 
-    async def handle_DATA(self, server, session, envelope) -> str:
+    async def handle_DATA(
+        self, server: Server, session: SMTPSession, envelope: SMTPEnvelope
+    ) -> str:
         return "499 Could not accept the message"
 
-    async def handle_exception(self, error) -> str:
+    async def handle_exception(self, error: Exception) -> str:
         self.error = error
         if not self.custom_response:
             return "500 ErroringHandler handling error"
@@ -970,7 +972,7 @@ class TestSMTPAuth(_CommonMethods):
 class TestAuthMechanisms(_CommonMethods):
     @pytest.fixture
     def do_auth_plain1(
-        self, client
+        self, client: SMTPClient
     ) -> Callable[[str], Tuple[int, bytes]]:
         self._ehlo(client)
 
@@ -982,7 +984,7 @@ class TestAuthMechanisms(_CommonMethods):
 
     @pytest.fixture
     def do_auth_login3(
-        self, client
+        self, client: SMTPClient
     ) -> Callable[[str], Tuple[int, bytes]]:
         self._ehlo(client)
         resp = client.docmd("AUTH LOGIN")
@@ -1109,7 +1111,7 @@ class TestAuthMechanisms(_CommonMethods):
         assert_nopassleak(PW, caplog.record_tuples)
 
     @pytest.fixture
-    def client_auth_plain2(self, client) -> SMTPClient:
+    def client_auth_plain2(self, client: SMTPClient) -> SMTPClient:
         self._ehlo(client)
         resp = client.docmd("AUTH PLAIN")
         assert resp == S.S334_AUTH_EMPTYPROMPT
@@ -1604,7 +1606,9 @@ class TestSMTPWithController(_CommonMethods):
             client.sendmail("anne@example.com", ["bart@example.com"], mail)
         assert exc.value.args == S.S500_DATALINE_TOO_LONG
 
-    def test_long_line_leak(self, mocker: MockFixture, plain_controller, client):
+    def test_long_line_leak(
+        self, mocker: MockFixture, plain_controller: Controller, client: SMTPClient
+    ):
         # Simulates situation where readuntil() does not raise LimitOverrunError,
         # but somehow the line_fragments when join()ed resulted in a too-long line
 
@@ -1720,7 +1724,7 @@ class TestCustomization(_CommonMethods):
 
 class TestClientCrash(_CommonMethods):
     def test_connection_reset_during_DATA(
-        self, mocker: MockFixture, plain_controller, client
+        self, mocker: MockFixture, plain_controller: Controller, client: SMTPClient
     ):
         # Trigger factory() to produce the smtpd server
         self._helo(client)
@@ -1748,7 +1752,7 @@ class TestClientCrash(_CommonMethods):
             plain_controller.stop()
 
     def test_connection_reset_during_command(
-        self, mocker: MockFixture, plain_controller, client
+        self, mocker: MockFixture, plain_controller: Controller, client: SMTPClient
     ):
         # Trigger factory() to produce the smtpd server
         self._helo(client)
@@ -1789,7 +1793,9 @@ class TestClientCrash(_CommonMethods):
         # and still == True if transport is closed.
         assert writer.transport.is_closing()
 
-    def test_close_in_command_2(self, mocker: MockFixture, plain_controller, client):
+    def test_close_in_command_2(
+        self, mocker: MockFixture, plain_controller: Controller, client: SMTPClient
+    ):
         self._helo(client)
         catchup_delay()
         smtpd: Server = plain_controller.smtpd
@@ -1817,7 +1823,9 @@ class TestClientCrash(_CommonMethods):
         # and still == True if transport is closed.
         assert writer.transport.is_closing()
 
-    def test_close_in_data(self, mocker: MockFixture, plain_controller, client):
+    def test_close_in_data(
+        self, mocker: MockFixture, plain_controller: Controller, client: SMTPClient
+    ):
         self._helo(client)
         smtpd: Server = plain_controller.smtpd
         writer = smtpd._writer
@@ -1843,7 +1851,9 @@ class TestClientCrash(_CommonMethods):
         finally:
             plain_controller.stop()
 
-    def test_sockclose_after_helo(self, mocker: MockFixture, plain_controller, client):
+    def test_sockclose_after_helo(
+        self, mocker: MockFixture, plain_controller: Controller, client: SMTPClient
+    ):
         client.send("HELO example.com\r\n")
         catchup_delay()
         smtpd: Server = plain_controller.smtpd
@@ -1966,7 +1976,12 @@ class TestAuthArgs:
 
 class TestLimits(_CommonMethods):
     def _consume_budget(
-        self, client: SMTPClient, nums: int, cmd: str, *args, ok_expected=None
+        self,
+        client: SMTPClient,
+        nums: int,
+        cmd: str,
+        *args,
+        ok_expected: Optional[StatusCode] = None
     ):
         code, _ = client.ehlo("example.com")
         assert code == 250

--- a/aiosmtpd/tests/test_smtps.py
+++ b/aiosmtpd/tests/test_smtps.py
@@ -3,9 +3,11 @@
 
 """Test SMTP over SSL/TLS."""
 
+import ssl
+
 from email.mime.text import MIMEText
 from smtplib import SMTP, SMTP_SSL
-from typing import Generator, Union
+from typing import Callable, Generator, Union
 
 import pytest
 
@@ -18,7 +20,7 @@ from .conftest import Global
 
 @pytest.fixture
 def ssl_controller(
-    get_controller, ssl_context_server
+    get_controller: Callable[..., Controller], ssl_context_server: ssl.SSLContext
 ) -> Generator[Controller, None, None]:
     handler = ReceivingHandler()
     controller = get_controller(handler, ssl_context=ssl_context_server)
@@ -31,14 +33,18 @@ def ssl_controller(
 
 
 @pytest.fixture
-def smtps_client(ssl_context_client) -> Generator[Union[SMTP_SSL, SMTP], None, None]:
+def smtps_client(
+    ssl_context_client: ssl.SSLContext,
+) -> Generator[Union[SMTP_SSL, SMTP], None, None]:
     context = ssl_context_client
     with SMTP_SSL(*Global.SrvAddr, context=context) as client:
         yield client
 
 
 class TestSMTPS:
-    def test_smtps(self, ssl_controller, smtps_client):
+    def test_smtps(
+        self, ssl_controller: Controller, smtps_client: Union[SMTP_SSL, SMTP]
+    ) -> None:
         sender = "sender@example.com"
         recipients = ["rcpt1@example.com"]
         resp = smtps_client.helo("example.com")

--- a/aiosmtpd/tests/test_starttls.py
+++ b/aiosmtpd/tests/test_starttls.py
@@ -5,7 +5,7 @@ import ssl
 from contextlib import suppress
 from email.mime.text import MIMEText
 from smtplib import SMTPServerDisconnected
-from typing import Generator
+from typing import Callable, Generator
 
 import pytest
 
@@ -42,7 +42,7 @@ class EOFingHandler:
 
 class HandshakeFailingHandler:
     def handle_STARTTLS(
-            self, server: Server, session: Sess_, envelope: Envelope
+        self, server: Server, session: Sess_, envelope: Envelope
     ) -> bool:
         return False
 
@@ -55,7 +55,9 @@ class HandshakeFailingHandler:
 
 @pytest.fixture
 def tls_controller(
-    get_handler, get_controller, ssl_context_server
+    get_handler: Callable,
+    get_controller: Callable[..., Controller],
+    ssl_context_server: ssl.SSLContext,
 ) -> Generator[Controller, None, None]:
     handler = get_handler()
     # controller = TLSController(handler)
@@ -79,7 +81,9 @@ def tls_controller(
 
 @pytest.fixture
 def tls_req_controller(
-    get_handler, get_controller, ssl_context_server
+    get_handler: Callable,
+    get_controller: Callable[..., Controller],
+    ssl_context_server: ssl.SSLContext,
 ) -> Generator[Controller, None, None]:
     handler = get_handler()
     controller = get_controller(
@@ -98,7 +102,9 @@ def tls_req_controller(
 
 @pytest.fixture
 def auth_req_tls_controller(
-    get_handler, get_controller, ssl_context_server
+    get_handler: Callable,
+    get_controller: Callable[..., Controller],
+    ssl_context_server: ssl.SSLContext,
 ) -> Generator[Controller, None, None]:
     handler = get_handler()
     controller = get_controller(

--- a/setup.cfg
+++ b/setup.cfg
@@ -117,8 +117,6 @@ ignore =
     # Explicit is better than implicit, range(0, val) is more explicit than range(val).
     PIE808
 per-file-ignores =
-    # FIXME add the 45 missing type annotations
-    aiosmtpd/tests/test_*:ANN001
     # S101: Pytest uses assert
     aiosmtpd/tests/*:S101
     aiosmtpd/tests/test_proxyprotocol.py:DUO102


### PR DESCRIPTION
## What do these changes do?
Allows removal of related flake8 override.
## Are there changes in behavior for the user?
No.
## Related issue number
No related issue.
## Checklist
- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] tox testenvs have been executed in the following environments:
  - [x] Linux (Ubuntu 18.04, Ubuntu 20.04, Arch): `{py39,py310,py311,py312}-{nocov,cov,diffcov}, qa, docs`
  - [ ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- [ ] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file