### PR TITLE
Add missing annotations addressing most flake8 ANN violations

### DIFF
--- a/aiosmtpd/docs/_exts/autoprogramm.py
+++ b/aiosmtpd/docs/_exts/autoprogramm.py
@@ -73,7 +73,7 @@ def scan_programs(
     maxdepth: int = 0,
     depth: int = 0,
     groups: bool = False,
-):
+) -> Iterable[Tuple[List[str], Any, Any]]:
     if command is None:
         command = []
 
@@ -107,7 +107,7 @@ def scan_programs(
                 yield from scan_programs(sub, command + [cmd], maxdepth, depth + 1)
 
 
-def scan_options(actions: list):
+def scan_options(actions: list) -> Iterable[Tuple[List[str], str]]:
     for arg in actions:
         if not (arg.option_strings or isinstance(arg, argparse._SubParsersAction)):
             yield format_positional_argument(arg)
@@ -201,7 +201,7 @@ class AutoprogrammDirective(Directive):
         "options_adornment": unchanged,
     }
 
-    def make_rst(self):
+    def make_rst(self) -> Iterable[str]:
         (import_name,) = self.arguments
         parser = import_object(import_name or "__undefined__")
         prog = self.options.get("prog")
@@ -306,7 +306,7 @@ def render_rst(
     epilog: Optional[str],
     options_title: Optional[str],
     options_adornment: str,
-):
+) -> Iterable[str]:
     if usage_strip:
         assert usage is not None
         to_strip = (title or "").rsplit(" ", 1)[0]

--- a/aiosmtpd/docs/conf.py
+++ b/aiosmtpd/docs/conf.py
@@ -36,7 +36,7 @@ else:
 repo_root = Path(".").expanduser().absolute().parent.parent
 
 
-def syspath_insert(pth: Path):
+def syspath_insert(pth: Path) -> None:
     print(f"Inserting {pth}")
     sys.path.insert(0, str(pth))
 
@@ -335,5 +335,5 @@ texinfo_documents = [
 # endregion
 
 
-def setup(app: _S):
+def setup(app: _S) -> None:
     app.add_css_file("aiosmtpd.css")

--- a/aiosmtpd/docs/conf.py
+++ b/aiosmtpd/docs/conf.py
@@ -18,6 +18,7 @@ import sys
 from pathlib import Path
 from typing import Dict
 
+from sphinx.application import Sphinx as _S
 import sphinx_rtd_theme  # noqa: F401 # pytype: disable=import-error
 
 try:
@@ -334,5 +335,5 @@ texinfo_documents = [
 # endregion
 
 
-def setup(app):  # noqa: ANN001
+def setup(app: _S):
     app.add_css_file("aiosmtpd.css")

--- a/aiosmtpd/qa/test_0packaging.py
+++ b/aiosmtpd/qa/test_0packaging.py
@@ -26,7 +26,7 @@ def aiosmtpd_version() -> version.Version:
 
 
 class TestVersion:
-    def test_pep440(self, aiosmtpd_version: version.Version):
+    def test_pep440(self, aiosmtpd_version: version.Version) -> None:
         """Ensure version number compliance to PEP-440"""
         assert isinstance(
             aiosmtpd_version, version.Version
@@ -35,7 +35,7 @@ class TestVersion:
     # noinspection PyUnboundLocalVariable
     def test_ge_master(
         self, aiosmtpd_version: version.Version, capsys: pytest.CaptureFixture
-    ):
+    ) -> None:
         """Ensure version is monotonically increasing"""
         reference = "master:aiosmtpd/__init__.py"
         cmd = f"git show {reference}".split()
@@ -56,7 +56,7 @@ class TestVersion:
 class TestNews:
     news_rst = list(Path(__file__).parent.parent.rglob("*/NEWS.rst"))[0]
 
-    def test_NEWS_version(self, aiosmtpd_version: version.Version):
+    def test_NEWS_version(self, aiosmtpd_version: version.Version) -> None:
         with self.news_rst.open("rt") as fin:
             # pairwise() from https://docs.python.org/3/library/itertools.html
             a, b = tee(fin)
@@ -78,7 +78,7 @@ class TestNews:
                 f"{newsver.base_version} < {aiosmtpd_version.base_version}"
             )
 
-    def test_release_date(self, aiosmtpd_version: version.Version):
+    def test_release_date(self, aiosmtpd_version: version.Version) -> None:
         if aiosmtpd_version.pre is not None:
             pytest.skip("Not a release version")
         with self.news_rst.open("rt") as fin:

--- a/aiosmtpd/qa/test_1testsuite.py
+++ b/aiosmtpd/qa/test_1testsuite.py
@@ -6,6 +6,7 @@
 import re
 import pytest
 import socket
+import typing as _t
 
 from aiosmtpd.testing import statuscodes
 from itertools import combinations
@@ -19,7 +20,7 @@ RE_ESC = re.compile(rb"(?P<digit1>\d)\.\d+\.\d+\s")
 
 # noinspection PyUnresolvedReferences
 @pytest.fixture(scope="module", autouse=True)
-def exit_on_fail(request: pytest.FixtureRequest):
+def exit_on_fail(request: pytest.FixtureRequest) -> _t.Generator:
     # Behavior of this will be undefined if tests are running in parallel.
     # But since parallel running is not practically possible (the ports will conflict),
     # then I don't think that will be a problem.
@@ -35,17 +36,17 @@ STATUS_CODES = {
 
 
 class TestStatusCodes:
-    def test_elemtype(self):
+    def test_elemtype(self) -> None:
         """Ensure status codes are instances of StatusCode"""
         for value in STATUS_CODES.values():
             assert isinstance(value, statuscodes.StatusCode)
 
-    def test_nameval(self):
+    def test_nameval(self) -> None:
         """Ensure each status code constant has SMTP Code embedded in the name"""
         for key, value in STATUS_CODES.items():
             assert int(key[1:4]) == value.code
 
-    def test_enhanced(self):
+    def test_enhanced(self) -> None:
         """Compliance with RFC 2034 § 4"""
         total_correct = 0
         for key, value in STATUS_CODES.items():
@@ -70,7 +71,7 @@ class TestStatusCodes:
             total_correct += 1  # noqa: SIM113
         assert total_correct > 0
 
-    def test_commands(self):
+    def test_commands(self) -> None:
         """
         Ensure lists in statuscodes are individual objects, so changes in one list
         won't affect the other lists
@@ -86,7 +87,7 @@ class TestStatusCodes:
 
 
 class TestHarness:
-    def test_fqdn_cached(self):
+    def test_fqdn_cached(self) -> None:
         """
         Ensure that socket.getfqdn does not change between calls
         """

--- a/aiosmtpd/testing/helpers.py
+++ b/aiosmtpd/testing/helpers.py
@@ -21,7 +21,7 @@ to be increased for slow and/or overburdened test systems.
 """
 
 
-def reset_connection(client: SMTP_Client):
+def reset_connection(client: SMTP_Client) -> None:
     # Close the connection with a TCP RST instead of a TCP FIN.  client must
     # be a smtplib.SMTP instance.
     #
@@ -58,7 +58,7 @@ class ReceivingHandler:
         return "250 OK"
 
 
-def catchup_delay(delay: float = ASYNCIO_CATCHUP_DELAY):
+def catchup_delay(delay: float = ASYNCIO_CATCHUP_DELAY) -> None:
     """
     Sleep for awhile to give asyncio's event loop time to catch up.
     """

--- a/aiosmtpd/testing/helpers.py
+++ b/aiosmtpd/testing/helpers.py
@@ -48,7 +48,7 @@ def reset_connection(client: SMTP_Client) -> None:
 
 
 class ReceivingHandler:
-    def __init__(self):
+    def __init__(self) -> None:
         self.box: List[Envelope] = []
 
     async def handle_DATA(

--- a/aiosmtpd/tests/conftest.py
+++ b/aiosmtpd/tests/conftest.py
@@ -82,7 +82,7 @@ AUTOSTOP_DELAY = 1.5
 
 # autouse=True and scope="session" automatically apply this fixture to ALL test cases
 @pytest.fixture(autouse=True, scope="session")
-def cache_fqdn(session_mocker: MockFixture):
+def cache_fqdn(session_mocker: MockFixture) -> None:
     """
     This fixture "caches" the socket.getfqdn() call. VERY necessary to prevent
     situations where quick repeated getfqdn() causes extreme slowdown. Probably due to

--- a/aiosmtpd/tests/conftest.py
+++ b/aiosmtpd/tests/conftest.py
@@ -65,7 +65,7 @@ class Global:
     FQDN: str = socket.getfqdn()
 
     @classmethod
-    def set_addr_from(cls, contr: Controller):
+    def set_addr_from(cls, contr: Controller) -> None:
         cls.SrvAddr = HostPort(contr.hostname, contr.port)
 
 

--- a/aiosmtpd/tests/test_handlers.py
+++ b/aiosmtpd/tests/test_handlers.py
@@ -203,7 +203,9 @@ class AsyncDeprecatedHandler:
 
 
 @pytest.fixture
-def debugging_controller(get_controller) -> Generator[Controller, None, None]:
+def debugging_controller(
+    get_controller: Callable[..., Controller],
+) -> Generator[Controller, None, None]:
     # Cannot use plain_controller fixture because we need to first create the
     # Debugging handler before creating the controller.
     stream = StringIO()
@@ -225,7 +227,7 @@ def temp_maildir(tmp_path: Path) -> Path:
 
 @pytest.fixture
 def mailbox_controller(
-    temp_maildir, get_controller
+    temp_maildir: Path, get_controller: Callable[..., Controller]
 ) -> Generator[Controller, None, None]:
     handler = Mailbox(temp_maildir)
     controller = get_controller(handler)
@@ -263,7 +265,9 @@ def with_fake_parser() -> Callable:
 
 
 @pytest.fixture
-def upstream_controller(get_controller) -> Generator[Controller, None, None]:
+def upstream_controller(
+    get_controller: Callable[..., Controller],
+) -> Generator[Controller, None, None]:
     upstream_handler = DataHandler()
     upstream_controller = get_controller(upstream_handler, port=9025)
     upstream_controller.start()
@@ -276,7 +280,7 @@ def upstream_controller(get_controller) -> Generator[Controller, None, None]:
 
 @pytest.fixture
 def proxy_nodecode_controller(
-    upstream_controller, get_controller
+    upstream_controller: Controller, get_controller: Callable[..., Controller]
 ) -> Generator[Union[Controller, KnowsUpstream], None, None]:
     proxy_handler = Proxy(upstream_controller.hostname, upstream_controller.port)
     proxy_controller = get_controller(proxy_handler)
@@ -291,7 +295,7 @@ def proxy_nodecode_controller(
 
 @pytest.fixture
 def proxy_decoding_controller(
-    upstream_controller, get_controller
+    upstream_controller: Controller, get_controller: Callable[..., Controller]
 ) -> Generator[Union[Controller, KnowsUpstream], None, None]:
     proxy_handler = Proxy(upstream_controller.hostname, upstream_controller.port)
     proxy_controller = get_controller(proxy_handler, decode_data=True)

--- a/aiosmtpd/tests/test_handlers.py
+++ b/aiosmtpd/tests/test_handlers.py
@@ -1,6 +1,7 @@
 # Copyright 2014-2021 The aiosmtpd Developers
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 import logging
 import sys
 from email.message import Message as Em_Message
@@ -11,9 +12,10 @@ from pathlib import Path
 from smtplib import SMTPDataError, SMTPRecipientsRefused
 from textwrap import dedent
 from types import SimpleNamespace
-from typing import AnyStr, Callable, Generator, Type, TypeVar, Union
+from typing import AnyStr, Callable, Generator, List, Optional, Type, TypeVar, Union
 
 import pytest
+from pytest_mock import MockFixture
 
 from aiosmtpd.controller import Controller
 from aiosmtpd.handlers import AsyncMessage, Debugging, Mailbox, Proxy, Sink
@@ -23,6 +25,8 @@ from aiosmtpd.smtp import Session as ServerSession
 from aiosmtpd.smtp import Envelope
 from aiosmtpd.testing.statuscodes import SMTP_STATUS_CODES as S
 from aiosmtpd.testing.statuscodes import StatusCode
+
+from smtplib import SMTP as SMTPClient
 
 from .conftest import Global, controller_data, handler_data
 
@@ -89,7 +93,9 @@ class AsyncMessageHandler(AsyncMessage):
 class HELOHandler:
     ReturnCode = StatusCode(250, b"pepoluan.was.here")
 
-    async def handle_HELO(self, server, session, envelope, hostname):
+    async def handle_HELO(
+        self, server: Server, session: ServerSession, envelope: Envelope, hostname: str
+    ):
         return self.ReturnCode.to_str()
 
 
@@ -97,7 +103,9 @@ class EHLOHandlerDeprecated:
     Domain = "alex.example.code"
     ReturnCode = StatusCode(250, Domain.encode("ascii"))
 
-    async def handle_EHLO(self, server, session, envelope, hostname):
+    async def handle_EHLO(
+        self, server: Server, session: ServerSession, envelope: Envelope, hostname: str
+    ):
         return self.ReturnCode.to_str()
 
 
@@ -110,7 +118,14 @@ class EHLOHandlerNew:
     def __init__(self, *features):
         self.features = features or tuple()
 
-    async def handle_EHLO(self, server, session, envelope, hostname, responses):
+    async def handle_EHLO(
+        self,
+        server: Server,
+        session: ServerSession,
+        envelope: Envelope,
+        hostname: str,
+        responses: List[str],
+    ):
         self.hostname = hostname
         self.orig_responses.clear()
         self.orig_responses.extend(responses)
@@ -121,12 +136,22 @@ class EHLOHandlerNew:
 
 
 class EHLOHandlerIncompatibleShort:
-    async def handle_EHLO(self, server, session, envelope):
+    async def handle_EHLO(
+        self, server: Server, session: ServerSession, envelope: Envelope
+    ):
         return
 
 
 class EHLOHandlerIncompatibleLong:
-    async def handle_EHLO(self, server, session, envelope, hostname, responses, xtra):
+    async def handle_EHLO(
+        self,
+        server: Server,
+        session: ServerSession,
+        envelope: Envelope,
+        hostname: str,
+        responses: List[str],
+        xtra: str,
+    ):
         return
 
 
@@ -134,7 +159,14 @@ class MAILHandler:
     ReplacementOptions = ["WAS_HANDLED"]
     ReturnCode = StatusCode(250, b"Yeah, sure")
 
-    async def handle_MAIL(self, server, session, envelope, address, options):
+    async def handle_MAIL(
+        self,
+        server: Server,
+        session: ServerSession,
+        envelope: Envelope,
+        address: str,
+        options: dict,
+    ):
         envelope.mail_options = self.ReplacementOptions
         return self.ReturnCode.to_str()
 
@@ -142,7 +174,14 @@ class MAILHandler:
 class RCPTHandler:
     RejectCode = StatusCode(550, b"Rejected")
 
-    async def handle_RCPT(self, server, session, envelope, address, options):
+    async def handle_RCPT(
+        self,
+        server: Server,
+        session: ServerSession,
+        envelope: Envelope,
+        address: str,
+        options: dict,
+    ):
         envelope.rcpt_options.extend(options)
         if address == "bart@example.com":
             return self.RejectCode.to_str()
@@ -153,12 +192,16 @@ class RCPTHandler:
 class ErroringDataHandler:
     ReturnCode = StatusCode(599, b"Not today")
 
-    async def handle_DATA(self, server, session, envelope):
+    async def handle_DATA(
+        self, server: Server, session: ServerSession, envelope: Envelope
+    ):
         return self.ReturnCode.to_str()
 
 
 class AUTHHandler:
-    async def handle_AUTH(self, server, session, envelope, args):
+    async def handle_AUTH(
+        self, server: Server, session: ServerSession, envelope: Envelope, args: List[str]
+    ):
         server.authenticates = True
         return S.S235_AUTH_SUCCESS.to_str()
 
@@ -187,12 +230,26 @@ class DeprecatedHookController(Controller):
 
 
 class DeprecatedHandler:
-    def process_message(self, peer, mailfrom, rcpttos, data, **kws):
+    def process_message(
+        self,
+        peer: AnyStr,
+        mailfrom: str,
+        rcpttos: List[str],
+        data: AnyStr,
+        **kws: AnyStr,
+    ):
         pass
 
 
 class AsyncDeprecatedHandler:
-    async def process_message(self, peer, mailfrom, rcpttos, data, **kws):
+    async def process_message(
+        self,
+        peer: AnyStr,
+        mailfrom: str,
+        rcpttos: List[str],
+        data: AnyStr,
+        **kws: AnyStr,
+    ):
         pass
 
 
@@ -313,7 +370,9 @@ def proxy_decoding_controller(
 
 class TestDebugging:
     @controller_data(decode_data=True)
-    def test_debugging(self, debugging_controller, client):
+    def test_debugging(
+        self, debugging_controller: Controller, client: SMTPClient
+    ):
         peer = client.sock.getsockname()
         client.sendmail(
             "anne@example.com",
@@ -346,7 +405,9 @@ class TestDebugging:
             """
         )
 
-    def test_debugging_bytes(self, debugging_controller, client):
+    def test_debugging_bytes(
+        self, debugging_controller: Controller, client: SMTPClient
+    ):
         peer = client.sock.getsockname()
         client.sendmail(
             "anne@example.com",
@@ -379,7 +440,9 @@ class TestDebugging:
             """
         )
 
-    def test_debugging_without_options(self, debugging_controller, client):
+    def test_debugging_without_options(
+        self, debugging_controller: Controller, client: SMTPClient
+    ):
         # Prevent ESMTP options.
         client.helo()
         peer = client.sock.getsockname()
@@ -412,7 +475,9 @@ class TestDebugging:
             """
         )
 
-    def test_debugging_with_options(self, debugging_controller, client):
+    def test_debugging_with_options(
+        self, debugging_controller: Controller, client: SMTPClient
+    ):
         peer = client.sock.getsockname()
         client.sendmail(
             "anne@example.com",
@@ -457,7 +522,7 @@ class TestMessage:
         ],
         ids=["bytes", "bytearray", "str"]
     )
-    def test_prepare_message(self, temp_event_loop, content):
+    def test_prepare_message(self, temp_event_loop: asyncio.AbstractEventLoop, content: Union[bytes, bytearray, str]):
         sess_ = ServerSession(temp_event_loop)
         enve_ = Envelope()
         handler = MessageHandler()
@@ -477,7 +542,12 @@ class TestMessage:
         ],
         ids=("None", "List", "Dict", "Tuple")
     )
-    def test_prepare_message_err(self, temp_event_loop, content, expectre):
+    def test_prepare_message_err(
+        self,
+        temp_event_loop: asyncio.AbstractEventLoop,
+        content: Optional[Union[list, dict, tuple]],
+        expectre: str,
+    ):
         sess_ = ServerSession(temp_event_loop)
         enve_ = Envelope()
         handler = MessageHandler()
@@ -486,7 +556,7 @@ class TestMessage:
             _ = handler.prepare_message(sess_, enve_)
 
     @handler_data(class_=DataHandler)
-    def test_message(self, plain_controller, client):
+    def test_message(self, plain_controller: Controller, client: SMTPClient):
         handler = plain_controller.handler
         assert isinstance(handler, DataHandler)
         # In this test, the message content comes in as a bytes.
@@ -510,7 +580,9 @@ class TestMessage:
         assert isinstance(handler.original_content, bytes)
 
     @handler_data(class_=DataHandler)
-    def test_message_decoded(self, decoding_controller, client):
+    def test_message_decoded(
+        self, decoding_controller: Controller, client: SMTPClient
+    ):
         handler = decoding_controller.handler
         assert isinstance(handler, DataHandler)
         # In this test, the message content comes in as a string.
@@ -533,7 +605,9 @@ class TestMessage:
         assert isinstance(handler.original_content, bytes)
 
     @handler_data(class_=AsyncMessageHandler)
-    def test_message_async(self, plain_controller, client):
+    def test_message_async(
+        self, plain_controller: Controller, client: SMTPClient
+    ):
         handler = plain_controller.handler
         assert isinstance(handler, AsyncMessageHandler)
         # In this test, the message data comes in as bytes.
@@ -559,7 +633,9 @@ class TestMessage:
         assert handled_message["X-RcptTo"] == "bart@example.com"
 
     @handler_data(class_=AsyncMessageHandler)
-    def test_message_decoded_async(self, decoding_controller, client):
+    def test_message_decoded_async(
+        self, decoding_controller: Controller, client: SMTPClient
+    ):
         handler = decoding_controller.handler
         assert isinstance(handler, AsyncMessageHandler)
         # With a server that decodes the data, the messages come in as
@@ -589,7 +665,12 @@ class TestMessage:
 
 
 class TestMailbox:
-    def test_mailbox(self, temp_maildir, mailbox_controller, client):
+    def test_mailbox(
+        self,
+        temp_maildir: Path,
+        mailbox_controller: Controller,
+        client: SMTPClient,
+    ):
         client.sendmail(
             "aperson@example.com",
             ["bperson@example.com"],
@@ -638,7 +719,12 @@ class TestMailbox:
         expect = ["<ant>", "<bee>", "<cat>"]
         assert [message["message-id"] for message in messages] == expect
 
-    def test_mailbox_reset(self, temp_maildir, mailbox_controller, client):
+    def test_mailbox_reset(
+        self,
+        temp_maildir: Path,
+        mailbox_controller: Controller,
+        client: SMTPClient,
+    ):
         client.sendmail(
             "aperson@example.com",
             ["bperson@example.com"],
@@ -659,56 +745,56 @@ class TestMailbox:
 
 
 class TestCLI:
-    def test_debugging_no_args(self, with_fake_parser):
+    def test_debugging_no_args(self, with_fake_parser: Callable):
         handler = with_fake_parser(Debugging)
         assert handler.exception is None
         assert handler.fparser.message is None
         assert handler.stream == sys.stdout
 
-    def test_debugging_two_args(self, with_fake_parser):
+    def test_debugging_two_args(self, with_fake_parser: Callable):
         handler = with_fake_parser(Debugging, "foo", "bar")
         assert handler.exception is SystemExit
         assert handler.fparser.message == "Debugging usage: [stdout|stderr]"
 
-    def test_debugging_stdout(self, with_fake_parser):
+    def test_debugging_stdout(self, with_fake_parser: Callable):
         handler = with_fake_parser(Debugging, "stdout")
         assert handler.exception is None
         assert handler.fparser.message is None
         assert handler.stream == sys.stdout
 
-    def test_debugging_stderr(self, with_fake_parser):
+    def test_debugging_stderr(self, with_fake_parser: Callable):
         handler = with_fake_parser(Debugging, "stderr")
         assert handler.exception is None
         assert handler.fparser.message is None
         assert handler.stream == sys.stderr
 
-    def test_debugging_bad_argument(self, with_fake_parser):
+    def test_debugging_bad_argument(self, with_fake_parser: Callable):
         handler = with_fake_parser(Debugging, "stdfoo")
         assert handler.exception is SystemExit
         assert handler.fparser.message == "Debugging usage: [stdout|stderr]"
 
-    def test_sink_no_args(self, with_fake_parser):
+    def test_sink_no_args(self, with_fake_parser: Callable):
         handler = with_fake_parser(Sink)
         assert handler.exception is None
         assert handler.fparser.message is None
         assert isinstance(handler, Sink)
 
-    def test_sink_any_args(self, with_fake_parser):
+    def test_sink_any_args(self, with_fake_parser: Callable):
         handler = with_fake_parser(Sink, "foo")
         assert handler.exception is SystemExit
         assert handler.fparser.message == "Sink handler does not accept arguments"
 
-    def test_mailbox_no_args(self, with_fake_parser):
+    def test_mailbox_no_args(self, with_fake_parser: Callable):
         handler = with_fake_parser(Mailbox)
         assert handler.exception is SystemExit
         assert handler.fparser.message == "The directory for the maildir is required"
 
-    def test_mailbox_too_many_args(self, with_fake_parser):
+    def test_mailbox_too_many_args(self, with_fake_parser: Callable):
         handler = with_fake_parser(Mailbox, "foo", "bar", "baz")
         assert handler.exception is SystemExit
         assert handler.fparser.message == "Too many arguments for Mailbox handler"
 
-    def test_mailbox(self, with_fake_parser, temp_maildir):
+    def test_mailbox(self, with_fake_parser: Callable, temp_maildir: Path):
         handler = with_fake_parser(Mailbox, temp_maildir)
         assert handler.exception is None
         assert handler.fparser.message is None
@@ -743,7 +829,9 @@ class TestProxy:
     # the one under test here- listens on port 9024 and proxies to the one
     # on port 9025.
 
-    def test_deliver_bytes(self, proxy_nodecode_controller, client):
+    def test_deliver_bytes(
+        self, proxy_nodecode_controller: Union[Controller, KnowsUpstream], client: SMTPClient
+    ):
         client.sendmail(self.sender_addr, [self.receiver_addr], self.source)
         upstream = proxy_nodecode_controller.upstream
         upstream_handler = upstream.handler
@@ -753,7 +841,9 @@ class TestProxy:
         assert upstream.handler.content == expected
         assert upstream.handler.original_content == expected
 
-    def test_deliver_str(self, proxy_decoding_controller, client):
+    def test_deliver_str(
+        self, proxy_decoding_controller: Union[Controller, KnowsUpstream], client: SMTPClient
+    ):
         client.sendmail(self.sender_addr, [self.receiver_addr], self.source)
         upstream = proxy_decoding_controller.upstream
         upstream_handler = upstream.handler
@@ -777,12 +867,16 @@ class TestProxyMocked:
     )
 
     @pytest.fixture
-    def patch_smtp_refused(self, mocker):
+    def patch_smtp_refused(self, mocker: MockFixture):
         mock = mocker.patch("aiosmtpd.handlers.smtplib.SMTP")
         mock().sendmail.side_effect = SMTPRecipientsRefused(self.BAD_BART)
 
     def test_recipients_refused(
-        self, caplog, patch_smtp_refused, proxy_decoding_controller, client
+        self,
+        caplog: pytest.LogCaptureFixture,
+        patch_smtp_refused: None,
+        proxy_decoding_controller: Union[Controller, KnowsUpstream],
+        client: SMTPClient,
     ):
         logger_name = "mail.debug"
         caplog.set_level(logging.INFO, logger=logger_name)
@@ -810,12 +904,16 @@ class TestProxyMocked:
         assert _l2 < _l1, "Log entries in wrong order"
 
     @pytest.fixture
-    def patch_smtp_oserror(self, mocker):
+    def patch_smtp_oserror(self, mocker: MockFixture):
         mock = mocker.patch("aiosmtpd.handlers.smtplib.SMTP")
         mock().sendmail.side_effect = OSError
 
     def test_oserror(
-        self, caplog, patch_smtp_oserror, proxy_decoding_controller, client
+        self,
+        caplog: pytest.LogCaptureFixture,
+        patch_smtp_oserror: None,
+        proxy_decoding_controller: Union[Controller, KnowsUpstream],
+        client: SMTPClient,
     ):
         logger_name = "mail.debug"
         caplog.set_level(logging.INFO, logger=logger_name)
@@ -833,14 +931,16 @@ class TestProxyMocked:
 
 class TestHooks:
     @handler_data(class_=HELOHandler)
-    def test_hook_HELO(self, plain_controller, client):
+    def test_hook_HELO(self, plain_controller: Controller, client: SMTPClient):
         assert isinstance(plain_controller.handler, HELOHandler)
         resp = client.helo("me")
         assert resp == HELOHandler.ReturnCode
 
     @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     @handler_data(class_=EHLOHandlerDeprecated)
-    def test_hook_EHLO_deprecated(self, plain_controller, client):
+    def test_hook_EHLO_deprecated(
+        self, plain_controller: Controller, client: SMTPClient
+    ):
         assert isinstance(plain_controller.handler, EHLOHandlerDeprecated)
         code, mesg = client.ehlo("me")
         lines = mesg.decode("utf-8").splitlines()
@@ -863,7 +963,7 @@ class TestHooks:
         class_=EHLOHandlerNew,
         args_=("FEATURE1", "FEATURE2 OPTION", "FEAT3 OPTA OPTB"),
     )
-    def test_hook_EHLO_new(self, plain_controller, client):
+    def test_hook_EHLO_new(self, plain_controller: Controller, client: SMTPClient):
         assert isinstance(plain_controller.handler, EHLOHandlerNew)
         code, mesg = client.ehlo("me")
         lines = mesg.decode("utf-8").splitlines()
@@ -887,12 +987,12 @@ class TestHooks:
         [EHLOHandlerIncompatibleShort, EHLOHandlerIncompatibleLong],
         ids=["TooShort", "TooLong"],
     )
-    def test_hook_EHLO_incompat(self, handler_class):
+    def test_hook_EHLO_incompat(self, handler_class: Type):
         with pytest.raises(RuntimeError, match="Unsupported EHLO Hook"):
             _ = Server(handler_class())
 
     @handler_data(class_=MAILHandler)
-    def test_hook_MAIL(self, plain_controller, client):
+    def test_hook_MAIL(self, plain_controller: Controller, client: SMTPClient):
         assert isinstance(plain_controller, Controller)
         handler = plain_controller.handler
         assert isinstance(handler, MAILHandler)
@@ -903,7 +1003,7 @@ class TestHooks:
         assert smtpd.envelope.mail_options == MAILHandler.ReplacementOptions
 
     @handler_data(class_=RCPTHandler)
-    def test_hook_RCPT(self, plain_controller, client):
+    def test_hook_RCPT(self, plain_controller: Controller, client: SMTPClient):
         assert isinstance(plain_controller.handler, RCPTHandler)
         client.helo("me")
         with pytest.raises(SMTPRecipientsRefused) as excinfo:
@@ -924,7 +1024,7 @@ class TestHooks:
         }
 
     @handler_data(class_=ErroringDataHandler)
-    def test_hook_DATA(self, plain_controller, client):
+    def test_hook_DATA(self, plain_controller: Controller, client: SMTPClient):
         assert isinstance(plain_controller.handler, ErroringDataHandler)
         with pytest.raises(SMTPDataError) as excinfo:
             client.sendmail(
@@ -946,14 +1046,14 @@ class TestHooks:
 
     @controller_data(decode_data=True, auth_require_tls=False)
     @handler_data(class_=AUTHHandler)
-    def test_hook_AUTH(self, plain_controller, client):
+    def test_hook_AUTH(self, plain_controller: Controller, client: SMTPClient):
         assert isinstance(plain_controller.handler, AUTHHandler)
         client.ehlo("me")
         resp = client.login("test", "test")
         assert resp == S.S235_AUTH_SUCCESS
 
     @handler_data(class_=NoHooksHandler)
-    def test_hook_NoHooks(self, plain_controller, client):
+    def test_hook_NoHooks(self, plain_controller: Controller, client: SMTPClient):
         assert isinstance(plain_controller.handler, NoHooksHandler)
         client.helo("me")
         client.mail("anne@example.com")
@@ -972,7 +1072,7 @@ class TestHooks:
 
 
 class TestDeprecation:
-    def _process_message_testing(self, controller, client):
+    def _process_message_testing(self, controller: Controller, client: SMTPClient):
         assert isinstance(controller, Controller)
         expectedre = r"Use handler.handle_DATA\(\) instead of .process_message\(\)"
         with pytest.warns(DeprecationWarning, match=expectedre):
@@ -991,7 +1091,7 @@ class TestDeprecation:
             )
 
     @handler_data(class_=DeprecatedHandler)
-    def test_process_message(self, plain_controller, client):
+    def test_process_message(self, plain_controller: Controller, client: SMTPClient):
         """handler.process_message is Deprecated"""
         handler = plain_controller.handler
         assert isinstance(handler, DeprecatedHandler)
@@ -999,7 +1099,9 @@ class TestDeprecation:
         self._process_message_testing(controller, client)
 
     @handler_data(class_=AsyncDeprecatedHandler)
-    def test_process_message_async(self, plain_controller, client):
+    def test_process_message_async(
+        self, plain_controller: Controller, client: SMTPClient
+    ):
         """handler.process_message is Deprecated"""
         handler = plain_controller.handler
         assert isinstance(handler, AsyncDeprecatedHandler)
@@ -1007,14 +1109,14 @@ class TestDeprecation:
         self._process_message_testing(controller, client)
 
     @controller_data(class_=DeprecatedHookController)
-    def test_ehlo_hook(self, plain_controller, client):
+    def test_ehlo_hook(self, plain_controller: Controller, client: SMTPClient):
         """SMTP.ehlo_hook is Deprecated"""
         expectedre = r"Use handler.handle_EHLO\(\) instead of .ehlo_hook\(\)"
         with pytest.warns(DeprecationWarning, match=expectedre):
             client.ehlo("example.com")
 
     @controller_data(class_=DeprecatedHookController)
-    def test_rset_hook(self, plain_controller, client):
+    def test_rset_hook(self, plain_controller: Controller, client: SMTPClient):
         """SMTP.rset_hook is Deprecated"""
         expectedre = r"Use handler.handle_RSET\(\) instead of .rset_hook\(\)"
         with pytest.warns(DeprecationWarning, match=expectedre):

--- a/aiosmtpd/tests/test_handlers.py
+++ b/aiosmtpd/tests/test_handlers.py
@@ -61,7 +61,7 @@ class FakeParser:
 
     message: Union[str, bytes, None] = None
 
-    def error(self, message: AnyStr):
+    def error(self, message: AnyStr) -> None:
         self.message = message
         raise SystemExit
 
@@ -95,7 +95,7 @@ class HELOHandler:
 
     async def handle_HELO(
         self, server: Server, session: ServerSession, envelope: Envelope, hostname: str
-    ):
+    ) -> str:
         return self.ReturnCode.to_str()
 
 
@@ -105,7 +105,7 @@ class EHLOHandlerDeprecated:
 
     async def handle_EHLO(
         self, server: Server, session: ServerSession, envelope: Envelope, hostname: str
-    ):
+    ) -> str:
         return self.ReturnCode.to_str()
 
 
@@ -125,7 +125,7 @@ class EHLOHandlerNew:
         envelope: Envelope,
         hostname: str,
         responses: List[str],
-    ):
+    ) -> List[str]:
         self.hostname = hostname
         self.orig_responses.clear()
         self.orig_responses.extend(responses)
@@ -138,7 +138,7 @@ class EHLOHandlerNew:
 class EHLOHandlerIncompatibleShort:
     async def handle_EHLO(
         self, server: Server, session: ServerSession, envelope: Envelope
-    ):
+    ) -> None:
         return
 
 
@@ -151,7 +151,7 @@ class EHLOHandlerIncompatibleLong:
         hostname: str,
         responses: List[str],
         xtra: str,
-    ):
+    ) -> None:
         return
 
 
@@ -166,7 +166,7 @@ class MAILHandler:
         envelope: Envelope,
         address: str,
         options: dict,
-    ):
+    ) -> str:
         envelope.mail_options = self.ReplacementOptions
         return self.ReturnCode.to_str()
 
@@ -181,7 +181,7 @@ class RCPTHandler:
         envelope: Envelope,
         address: str,
         options: dict,
-    ):
+    ) -> str:
         envelope.rcpt_options.extend(options)
         if address == "bart@example.com":
             return self.RejectCode.to_str()
@@ -194,14 +194,14 @@ class ErroringDataHandler:
 
     async def handle_DATA(
         self, server: Server, session: ServerSession, envelope: Envelope
-    ):
+    ) -> str:
         return self.ReturnCode.to_str()
 
 
 class AUTHHandler:
     async def handle_AUTH(
         self, server: Server, session: ServerSession, envelope: Envelope, args: List[str]
-    ):
+    ) -> str:
         server.authenticates = True
         return S.S235_AUTH_SUCCESS.to_str()
 
@@ -218,13 +218,13 @@ class DeprecatedHookController(Controller):
         def __init__(self, *args, **kws):
             super().__init__(*args, **kws)
 
-        async def ehlo_hook(self):
+        async def ehlo_hook(self) -> None:
             pass
 
-        async def rset_hook(self):
+        async def rset_hook(self) -> None:
             pass
 
-    def factory(self):
+    def factory(self) -> Server:
         self.smtpd = self.DeprecatedHookServer(self.handler)
         return self.smtpd
 
@@ -237,7 +237,7 @@ class DeprecatedHandler:
         rcpttos: List[str],
         data: AnyStr,
         **kws: AnyStr,
-    ):
+    ) -> None:
         pass
 
 
@@ -249,7 +249,7 @@ class AsyncDeprecatedHandler:
         rcpttos: List[str],
         data: AnyStr,
         **kws: AnyStr,
-    ):
+    ) -> None:
         pass
 
 
@@ -372,7 +372,7 @@ class TestDebugging:
     @controller_data(decode_data=True)
     def test_debugging(
         self, debugging_controller: Controller, client: SMTPClient
-    ):
+    ) -> None:
         peer = client.sock.getsockname()
         client.sendmail(
             "anne@example.com",
@@ -407,7 +407,7 @@ class TestDebugging:
 
     def test_debugging_bytes(
         self, debugging_controller: Controller, client: SMTPClient
-    ):
+    ) -> None:
         peer = client.sock.getsockname()
         client.sendmail(
             "anne@example.com",
@@ -442,7 +442,7 @@ class TestDebugging:
 
     def test_debugging_without_options(
         self, debugging_controller: Controller, client: SMTPClient
-    ):
+    ) -> None:
         # Prevent ESMTP options.
         client.helo()
         peer = client.sock.getsockname()
@@ -477,7 +477,7 @@ class TestDebugging:
 
     def test_debugging_with_options(
         self, debugging_controller: Controller, client: SMTPClient
-    ):
+    ) -> None:
         peer = client.sock.getsockname()
         client.sendmail(
             "anne@example.com",
@@ -522,7 +522,7 @@ class TestMessage:
         ],
         ids=["bytes", "bytearray", "str"]
     )
-    def test_prepare_message(self, temp_event_loop: asyncio.AbstractEventLoop, content: Union[bytes, bytearray, str]):
+    def test_prepare_message(self, temp_event_loop: asyncio.AbstractEventLoop, content: Union[bytes, bytearray, str]) -> None:
         sess_ = ServerSession(temp_event_loop)
         enve_ = Envelope()
         handler = MessageHandler()
@@ -547,7 +547,7 @@ class TestMessage:
         temp_event_loop: asyncio.AbstractEventLoop,
         content: Optional[Union[list, dict, tuple]],
         expectre: str,
-    ):
+    ) -> None:
         sess_ = ServerSession(temp_event_loop)
         enve_ = Envelope()
         handler = MessageHandler()
@@ -556,7 +556,7 @@ class TestMessage:
             _ = handler.prepare_message(sess_, enve_)
 
     @handler_data(class_=DataHandler)
-    def test_message(self, plain_controller: Controller, client: SMTPClient):
+    def test_message(self, plain_controller: Controller, client: SMTPClient) -> None:
         handler = plain_controller.handler
         assert isinstance(handler, DataHandler)
         # In this test, the message content comes in as a bytes.
@@ -582,7 +582,7 @@ class TestMessage:
     @handler_data(class_=DataHandler)
     def test_message_decoded(
         self, decoding_controller: Controller, client: SMTPClient
-    ):
+    ) -> None:
         handler = decoding_controller.handler
         assert isinstance(handler, DataHandler)
         # In this test, the message content comes in as a string.
@@ -607,7 +607,7 @@ class TestMessage:
     @handler_data(class_=AsyncMessageHandler)
     def test_message_async(
         self, plain_controller: Controller, client: SMTPClient
-    ):
+    ) -> None:
         handler = plain_controller.handler
         assert isinstance(handler, AsyncMessageHandler)
         # In this test, the message data comes in as bytes.
@@ -635,7 +635,7 @@ class TestMessage:
     @handler_data(class_=AsyncMessageHandler)
     def test_message_decoded_async(
         self, decoding_controller: Controller, client: SMTPClient
-    ):
+    ) -> None:
         handler = decoding_controller.handler
         assert isinstance(handler, AsyncMessageHandler)
         # With a server that decodes the data, the messages come in as
@@ -670,7 +670,7 @@ class TestMailbox:
         temp_maildir: Path,
         mailbox_controller: Controller,
         client: SMTPClient,
-    ):
+    ) -> None:
         client.sendmail(
             "aperson@example.com",
             ["bperson@example.com"],
@@ -724,7 +724,7 @@ class TestMailbox:
         temp_maildir: Path,
         mailbox_controller: Controller,
         client: SMTPClient,
-    ):
+    ) -> None:
         client.sendmail(
             "aperson@example.com",
             ["bperson@example.com"],
@@ -745,56 +745,56 @@ class TestMailbox:
 
 
 class TestCLI:
-    def test_debugging_no_args(self, with_fake_parser: Callable):
+    def test_debugging_no_args(self, with_fake_parser: Callable) -> None:
         handler = with_fake_parser(Debugging)
         assert handler.exception is None
         assert handler.fparser.message is None
         assert handler.stream == sys.stdout
 
-    def test_debugging_two_args(self, with_fake_parser: Callable):
+    def test_debugging_two_args(self, with_fake_parser: Callable) -> None:
         handler = with_fake_parser(Debugging, "foo", "bar")
         assert handler.exception is SystemExit
         assert handler.fparser.message == "Debugging usage: [stdout|stderr]"
 
-    def test_debugging_stdout(self, with_fake_parser: Callable):
+    def test_debugging_stdout(self, with_fake_parser: Callable) -> None:
         handler = with_fake_parser(Debugging, "stdout")
         assert handler.exception is None
         assert handler.fparser.message is None
         assert handler.stream == sys.stdout
 
-    def test_debugging_stderr(self, with_fake_parser: Callable):
+    def test_debugging_stderr(self, with_fake_parser: Callable) -> None:
         handler = with_fake_parser(Debugging, "stderr")
         assert handler.exception is None
         assert handler.fparser.message is None
         assert handler.stream == sys.stderr
 
-    def test_debugging_bad_argument(self, with_fake_parser: Callable):
+    def test_debugging_bad_argument(self, with_fake_parser: Callable) -> None:
         handler = with_fake_parser(Debugging, "stdfoo")
         assert handler.exception is SystemExit
         assert handler.fparser.message == "Debugging usage: [stdout|stderr]"
 
-    def test_sink_no_args(self, with_fake_parser: Callable):
+    def test_sink_no_args(self, with_fake_parser: Callable) -> None:
         handler = with_fake_parser(Sink)
         assert handler.exception is None
         assert handler.fparser.message is None
         assert isinstance(handler, Sink)
 
-    def test_sink_any_args(self, with_fake_parser: Callable):
+    def test_sink_any_args(self, with_fake_parser: Callable) -> None:
         handler = with_fake_parser(Sink, "foo")
         assert handler.exception is SystemExit
         assert handler.fparser.message == "Sink handler does not accept arguments"
 
-    def test_mailbox_no_args(self, with_fake_parser: Callable):
+    def test_mailbox_no_args(self, with_fake_parser: Callable) -> None:
         handler = with_fake_parser(Mailbox)
         assert handler.exception is SystemExit
         assert handler.fparser.message == "The directory for the maildir is required"
 
-    def test_mailbox_too_many_args(self, with_fake_parser: Callable):
+    def test_mailbox_too_many_args(self, with_fake_parser: Callable) -> None:
         handler = with_fake_parser(Mailbox, "foo", "bar", "baz")
         assert handler.exception is SystemExit
         assert handler.fparser.message == "Too many arguments for Mailbox handler"
 
-    def test_mailbox(self, with_fake_parser: Callable, temp_maildir: Path):
+    def test_mailbox(self, with_fake_parser: Callable, temp_maildir: Path) -> None:
         handler = with_fake_parser(Mailbox, temp_maildir)
         assert handler.exception is None
         assert handler.fparser.message is None
@@ -831,7 +831,7 @@ class TestProxy:
 
     def test_deliver_bytes(
         self, proxy_nodecode_controller: Union[Controller, KnowsUpstream], client: SMTPClient
-    ):
+    ) -> None:
         client.sendmail(self.sender_addr, [self.receiver_addr], self.source)
         upstream = proxy_nodecode_controller.upstream
         upstream_handler = upstream.handler
@@ -843,7 +843,7 @@ class TestProxy:
 
     def test_deliver_str(
         self, proxy_decoding_controller: Union[Controller, KnowsUpstream], client: SMTPClient
-    ):
+    ) -> None:
         client.sendmail(self.sender_addr, [self.receiver_addr], self.source)
         upstream = proxy_decoding_controller.upstream
         upstream_handler = upstream.handler
@@ -867,7 +867,7 @@ class TestProxyMocked:
     )
 
     @pytest.fixture
-    def patch_smtp_refused(self, mocker: MockFixture):
+    def patch_smtp_refused(self, mocker: MockFixture) -> None:
         mock = mocker.patch("aiosmtpd.handlers.smtplib.SMTP")
         mock().sendmail.side_effect = SMTPRecipientsRefused(self.BAD_BART)
 
@@ -877,7 +877,7 @@ class TestProxyMocked:
         patch_smtp_refused: None,
         proxy_decoding_controller: Union[Controller, KnowsUpstream],
         client: SMTPClient,
-    ):
+    ) -> None:
         logger_name = "mail.debug"
         caplog.set_level(logging.INFO, logger=logger_name)
         client.sendmail("anne@example.com", ["bart@example.com"], self.SOURCE)
@@ -904,7 +904,7 @@ class TestProxyMocked:
         assert _l2 < _l1, "Log entries in wrong order"
 
     @pytest.fixture
-    def patch_smtp_oserror(self, mocker: MockFixture):
+    def patch_smtp_oserror(self, mocker: MockFixture) -> None:
         mock = mocker.patch("aiosmtpd.handlers.smtplib.SMTP")
         mock().sendmail.side_effect = OSError
 
@@ -914,7 +914,7 @@ class TestProxyMocked:
         patch_smtp_oserror: None,
         proxy_decoding_controller: Union[Controller, KnowsUpstream],
         client: SMTPClient,
-    ):
+    ) -> None:
         logger_name = "mail.debug"
         caplog.set_level(logging.INFO, logger=logger_name)
         client.sendmail("anne@example.com", ["bart@example.com"], self.SOURCE)
@@ -931,7 +931,7 @@ class TestProxyMocked:
 
 class TestHooks:
     @handler_data(class_=HELOHandler)
-    def test_hook_HELO(self, plain_controller: Controller, client: SMTPClient):
+    def test_hook_HELO(self, plain_controller: Controller, client: SMTPClient) -> None:
         assert isinstance(plain_controller.handler, HELOHandler)
         resp = client.helo("me")
         assert resp == HELOHandler.ReturnCode
@@ -940,14 +940,14 @@ class TestHooks:
     @handler_data(class_=EHLOHandlerDeprecated)
     def test_hook_EHLO_deprecated(
         self, plain_controller: Controller, client: SMTPClient
-    ):
+    ) -> None:
         assert isinstance(plain_controller.handler, EHLOHandlerDeprecated)
         code, mesg = client.ehlo("me")
         lines = mesg.decode("utf-8").splitlines()
         assert code == 250
         assert lines[-1] == EHLOHandlerDeprecated.Domain
 
-    def test_hook_EHLO_deprecated_warning(self):
+    def test_hook_EHLO_deprecated_warning(self) -> None:
         with pytest.warns(
             DeprecationWarning,
             match=(
@@ -963,7 +963,7 @@ class TestHooks:
         class_=EHLOHandlerNew,
         args_=("FEATURE1", "FEATURE2 OPTION", "FEAT3 OPTA OPTB"),
     )
-    def test_hook_EHLO_new(self, plain_controller: Controller, client: SMTPClient):
+    def test_hook_EHLO_new(self, plain_controller: Controller, client: SMTPClient) -> None:
         assert isinstance(plain_controller.handler, EHLOHandlerNew)
         code, mesg = client.ehlo("me")
         lines = mesg.decode("utf-8").splitlines()
@@ -987,12 +987,12 @@ class TestHooks:
         [EHLOHandlerIncompatibleShort, EHLOHandlerIncompatibleLong],
         ids=["TooShort", "TooLong"],
     )
-    def test_hook_EHLO_incompat(self, handler_class: Type):
+    def test_hook_EHLO_incompat(self, handler_class: Type) -> None:
         with pytest.raises(RuntimeError, match="Unsupported EHLO Hook"):
             _ = Server(handler_class())
 
     @handler_data(class_=MAILHandler)
-    def test_hook_MAIL(self, plain_controller: Controller, client: SMTPClient):
+    def test_hook_MAIL(self, plain_controller: Controller, client: SMTPClient) -> None:
         assert isinstance(plain_controller, Controller)
         handler = plain_controller.handler
         assert isinstance(handler, MAILHandler)
@@ -1003,7 +1003,7 @@ class TestHooks:
         assert smtpd.envelope.mail_options == MAILHandler.ReplacementOptions
 
     @handler_data(class_=RCPTHandler)
-    def test_hook_RCPT(self, plain_controller: Controller, client: SMTPClient):
+    def test_hook_RCPT(self, plain_controller: Controller, client: SMTPClient) -> None:
         assert isinstance(plain_controller.handler, RCPTHandler)
         client.helo("me")
         with pytest.raises(SMTPRecipientsRefused) as excinfo:
@@ -1024,7 +1024,7 @@ class TestHooks:
         }
 
     @handler_data(class_=ErroringDataHandler)
-    def test_hook_DATA(self, plain_controller: Controller, client: SMTPClient):
+    def test_hook_DATA(self, plain_controller: Controller, client: SMTPClient) -> None:
         assert isinstance(plain_controller.handler, ErroringDataHandler)
         with pytest.raises(SMTPDataError) as excinfo:
             client.sendmail(
@@ -1046,14 +1046,14 @@ class TestHooks:
 
     @controller_data(decode_data=True, auth_require_tls=False)
     @handler_data(class_=AUTHHandler)
-    def test_hook_AUTH(self, plain_controller: Controller, client: SMTPClient):
+    def test_hook_AUTH(self, plain_controller: Controller, client: SMTPClient) -> None:
         assert isinstance(plain_controller.handler, AUTHHandler)
         client.ehlo("me")
         resp = client.login("test", "test")
         assert resp == S.S235_AUTH_SUCCESS
 
     @handler_data(class_=NoHooksHandler)
-    def test_hook_NoHooks(self, plain_controller: Controller, client: SMTPClient):
+    def test_hook_NoHooks(self, plain_controller: Controller, client: SMTPClient) -> None:
         assert isinstance(plain_controller.handler, NoHooksHandler)
         client.helo("me")
         client.mail("anne@example.com")
@@ -1091,7 +1091,7 @@ class TestDeprecation:
             )
 
     @handler_data(class_=DeprecatedHandler)
-    def test_process_message(self, plain_controller: Controller, client: SMTPClient):
+    def test_process_message(self, plain_controller: Controller, client: SMTPClient) -> None:
         """handler.process_message is Deprecated"""
         handler = plain_controller.handler
         assert isinstance(handler, DeprecatedHandler)
@@ -1101,7 +1101,7 @@ class TestDeprecation:
     @handler_data(class_=AsyncDeprecatedHandler)
     def test_process_message_async(
         self, plain_controller: Controller, client: SMTPClient
-    ):
+    ) -> None:
         """handler.process_message is Deprecated"""
         handler = plain_controller.handler
         assert isinstance(handler, AsyncDeprecatedHandler)
@@ -1109,14 +1109,14 @@ class TestDeprecation:
         self._process_message_testing(controller, client)
 
     @controller_data(class_=DeprecatedHookController)
-    def test_ehlo_hook(self, plain_controller: Controller, client: SMTPClient):
+    def test_ehlo_hook(self, plain_controller: Controller, client: SMTPClient) -> None:
         """SMTP.ehlo_hook is Deprecated"""
         expectedre = r"Use handler.handle_EHLO\(\) instead of .ehlo_hook\(\)"
         with pytest.warns(DeprecationWarning, match=expectedre):
             client.ehlo("example.com")
 
     @controller_data(class_=DeprecatedHookController)
-    def test_rset_hook(self, plain_controller: Controller, client: SMTPClient):
+    def test_rset_hook(self, plain_controller: Controller, client: SMTPClient) -> None:
         """SMTP.rset_hook is Deprecated"""
         expectedre = r"Use handler.handle_RSET\(\) instead of .rset_hook\(\)"
         with pytest.warns(DeprecationWarning, match=expectedre):

--- a/aiosmtpd/tests/test_handlers.py
+++ b/aiosmtpd/tests/test_handlers.py
@@ -1072,7 +1072,7 @@ class TestHooks:
 
 
 class TestDeprecation:
-    def _process_message_testing(self, controller: Controller, client: SMTPClient):
+    def _process_message_testing(self, controller: Controller, client: SMTPClient) -> None:
         assert isinstance(controller, Controller)
         expectedre = r"Use handler.handle_DATA\(\) instead of .process_message\(\)"
         with pytest.warns(DeprecationWarning, match=expectedre):

--- a/aiosmtpd/tests/test_handlers.py
+++ b/aiosmtpd/tests/test_handlers.py
@@ -115,7 +115,7 @@ class EHLOHandlerNew:
     hostname = None
     orig_responses = []
 
-    def __init__(self, *features):
+    def __init__(self, *features) -> None:
         self.features = features or tuple()
 
     async def handle_EHLO(
@@ -215,7 +215,7 @@ class DeprecatedHookController(Controller):
 
         warnings: list = None
 
-        def __init__(self, *args, **kws):
+        def __init__(self, *args, **kws) -> None:
             super().__init__(*args, **kws)
 
         async def ehlo_hook(self) -> None:

--- a/aiosmtpd/tests/test_lmtp.py
+++ b/aiosmtpd/tests/test_lmtp.py
@@ -12,13 +12,14 @@ import pytest
 from aiosmtpd.controller import Controller
 from aiosmtpd.handlers import Sink
 from aiosmtpd.lmtp import LMTP
+from aiosmtpd.smtp import SMTP as Server
 from aiosmtpd.testing.statuscodes import SMTP_STATUS_CODES as S
 
 from .conftest import Global
 
 
 class LMTPController(Controller):
-    def factory(self):
+    def factory(self) -> Server:
         self.smtpd = LMTP(self.handler)
         return self.smtpd
 
@@ -34,7 +35,7 @@ def lmtp_controller() -> Generator[LMTPController, None, None]:
     controller.stop()
 
 
-def test_lhlo(client: SMTPClient):
+def test_lhlo(client: SMTPClient) -> None:
     code, mesg = client.docmd("LHLO example.com")
     lines = mesg.splitlines()
     assert lines == [
@@ -46,19 +47,19 @@ def test_lhlo(client: SMTPClient):
     assert code == 250
 
 
-def test_helo(client: SMTPClient):
+def test_helo(client: SMTPClient) -> None:
     # HELO and EHLO are not valid LMTP commands.
     resp = client.helo("example.com")
     assert resp == S.S500_CMD_UNRECOG(b"HELO")
 
 
-def test_ehlo(client: SMTPClient):
+def test_ehlo(client: SMTPClient) -> None:
     # HELO and EHLO are not valid LMTP commands.
     resp = client.ehlo("example.com")
     assert resp == S.S500_CMD_UNRECOG(b"EHLO")
 
 
-def test_help(client: SMTPClient):
+def test_help(client: SMTPClient) -> None:
     # https://github.com/aio-libs/aiosmtpd/issues/113
     resp = client.docmd("HELP")
     assert resp == S.S250_SUPPCMD_LMTP

--- a/aiosmtpd/tests/test_lmtp.py
+++ b/aiosmtpd/tests/test_lmtp.py
@@ -4,6 +4,7 @@
 """Test the LMTP protocol."""
 
 import socket
+from smtplib import SMTP as SMTPClient
 from typing import Generator
 
 import pytest
@@ -33,7 +34,7 @@ def lmtp_controller() -> Generator[LMTPController, None, None]:
     controller.stop()
 
 
-def test_lhlo(client):
+def test_lhlo(client: SMTPClient):
     code, mesg = client.docmd("LHLO example.com")
     lines = mesg.splitlines()
     assert lines == [
@@ -45,19 +46,19 @@ def test_lhlo(client):
     assert code == 250
 
 
-def test_helo(client):
+def test_helo(client: SMTPClient):
     # HELO and EHLO are not valid LMTP commands.
     resp = client.helo("example.com")
     assert resp == S.S500_CMD_UNRECOG(b"HELO")
 
 
-def test_ehlo(client):
+def test_ehlo(client: SMTPClient):
     # HELO and EHLO are not valid LMTP commands.
     resp = client.ehlo("example.com")
     assert resp == S.S500_CMD_UNRECOG(b"EHLO")
 
 
-def test_help(client):
+def test_help(client: SMTPClient):
     # https://github.com/aio-libs/aiosmtpd/issues/113
     resp = client.docmd("HELP")
     assert resp == S.S250_SUPPCMD_LMTP

--- a/aiosmtpd/tests/test_main.py
+++ b/aiosmtpd/tests/test_main.py
@@ -41,7 +41,7 @@ class FromCliHandler:
         self.called = called
 
     @classmethod
-    def from_cli(cls, parser: ArgumentParser, *args: str):
+    def from_cli(cls, parser: ArgumentParser, *args: str) -> "FromCliHandler":
         return cls(*args)
 
 

--- a/aiosmtpd/tests/test_main.py
+++ b/aiosmtpd/tests/test_main.py
@@ -37,7 +37,7 @@ MAIL_LOG = logging.getLogger("mail.log")
 
 
 class FromCliHandler:
-    def __init__(self, called: bool):
+    def __init__(self, called: bool) -> None:
         self.called = called
 
     @classmethod

--- a/aiosmtpd/tests/test_main.py
+++ b/aiosmtpd/tests/test_main.py
@@ -7,11 +7,12 @@ import multiprocessing as MP
 import os
 import sys
 import time
+from argparse import ArgumentParser
 from contextlib import contextmanager
 from multiprocessing.synchronize import Event as MP_Event
 from smtplib import SMTP as SMTPClient
 from smtplib import SMTP_SSL
-from typing import Generator
+from typing import Callable, Generator, Tuple
 
 import pytest
 from pytest_mock import MockFixture
@@ -40,7 +41,7 @@ class FromCliHandler:
         self.called = called
 
     @classmethod
-    def from_cli(cls, parser, *args):
+    def from_cli(cls, parser: ArgumentParser, *args: str):
         return cls(*args)
 
 
@@ -122,7 +123,7 @@ def main_n(*args):
 
 
 @contextmanager
-def watcher_process(func):
+def watcher_process(func: Callable):
     redy = MP.Event()
     retq = MP.Queue()
     proc = MP.Process(target=func, args=(redy, retq))
@@ -137,12 +138,14 @@ def watcher_process(func):
 
 @pytest.mark.usefixtures("autostop_loop")
 class TestMain:
-    def test_setuid(self, nobody_uid, mocker):
+    def test_setuid(self, nobody_uid: int, mocker: MockFixture):
         mock = mocker.patch("os.setuid")
         main(args=())
         mock.assert_called_with(nobody_uid)
 
-    def test_setuid_permission_error(self, nobody_uid, mocker, capsys):
+    def test_setuid_permission_error(
+        self, nobody_uid: int, mocker: MockFixture, capsys: pytest.CaptureFixture[str]
+    ):
         mock = mocker.patch("os.setuid", side_effect=PermissionError)
         with pytest.raises(SystemExit) as excinfo:
             main(args=())
@@ -153,18 +156,20 @@ class TestMain:
             == 'Cannot setuid "nobody"; try running with -n option.\n'
         )
 
-    def test_setuid_no_pwd_module(self, nobody_uid, mocker, capsys):
+    def test_setuid_no_pwd_module(
+        self, nobody_uid: int, mocker: MockFixture, capsys: pytest.CaptureFixture[str]
+    ):
         mocker.patch("aiosmtpd.main.pwd", None)
         with pytest.raises(SystemExit) as excinfo:
             main(args=())
         assert excinfo.value.code == 1
         assert capsys.readouterr().err == 'Cannot import module "pwd"; try running with -n option.\n'
 
-    def test_n(self, setuid):
+    def test_n(self, setuid: None):
         with pytest.raises(RuntimeError):
             main_n()
 
-    def test_nosetuid(self, setuid):
+    def test_nosetuid(self, setuid: None):
         with pytest.raises(RuntimeError):
             main(("--nosetuid",))
 
@@ -191,7 +196,12 @@ class TestMain:
 
 @pytest.mark.skipif(sys.platform == "darwin", reason="No idea why these are failing")
 class TestMainByWatcher:
-    def test_tls(self, temp_event_loop, tls_cert_pem_path, tls_key_pem_path):
+    def test_tls(
+        self,
+        temp_event_loop: asyncio.AbstractEventLoop,
+        tls_cert_pem_path: str,
+        tls_key_pem_path: str,
+    ):
         with watcher_process(watch_for_tls) as retq:
             temp_event_loop.call_later(AUTOSTOP_DELAY, temp_event_loop.stop)
             main_n("--tlscert", tls_cert_pem_path, "--tlskey", tls_key_pem_path)
@@ -201,7 +211,12 @@ class TestMainByWatcher:
         require_tls = retq.get()
         assert require_tls is True
 
-    def test_tls_noreq(self, temp_event_loop, tls_cert_pem_path, tls_key_pem_path):
+    def test_tls_noreq(
+        self,
+        temp_event_loop: asyncio.AbstractEventLoop,
+        tls_cert_pem_path: str,
+        tls_key_pem_path: str,
+    ):
         with watcher_process(watch_for_tls) as retq:
             temp_event_loop.call_later(AUTOSTOP_DELAY, temp_event_loop.stop)
             main_n(
@@ -217,7 +232,12 @@ class TestMainByWatcher:
         require_tls = retq.get()
         assert require_tls is False
 
-    def test_smtps(self, temp_event_loop, tls_cert_pem_path, tls_key_pem_path):
+    def test_smtps(
+        self,
+        temp_event_loop: asyncio.AbstractEventLoop,
+        tls_cert_pem_path: str,
+        tls_key_pem_path: str,
+    ):
         with watcher_process(watch_for_smtps) as retq:
             temp_event_loop.call_later(AUTOSTOP_DELAY, temp_event_loop.stop)
             main_n("--smtpscert", tls_cert_pem_path, "--smtpskey", tls_key_pem_path)
@@ -260,7 +280,7 @@ class TestParseArgs:
         with pytest.raises(TypeError):
             parseargs(("-c", "aiosmtpd.tests.test_main.FromCliHandler", "FOO", "BAR"))
 
-    def test_handler_no_from_cli_exception(self, capsys):
+    def test_handler_no_from_cli_exception(self, capsys: pytest.CaptureFixture[str]):
         with pytest.raises(SystemExit) as excinfo:
             parseargs(("-c", "aiosmtpd.tests.test_main.NullHandler", "FOO", "BAR"))
         assert excinfo.value.code == 2
@@ -280,19 +300,19 @@ class TestParseArgs:
             (("-l", "::0:25"), "::0", 25),
         ],
     )
-    def test_host_port(self, args, exp_host, exp_port):
+    def test_host_port(self, args: Tuple, exp_host: str, exp_port: int):
         parser, args_ = parseargs(args=args)
         assert args_.host == exp_host
         assert args_.port == exp_port
 
-    def test_bad_port_number(self, capsys):
+    def test_bad_port_number(self, capsys: pytest.CaptureFixture[str]):
         with pytest.raises(SystemExit) as excinfo:
             parseargs(("-l", ":foo"))
         assert excinfo.value.code == 2
         assert "Invalid port number: foo" in capsys.readouterr().err
 
     @pytest.mark.parametrize("opt", ["--version", "-v"])
-    def test_version(self, capsys, mocker, opt):
+    def test_version(self, capsys: pytest.CaptureFixture[str], mocker: MockFixture, opt: str):
         mocker.patch("aiosmtpd.main.PROGRAM", "smtpd")
         with pytest.raises(SystemExit) as excinfo:
             parseargs((opt,))
@@ -300,7 +320,7 @@ class TestParseArgs:
         assert capsys.readouterr().out == f"smtpd {__version__}\n"
 
     @pytest.mark.parametrize("args", [("--smtpscert", "x"), ("--smtpskey", "x")])
-    def test_smtps(self, capsys, mocker, args):
+    def test_smtps(self, capsys: pytest.CaptureFixture[str], mocker: MockFixture, args: Tuple):
         mocker.patch("aiosmtpd.main.PROGRAM", "smtpd")
         with pytest.raises(SystemExit) as exc:
             parseargs(args)
@@ -311,7 +331,7 @@ class TestParseArgs:
         )
 
     @pytest.mark.parametrize("args", [("--tlscert", "x"), ("--tlskey", "x")])
-    def test_tls(self, capsys, mocker, args):
+    def test_tls(self, capsys: pytest.CaptureFixture[str], mocker: MockFixture, args: Tuple):
         mocker.patch("aiosmtpd.main.PROGRAM", "smtpd")
         with pytest.raises(SystemExit) as exc:
             parseargs(args)
@@ -321,7 +341,7 @@ class TestParseArgs:
             in capsys.readouterr().err
         )
 
-    def test_norequiretls(self, capsys, mocker):
+    def test_norequiretls(self, capsys: pytest.CaptureFixture[str], mocker: MockFixture):
         mocker.patch("aiosmtpd.main.PROGRAM", "smtpd")
         parser, args = parseargs(("--no-requiretls",))
         assert args.requiretls is False
@@ -336,7 +356,16 @@ class TestParseArgs:
         ids=["x-x", "cert-x", "x-key"],
     )
     @pytest.mark.parametrize("meth", ["smtps", "tls"])
-    def test_ssl_files_err(self, capsys, mocker, meth, certfile_present, keyfile_present, expect, request):
+    def test_ssl_files_err(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        mocker: MockFixture,
+        meth: str,
+        certfile_present: bool,
+        keyfile_present: bool,
+        expect: str,
+        request: pytest.FixtureRequest,
+    ):
         certfile = request.getfixturevalue("tls_cert_pem_path") if certfile_present else "x"
         keyfile = request.getfixturevalue("tls_key_pem_path") if keyfile_present else "x"
         mocker.patch("aiosmtpd.main.PROGRAM", "smtpd")
@@ -347,7 +376,7 @@ class TestParseArgs:
 
 
 class TestSigint:
-    def test_keyboard_interrupt(self, temp_event_loop):
+    def test_keyboard_interrupt(self, temp_event_loop: asyncio.AbstractEventLoop):
         """main() must close loop gracefully on KeyboardInterrupt."""
 
         def interrupt():

--- a/aiosmtpd/tests/test_main.py
+++ b/aiosmtpd/tests/test_main.py
@@ -67,7 +67,7 @@ def nobody_uid() -> Generator[int, None, None]:
 
 
 @pytest.fixture
-def setuid(mocker: MockFixture):
+def setuid(mocker: MockFixture) -> None:
     if not HAS_SETUID:
         pytest.skip("setuid is unavailable")
     mocker.patch("aiosmtpd.main.pwd", None)
@@ -80,7 +80,7 @@ def setuid(mocker: MockFixture):
 # region ##### Helper Funcs ###########################################################
 
 
-def watch_for_tls(ready_flag: MP_Event, retq: MP.Queue):
+def watch_for_tls(ready_flag: MP_Event, retq: MP.Queue) -> None:
     has_tls = False
     req_tls = False
     ready_flag.set()
@@ -102,7 +102,7 @@ def watch_for_tls(ready_flag: MP_Event, retq: MP.Queue):
     retq.put(req_tls)
 
 
-def watch_for_smtps(ready_flag: MP_Event, retq: MP.Queue):
+def watch_for_smtps(ready_flag: MP_Event, retq: MP.Queue) -> None:
     has_smtps = False
     ready_flag.set()
     start = time.monotonic()
@@ -118,12 +118,12 @@ def watch_for_smtps(ready_flag: MP_Event, retq: MP.Queue):
     retq.put(has_smtps)
 
 
-def main_n(*args):
+def main_n(*args) -> None:
     main(("-n",) + args)
 
 
 @contextmanager
-def watcher_process(func: Callable):
+def watcher_process(func: Callable) -> Generator[MP.Queue, None, None]:
     redy = MP.Event()
     retq = MP.Queue()
     proc = MP.Process(target=func, args=(redy, retq))
@@ -138,14 +138,14 @@ def watcher_process(func: Callable):
 
 @pytest.mark.usefixtures("autostop_loop")
 class TestMain:
-    def test_setuid(self, nobody_uid: int, mocker: MockFixture):
+    def test_setuid(self, nobody_uid: int, mocker: MockFixture) -> None:
         mock = mocker.patch("os.setuid")
         main(args=())
         mock.assert_called_with(nobody_uid)
 
     def test_setuid_permission_error(
         self, nobody_uid: int, mocker: MockFixture, capsys: pytest.CaptureFixture[str]
-    ):
+    ) -> None:
         mock = mocker.patch("os.setuid", side_effect=PermissionError)
         with pytest.raises(SystemExit) as excinfo:
             main(args=())
@@ -158,37 +158,37 @@ class TestMain:
 
     def test_setuid_no_pwd_module(
         self, nobody_uid: int, mocker: MockFixture, capsys: pytest.CaptureFixture[str]
-    ):
+    ) -> None:
         mocker.patch("aiosmtpd.main.pwd", None)
         with pytest.raises(SystemExit) as excinfo:
             main(args=())
         assert excinfo.value.code == 1
         assert capsys.readouterr().err == 'Cannot import module "pwd"; try running with -n option.\n'
 
-    def test_n(self, setuid: None):
+    def test_n(self, setuid: None) -> None:
         with pytest.raises(RuntimeError):
             main_n()
 
-    def test_nosetuid(self, setuid: None):
+    def test_nosetuid(self, setuid: None) -> None:
         with pytest.raises(RuntimeError):
             main(("--nosetuid",))
 
-    def test_debug_0(self):
+    def test_debug_0(self) -> None:
         # For this test, the test runner likely has already set the log level
         # so it may not be logging.ERROR.
         default_level = MAIL_LOG.getEffectiveLevel()
         main_n()
         assert MAIL_LOG.getEffectiveLevel() == default_level
 
-    def test_debug_1(self):
+    def test_debug_1(self) -> None:
         main_n("-d")
         assert MAIL_LOG.getEffectiveLevel() == logging.INFO
 
-    def test_debug_2(self):
+    def test_debug_2(self) -> None:
         main_n("-dd")
         assert MAIL_LOG.getEffectiveLevel() == logging.DEBUG
 
-    def test_debug_3(self):
+    def test_debug_3(self) -> None:
         main_n("-ddd")
         assert MAIL_LOG.getEffectiveLevel() == logging.DEBUG
         assert asyncio.get_event_loop().get_debug()
@@ -201,7 +201,7 @@ class TestMainByWatcher:
         temp_event_loop: asyncio.AbstractEventLoop,
         tls_cert_pem_path: str,
         tls_key_pem_path: str,
-    ):
+    ) -> None:
         with watcher_process(watch_for_tls) as retq:
             temp_event_loop.call_later(AUTOSTOP_DELAY, temp_event_loop.stop)
             main_n("--tlscert", tls_cert_pem_path, "--tlskey", tls_key_pem_path)
@@ -216,7 +216,7 @@ class TestMainByWatcher:
         temp_event_loop: asyncio.AbstractEventLoop,
         tls_cert_pem_path: str,
         tls_key_pem_path: str,
-    ):
+    ) -> None:
         with watcher_process(watch_for_tls) as retq:
             temp_event_loop.call_later(AUTOSTOP_DELAY, temp_event_loop.stop)
             main_n(
@@ -237,7 +237,7 @@ class TestMainByWatcher:
         temp_event_loop: asyncio.AbstractEventLoop,
         tls_cert_pem_path: str,
         tls_key_pem_path: str,
-    ):
+    ) -> None:
         with watcher_process(watch_for_smtps) as retq:
             temp_event_loop.call_later(AUTOSTOP_DELAY, temp_event_loop.stop)
             main_n("--smtpscert", tls_cert_pem_path, "--smtpskey", tls_key_pem_path)
@@ -247,7 +247,7 @@ class TestMainByWatcher:
 
 
 class TestParseArgs:
-    def test_defaults(self):
+    def test_defaults(self) -> None:
         parser, args = parseargs(tuple())
         assert args.classargs == tuple()
         assert args.classpath == "aiosmtpd.handlers.Debugging"
@@ -265,22 +265,22 @@ class TestParseArgs:
         assert args.tlskey is None
         assert args.requiretls is True
 
-    def test_handler_from_cli(self):
+    def test_handler_from_cli(self) -> None:
         parser, args = parseargs(
             ("-c", "aiosmtpd.tests.test_main.FromCliHandler", "--", "FOO")
         )
         assert isinstance(args.handler, FromCliHandler)
         assert args.handler.called == "FOO"
 
-    def test_handler_no_from_cli(self):
+    def test_handler_no_from_cli(self) -> None:
         parser, args = parseargs(("-c", "aiosmtpd.tests.test_main.NullHandler"))
         assert isinstance(args.handler, NullHandler)
 
-    def test_handler_from_cli_exception(self):
+    def test_handler_from_cli_exception(self) -> None:
         with pytest.raises(TypeError):
             parseargs(("-c", "aiosmtpd.tests.test_main.FromCliHandler", "FOO", "BAR"))
 
-    def test_handler_no_from_cli_exception(self, capsys: pytest.CaptureFixture[str]):
+    def test_handler_no_from_cli_exception(self, capsys: pytest.CaptureFixture[str]) -> None:
         with pytest.raises(SystemExit) as excinfo:
             parseargs(("-c", "aiosmtpd.tests.test_main.NullHandler", "FOO", "BAR"))
         assert excinfo.value.code == 2
@@ -300,19 +300,19 @@ class TestParseArgs:
             (("-l", "::0:25"), "::0", 25),
         ],
     )
-    def test_host_port(self, args: Tuple, exp_host: str, exp_port: int):
+    def test_host_port(self, args: Tuple, exp_host: str, exp_port: int) -> None:
         parser, args_ = parseargs(args=args)
         assert args_.host == exp_host
         assert args_.port == exp_port
 
-    def test_bad_port_number(self, capsys: pytest.CaptureFixture[str]):
+    def test_bad_port_number(self, capsys: pytest.CaptureFixture[str]) -> None:
         with pytest.raises(SystemExit) as excinfo:
             parseargs(("-l", ":foo"))
         assert excinfo.value.code == 2
         assert "Invalid port number: foo" in capsys.readouterr().err
 
     @pytest.mark.parametrize("opt", ["--version", "-v"])
-    def test_version(self, capsys: pytest.CaptureFixture[str], mocker: MockFixture, opt: str):
+    def test_version(self, capsys: pytest.CaptureFixture[str], mocker: MockFixture, opt: str) -> None:
         mocker.patch("aiosmtpd.main.PROGRAM", "smtpd")
         with pytest.raises(SystemExit) as excinfo:
             parseargs((opt,))
@@ -320,7 +320,7 @@ class TestParseArgs:
         assert capsys.readouterr().out == f"smtpd {__version__}\n"
 
     @pytest.mark.parametrize("args", [("--smtpscert", "x"), ("--smtpskey", "x")])
-    def test_smtps(self, capsys: pytest.CaptureFixture[str], mocker: MockFixture, args: Tuple):
+    def test_smtps(self, capsys: pytest.CaptureFixture[str], mocker: MockFixture, args: Tuple) -> None:
         mocker.patch("aiosmtpd.main.PROGRAM", "smtpd")
         with pytest.raises(SystemExit) as exc:
             parseargs(args)
@@ -331,7 +331,7 @@ class TestParseArgs:
         )
 
     @pytest.mark.parametrize("args", [("--tlscert", "x"), ("--tlskey", "x")])
-    def test_tls(self, capsys: pytest.CaptureFixture[str], mocker: MockFixture, args: Tuple):
+    def test_tls(self, capsys: pytest.CaptureFixture[str], mocker: MockFixture, args: Tuple) -> None:
         mocker.patch("aiosmtpd.main.PROGRAM", "smtpd")
         with pytest.raises(SystemExit) as exc:
             parseargs(args)
@@ -341,7 +341,7 @@ class TestParseArgs:
             in capsys.readouterr().err
         )
 
-    def test_norequiretls(self, capsys: pytest.CaptureFixture[str], mocker: MockFixture):
+    def test_norequiretls(self, capsys: pytest.CaptureFixture[str], mocker: MockFixture) -> None:
         mocker.patch("aiosmtpd.main.PROGRAM", "smtpd")
         parser, args = parseargs(("--no-requiretls",))
         assert args.requiretls is False
@@ -365,7 +365,7 @@ class TestParseArgs:
         keyfile_present: bool,
         expect: str,
         request: pytest.FixtureRequest,
-    ):
+    ) -> None:
         certfile = request.getfixturevalue("tls_cert_pem_path") if certfile_present else "x"
         keyfile = request.getfixturevalue("tls_key_pem_path") if keyfile_present else "x"
         mocker.patch("aiosmtpd.main.PROGRAM", "smtpd")
@@ -376,10 +376,10 @@ class TestParseArgs:
 
 
 class TestSigint:
-    def test_keyboard_interrupt(self, temp_event_loop: asyncio.AbstractEventLoop):
+    def test_keyboard_interrupt(self, temp_event_loop: asyncio.AbstractEventLoop) -> None:
         """main() must close loop gracefully on KeyboardInterrupt."""
 
-        def interrupt():
+        def interrupt() -> None:
             raise KeyboardInterrupt
 
         temp_event_loop.call_later(1.0, interrupt)

--- a/aiosmtpd/tests/test_misc.py
+++ b/aiosmtpd/tests/test_misc.py
@@ -34,7 +34,7 @@ class TestInit:
 
     def test_create_new_if_none(
         self, close_existing_loop: Optional[asyncio.AbstractEventLoop]
-    ):
+    ) -> None:
         old_loop = close_existing_loop
         loop: Optional[asyncio.AbstractEventLoop]
         loop = _get_or_new_eventloop()
@@ -44,7 +44,7 @@ class TestInit:
 
     def test_not_create_new_if_exist(
         self, close_existing_loop: Optional[asyncio.AbstractEventLoop]
-    ):
+    ) -> None:
         old_loop = close_existing_loop
         loop: Optional[asyncio.AbstractEventLoop]
         loop = asyncio.new_event_loop()

--- a/aiosmtpd/tests/test_misc.py
+++ b/aiosmtpd/tests/test_misc.py
@@ -32,7 +32,9 @@ def close_existing_loop() -> Generator[Optional[asyncio.AbstractEventLoop], None
 
 class TestInit:
 
-    def test_create_new_if_none(self, close_existing_loop):
+    def test_create_new_if_none(
+        self, close_existing_loop: Optional[asyncio.AbstractEventLoop]
+    ):
         old_loop = close_existing_loop
         loop: Optional[asyncio.AbstractEventLoop]
         loop = _get_or_new_eventloop()
@@ -40,7 +42,9 @@ class TestInit:
         assert loop is not old_loop
         assert isinstance(loop, asyncio.AbstractEventLoop)
 
-    def test_not_create_new_if_exist(self, close_existing_loop):
+    def test_not_create_new_if_exist(
+        self, close_existing_loop: Optional[asyncio.AbstractEventLoop]
+    ):
         old_loop = close_existing_loop
         loop: Optional[asyncio.AbstractEventLoop]
         loop = asyncio.new_event_loop()

--- a/aiosmtpd/tests/test_proxyprotocol.py
+++ b/aiosmtpd/tests/test_proxyprotocol.py
@@ -96,7 +96,7 @@ HANDSHAKES = {
 
 
 class ProxyPeekerHandler(Sink):
-    def __init__(self, retval: bool = True):
+    def __init__(self, retval: bool = True) -> None:
         self.called = False
         self.sessions: List[SMTPSession] = []
         self.proxy_datas: List[ProxyData] = []
@@ -363,7 +363,7 @@ class TestProxyTLV:
 
 class TestModule:
     class MockAsyncReader(AsyncReader):
-        def __init__(self, data: bytes, timeout: float = 0.4):
+        def __init__(self, data: bytes, timeout: float = 0.4) -> None:
             self.data = bytearray(data)
             self.timeout = 0.4
 

--- a/aiosmtpd/tests/test_proxyprotocol.py
+++ b/aiosmtpd/tests/test_proxyprotocol.py
@@ -487,7 +487,7 @@ class TestGetV1(_TestProxyProtocolCommon):
         handler = self.protocol.event_handler
         assert handler.called
 
-    def _assert_valid(self, af: AF, proto: PROTO, srcip: str, dstip: str, srcport: int, dstport: int, testline: str):
+    def _assert_valid(self, af: AF, proto: PROTO, srcip: str, dstip: str, srcport: int, dstport: int, testline: str) -> None:
         self.protocol.data_received(testline.encode("ascii"))
         self.runner()
         assert self.protocol.session.proxy_data.error == ""
@@ -582,7 +582,7 @@ class TestGetV1(_TestProxyProtocolCommon):
             rest=b"",
         )
 
-    def _assert_invalid(self, testline: str, expect_err: str = ""):
+    def _assert_invalid(self, testline: str, expect_err: str = "") -> None:
         self.protocol.data_received(testline.encode("ascii"))
         self.runner()
         handler: ProxyPeekerHandler = self.protocol.event_handler

--- a/aiosmtpd/tests/test_proxyprotocol.py
+++ b/aiosmtpd/tests/test_proxyprotocol.py
@@ -15,7 +15,7 @@ from functools import partial
 from ipaddress import IPv4Address, IPv6Address
 from smtplib import SMTP as SMTPClient
 from smtplib import SMTPServerDisconnected
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, Generator, List, Optional, Union
 
 import pytest
 from pytest_mock import MockFixture
@@ -116,7 +116,7 @@ class ProxyPeekerHandler(Sink):
 
 
 @contextmanager
-def does_not_raise():
+def does_not_raise() -> Generator[None, None, None]:
     yield
 
 
@@ -131,13 +131,13 @@ def setup_proxy_protocol(
     handler = ProxyPeekerHandler()
     loop = temp_event_loop
 
-    def getter(test_obj: "_TestProxyProtocolCommon", *args, **kwargs):
+    def getter(test_obj: "_TestProxyProtocolCommon", *args, **kwargs) -> None:
         kwargs["loop"] = loop
         kwargs["proxy_protocol_timeout"] = proxy_timeout
         protocol = SMTPServer(handler, *args, **kwargs)
         protocol.connection_made(transport)
 
-        def runner(stop_after: float = DEFAULT_AUTOCANCEL):
+        def runner(stop_after: float = DEFAULT_AUTOCANCEL) -> None:
             loop.call_later(stop_after, protocol._handler_coroutine.cancel)
             with suppress(asyncio.CancelledError):
                 loop.run_until_complete(protocol._handler_coroutine)
@@ -156,30 +156,30 @@ class _TestProxyProtocolCommon:
 
 
 class TestProxyData:
-    def test_invalid_version(self):
+    def test_invalid_version(self) -> None:
         pd = ProxyData(version=None)
         assert not pd.valid
         assert not pd
 
-    def test_invalid_error(self):
+    def test_invalid_error(self) -> None:
         pd = ProxyData(version=1)
         pd.error = "SomeError"
         assert not pd.valid
         assert not pd
 
-    def test_invalid_protocol(self):
+    def test_invalid_protocol(self) -> None:
         pd = ProxyData(version=1)
         assert not pd.valid
         assert not pd
 
-    def test_mismatch(self):
+    def test_mismatch(self) -> None:
         pd = ProxyData(version=1)
         pd.protocol = PROTO.UNSPEC
         assert pd.valid
         assert pd
         assert not pd.same_attribs(protocol=PROTO.STREAM)
 
-    def test_mismatch_raises(self):
+    def test_mismatch_raises(self) -> None:
         pd = ProxyData(version=1)
         pd.protocol = PROTO.UNSPEC
         assert pd.valid
@@ -188,21 +188,21 @@ class TestProxyData:
         with pytest.raises(ValueError, match=expectre):
             pd.same_attribs(_raises=True, protocol=PROTO.STREAM)
 
-    def test_unsetkey(self):
+    def test_unsetkey(self) -> None:
         pd = ProxyData(version=1)
         pd.protocol = PROTO.UNSPEC
         assert pd.valid
         assert pd
         assert not pd.same_attribs(src_addr="Missing")
 
-    def test_unknownkey(self):
+    def test_unknownkey(self) -> None:
         pd = ProxyData(version=1)
         pd.protocol = PROTO.UNSPEC
         assert pd.valid
         assert pd
         assert not pd.same_attribs(strange_key="Unrecognized")
 
-    def test_unknownkey_raises(self):
+    def test_unknownkey_raises(self) -> None:
         pd = ProxyData(version=1)
         pd.protocol = PROTO.UNSPEC
         assert pd.valid
@@ -211,16 +211,16 @@ class TestProxyData:
         with pytest.raises(KeyError, match=expectre):
             pd.same_attribs(_raises=True, strange_key="Unrecognized")
 
-    def test_tlv_none(self):
+    def test_tlv_none(self) -> None:
         pd = ProxyData(version=2)
         assert pd.tlv is None
 
-    def test_tlv_fake(self):
+    def test_tlv_fake(self) -> None:
         pd = ProxyData(version=2)
         pd.rest = b"fake_tlv"  # Must be something that fails parsing in ProxyTLV
         assert pd.tlv is None
 
-    def test_tlv_1(self):
+    def test_tlv_1(self) -> None:
         pd = ProxyData(version=2)
         pd.rest = TEST_TLV_DATA_1
         assert pd.tlv is not None
@@ -237,7 +237,7 @@ class TestProxyData:
 
 
 class TestProxyTLV:
-    def test_1(self):
+    def test_1(self) -> None:
         ptlv = ProxyTLV.from_raw(TEST_TLV_DATA_1)
         assert "ALPN" not in ptlv
         assert "NOOP" not in ptlv
@@ -256,12 +256,12 @@ class TestProxyTLV:
             SSL_KEY_ALG=b"RSA4096",
         )
 
-    def test_1_ne(self):
+    def test_1_ne(self) -> None:
         ptlv = ProxyTLV.from_raw(TEST_TLV_DATA_1)
         assert not ptlv.same_attribs(SSL=False)
         assert not ptlv.same_attribs(false_attrib=None)
 
-    def test_1_ne_raises(self):
+    def test_1_ne_raises(self) -> None:
         ptlv = ProxyTLV.from_raw(TEST_TLV_DATA_1)
         expectre = r"mismatch:AUTHORITY actual=.* expect=.*"
         with pytest.raises(ValueError, match=expectre):
@@ -270,7 +270,7 @@ class TestProxyTLV:
         with pytest.raises(KeyError, match=expectre):
             ptlv.same_attribs(_raises=True, i_dont_even=b"what is this")
 
-    def test_2(self):
+    def test_2(self) -> None:
         ptlv = ProxyTLV.from_raw(TEST_TLV_DATA_2)
         assert "ALPN" not in ptlv
         assert "NOOP" not in ptlv
@@ -311,10 +311,10 @@ class TestProxyTLV:
             (None, "wrongname"),
         ],
     )
-    def test_backmap(self, typename: str, typeint: int):
+    def test_backmap(self, typename: str, typeint: int) -> None:
         assert ProxyTLV.name_to_num(typename) == typeint
 
-    def test_parse_partial(self):
+    def test_parse_partial(self) -> None:
         TEST_TLV_DATA_1_TRUNCATED = (
             b"\x03\x00\x04Z\xfd\xc6\xff\x02\x00\tAUTHORITI\x05\x00\tUNIKUE_I"
         )
@@ -323,19 +323,19 @@ class TestProxyTLV:
         assert isinstance(rslt, dict)
         assert "CRC32C" in rslt
 
-    def test_unknowntype_notstrict(self):
+    def test_unknowntype_notstrict(self) -> None:
         test_data = b"\xFF\x00\x04yeah"
         rslt: Dict[str, Any]
         rslt, _ = ProxyTLV.parse(test_data, strict=False)
         assert "xFF" in rslt
         assert rslt["xFF"] == b"yeah"
 
-    def test_unknowntype_strict(self):
+    def test_unknowntype_strict(self) -> None:
         test_data = b"\xFF\x00\x04yeah"
         with pytest.raises(UnknownTypeTLV):
             _ = ProxyTLV.parse(test_data, strict=True)
 
-    def test_malformed_ssl_partialok(self):
+    def test_malformed_ssl_partialok(self) -> None:
         test_data = (
             b"\x20\x00\x17\x01\x02\x03\x04\x05\x21\x00\x07version\x22\x00\x09trunc"
         )
@@ -345,14 +345,14 @@ class TestProxyTLV:
         assert rslt["SSL_VERSION"] == b"version"
         assert "SSL_CN" not in rslt
 
-    def test_malformed_ssl_notpartialok(self):
+    def test_malformed_ssl_notpartialok(self) -> None:
         test_data = (
             b"\x20\x00\x0D\x01\x02\x03\x04\x05\x21\x00\x07version\x22\x00\x09trunc"
         )
         with pytest.raises(MalformedTLV):
             _ = ProxyTLV.parse(test_data, partial_ok=False)
 
-    def test_eq(self):
+    def test_eq(self) -> None:
         data1 = b"\x03\x00\x04Z\xfd\xc6\xff\x02\x00\tAUTHORITI"
         ptlv1 = ProxyTLV.from_raw(data1)
         data2 = b"\x02\x00\tAUTHORITI\x03\x00\x04Z\xfd\xc6\xff"
@@ -397,7 +397,7 @@ class TestModule:
         caplog: pytest.LogCaptureFixture,
         temp_event_loop: asyncio.AbstractEventLoop,
         handshake: bytes,
-    ):
+    ) -> None:
         caplog.set_level(logging.DEBUG)
         mock_reader = self.MockAsyncReader(handshake)
         reslt = temp_event_loop.run_until_complete(get_proxy(mock_reader))
@@ -408,7 +408,7 @@ class TestModule:
         self,
         caplog: pytest.LogCaptureFixture,
         temp_event_loop: asyncio.AbstractEventLoop,
-    ):
+    ) -> None:
         caplog.set_level(logging.DEBUG)
         mock_reader = self.MockAsyncReader(GOOD_V1_HANDSHAKE[0:20])
         reslt = temp_event_loop.run_until_complete(get_proxy(mock_reader))
@@ -422,7 +422,7 @@ class TestModule:
         self,
         caplog: pytest.LogCaptureFixture,
         temp_event_loop: asyncio.AbstractEventLoop,
-    ):
+    ) -> None:
         caplog.set_level(logging.DEBUG)
         mock_reader = self.MockAsyncReader(TEST_V2_DATA1_EXACT[0:20])
         reslt = temp_event_loop.run_until_complete(get_proxy(mock_reader))
@@ -437,7 +437,7 @@ class TestModule:
         self,
         caplog: pytest.LogCaptureFixture,
         temp_event_loop: asyncio.AbstractEventLoop,
-    ):
+    ) -> None:
         caplog.set_level(logging.DEBUG)
         mock_reader = self.MockAsyncReader(b"PROXI TCP4 1.2.3.4 5.6.7.8 9 10\r\n")
         reslt = temp_event_loop.run_until_complete(get_proxy(mock_reader))
@@ -451,24 +451,24 @@ class TestModule:
 
 class TestSMTPInit:
     @parametrize("value", [int(-1), float(-1.0), int(0), float(0.0)])
-    def test_value_error(self, temp_event_loop: asyncio.AbstractEventLoop, value: Union[int, float]):
+    def test_value_error(self, temp_event_loop: asyncio.AbstractEventLoop, value: Union[int, float]) -> None:
         with pytest.raises(ValueError, match=r"proxy_protocol_timeout must be > 0"):
             _ = SMTPServer(Sink(), proxy_protocol_timeout=value, loop=temp_event_loop)
 
-    def test_lt_3(self, caplog: pytest.LogCaptureFixture, temp_event_loop: asyncio.AbstractEventLoop):
+    def test_lt_3(self, caplog: pytest.LogCaptureFixture, temp_event_loop: asyncio.AbstractEventLoop) -> None:
         _ = SMTPServer(Sink(), proxy_protocol_timeout=1, loop=temp_event_loop)
         expect = ("mail.log", logging.WARNING, "proxy_protocol_timeout < 3.0")
         assert expect in caplog.record_tuples
 
     @parametrize("value", [int(3), float(3.0), int(4), float(4.0)])
-    def test_ge_3(self, caplog: pytest.LogCaptureFixture, temp_event_loop: asyncio.AbstractEventLoop, value: Union[int, float]):
+    def test_ge_3(self, caplog: pytest.LogCaptureFixture, temp_event_loop: asyncio.AbstractEventLoop, value: Union[int, float]) -> None:
         _ = SMTPServer(Sink(), proxy_protocol_timeout=value, loop=temp_event_loop)
         expect = ("mail.log", logging.WARNING, "proxy_protocol_timeout < 3.0")
         assert expect not in caplog.record_tuples
 
 
 class TestGetV1(_TestProxyProtocolCommon):
-    def test_noproxy(self, setup_proxy_protocol: Callable):
+    def test_noproxy(self, setup_proxy_protocol: Callable) -> None:
         setup_proxy_protocol(self)
         data = b"HELO example.org\r\n"
         self.protocol.data_received(data)
@@ -476,7 +476,7 @@ class TestGetV1(_TestProxyProtocolCommon):
         assert self.transport.close.called
 
     @parametrize("patt", PUBLIC_V1_PATTERNS.values(), ids=PUBLIC_V1_PATTERNS.keys())
-    def test_valid_patterns(self, setup_proxy_protocol: Callable, patt: bytes):
+    def test_valid_patterns(self, setup_proxy_protocol: Callable, patt: bytes) -> None:
         if not patt.endswith(b"\r\n"):
             patt += b"\r\n"
         setup_proxy_protocol(self)
@@ -506,7 +506,7 @@ class TestGetV1(_TestProxyProtocolCommon):
             dst_port=dstport,
         )
 
-    def test_tcp4(self, setup_proxy_protocol: Callable):
+    def test_tcp4(self, setup_proxy_protocol: Callable) -> None:
         srcip = "1.2.3.4"
         dstip = "5.6.7.8"
         srcport = 0
@@ -517,7 +517,7 @@ class TestGetV1(_TestProxyProtocolCommon):
             AF.INET, PROTO.STREAM, srcip, dstip, srcport, dstport, prox_test
         )
 
-    def test_tcp4_random(self, setup_proxy_protocol: Callable):
+    def test_tcp4_random(self, setup_proxy_protocol: Callable) -> None:
         setup_proxy_protocol(self)
         srcip = ".".join(f"{random.getrandbits(8)}" for _ in range(0, 4))
         dstip = ".".join(f"{random.getrandbits(8)}" for _ in range(0, 4))
@@ -528,7 +528,7 @@ class TestGetV1(_TestProxyProtocolCommon):
             AF.INET, PROTO.STREAM, srcip, dstip, srcport, dstport, prox_test
         )
 
-    def test_tcp6_shortened(self, setup_proxy_protocol: Callable):
+    def test_tcp6_shortened(self, setup_proxy_protocol: Callable) -> None:
         srcip = "2020:dead::0001"
         dstip = "2021:cafe::0002"
         srcport = 8000
@@ -539,7 +539,7 @@ class TestGetV1(_TestProxyProtocolCommon):
             AF.INET6, PROTO.STREAM, srcip, dstip, srcport, dstport, prox_test
         )
 
-    def test_tcp6_random(self, setup_proxy_protocol: Callable):
+    def test_tcp6_random(self, setup_proxy_protocol: Callable) -> None:
         srcip = ":".join(f"{random.getrandbits(16):04x}" for _ in range(0, 8))
         dstip = ":".join(f"{random.getrandbits(16):04x}" for _ in range(0, 8))
         srcport = random_port()
@@ -550,7 +550,7 @@ class TestGetV1(_TestProxyProtocolCommon):
             AF.INET6, PROTO.STREAM, srcip, dstip, srcport, dstport, prox_test
         )
 
-    def test_unknown(self, setup_proxy_protocol: Callable):
+    def test_unknown(self, setup_proxy_protocol: Callable) -> None:
         prox_test = "PROXY UNKNOWN whatever\r\n"
         setup_proxy_protocol(self)
         self.protocol.data_received(prox_test.encode("ascii"))
@@ -566,7 +566,7 @@ class TestGetV1(_TestProxyProtocolCommon):
             rest=b" whatever",
         )
 
-    def test_unknown_short(self, setup_proxy_protocol: Callable):
+    def test_unknown_short(self, setup_proxy_protocol: Callable) -> None:
         prox_test = "PROXY UNKNOWN\r\n"
         setup_proxy_protocol(self)
         self.protocol.data_received(prox_test.encode("ascii"))
@@ -591,12 +591,12 @@ class TestGetV1(_TestProxyProtocolCommon):
         assert self.transport.close.called
         assert self.protocol.session.proxy_data.error == expect_err
 
-    def test_invalid_sig(self, setup_proxy_protocol: Callable):
+    def test_invalid_sig(self, setup_proxy_protocol: Callable) -> None:
         prox_test = "PROXY1 UNKNOWN whatevs\r\n"
         setup_proxy_protocol(self)
         self._assert_invalid(prox_test, "PROXYv1 wrong signature")
 
-    def test_unsupported_family(self, setup_proxy_protocol: Callable):
+    def test_unsupported_family(self, setup_proxy_protocol: Callable) -> None:
         prox_test = "PROXY TCP5 123.123.123.123 231.231.231.231 80 90\r\n"
         setup_proxy_protocol(self)
         self._assert_invalid(prox_test, "PROXYv1 unrecognized family")
@@ -604,22 +604,22 @@ class TestGetV1(_TestProxyProtocolCommon):
         setup_proxy_protocol(self)
         self._assert_invalid(prox_test, "PROXYv1 unrecognized family")
 
-    def test_unsupported_proto(self, setup_proxy_protocol: Callable):
+    def test_unsupported_proto(self, setup_proxy_protocol: Callable) -> None:
         prox_test = "PROXY UDP4 123.123.123.123 231.231.231.231 80 90\r\n"
         setup_proxy_protocol(self)
         self._assert_invalid(prox_test, "PROXYv1 unrecognized protocol")
 
-    def test_too_long(self, setup_proxy_protocol: Callable):
+    def test_too_long(self, setup_proxy_protocol: Callable) -> None:
         prox_test = "PROXY UNKNOWN " + "*" * 100 + "\r\n"
         setup_proxy_protocol(self)
         self._assert_invalid(prox_test, "PROXYv1 header too long")
 
-    def test_malformed_nocr(self, setup_proxy_protocol: Callable):
+    def test_malformed_nocr(self, setup_proxy_protocol: Callable) -> None:
         prox_test = "PROXY UNKNOWN\n"
         setup_proxy_protocol(self)
         self._assert_invalid(prox_test, "PROXYv1 malformed")
 
-    def test_malformed_notproxy(self, setup_proxy_protocol: Callable):
+    def test_malformed_notproxy(self, setup_proxy_protocol: Callable) -> None:
         srcip = "1.2.3.4"
         dstip = "5.6.7.8"
         srcport = 65535
@@ -628,7 +628,7 @@ class TestGetV1(_TestProxyProtocolCommon):
         setup_proxy_protocol(self)
         self._assert_invalid(prox_test, "PROXY unrecognized signature")
 
-    def test_malformed_wrongtype_64(self, setup_proxy_protocol: Callable):
+    def test_malformed_wrongtype_64(self, setup_proxy_protocol: Callable) -> None:
         srcip = "1.2.3.4"
         dstip = "5.6.7.8"
         srcport = 65535
@@ -637,7 +637,7 @@ class TestGetV1(_TestProxyProtocolCommon):
         setup_proxy_protocol(self)
         self._assert_invalid(prox_test, "PROXYv1 address not IPv6")
 
-    def test_malformed_wrongtype_46(self, setup_proxy_protocol: Callable):
+    def test_malformed_wrongtype_46(self, setup_proxy_protocol: Callable) -> None:
         srcip = "2020:dead::0001"
         dstip = "2021:cafe::0002"
         srcport = 65535
@@ -646,7 +646,7 @@ class TestGetV1(_TestProxyProtocolCommon):
         setup_proxy_protocol(self)
         self._assert_invalid(prox_test, "PROXYv1 address not IPv4")
 
-    def test_malformed_wrongtype_6mixed(self, setup_proxy_protocol: Callable):
+    def test_malformed_wrongtype_6mixed(self, setup_proxy_protocol: Callable) -> None:
         srcip = "1.2.3.4"
         dstip = "2021:cafe::0002"
         srcport = 65535
@@ -672,7 +672,7 @@ class TestGetV1(_TestProxyProtocolCommon):
     )
     def test_malformed_addr(
         self, setup_proxy_protocol: Callable, srcip: str, dstip: str, srcport: Optional[int], dstport: Optional[int], whatwrong: str
-    ):
+    ) -> None:
         if srcport is None:
             srcport = random_port()
         if dstport is None:
@@ -688,12 +688,12 @@ class TestGetV1(_TestProxyProtocolCommon):
             param(" text", id="sptext"),
         ],
     )
-    def test_extra(self, setup_proxy_protocol: Callable, extra: str):
+    def test_extra(self, setup_proxy_protocol: Callable, extra: str) -> None:
         prox_test = f"PROXY TCP6 {self.IP6_dead} {self.IP6_cafe} 0 25{extra}\r\n"
         setup_proxy_protocol(self)
         self._assert_invalid(prox_test, "PROXYv1 unrecognized extraneous data")
 
-    def test_malformed_addr4(self, setup_proxy_protocol: Callable):
+    def test_malformed_addr4(self, setup_proxy_protocol: Callable) -> None:
         srcip = "1.2.3.a"
         dstip = "5.6.7.8"
         srcport = 65535
@@ -702,7 +702,7 @@ class TestGetV1(_TestProxyProtocolCommon):
         setup_proxy_protocol(self)
         self._assert_invalid(prox_test, "PROXYv1 address malformed")
 
-    def test_ports_oob(self, setup_proxy_protocol: Callable):
+    def test_ports_oob(self, setup_proxy_protocol: Callable) -> None:
         srcip = "1.2.3.4"
         dstip = "5.6.7.8"
         srcport = 65536
@@ -711,7 +711,7 @@ class TestGetV1(_TestProxyProtocolCommon):
         setup_proxy_protocol(self)
         self._assert_invalid(prox_test, "PROXYv1 src port out of bounds")
 
-    def test_portd_oob(self, setup_proxy_protocol: Callable):
+    def test_portd_oob(self, setup_proxy_protocol: Callable) -> None:
         srcip = "2020:dead::0001"
         dstip = "2021:cafe::0002"
         srcport = 10000
@@ -722,7 +722,7 @@ class TestGetV1(_TestProxyProtocolCommon):
 
 
 class TestGetV2(_TestProxyProtocolCommon):
-    def test_1(self, setup_proxy_protocol: Callable):
+    def test_1(self, setup_proxy_protocol: Callable) -> None:
         setup_proxy_protocol(self)
         self.protocol.data_received(TEST_V2_DATA1_XTRA)
         self.runner()
@@ -773,13 +773,13 @@ class TestGetV2(_TestProxyProtocolCommon):
         assert handler.called
         return handler.proxy_datas[-1]
 
-    def test_UNSPEC_empty(self, setup_proxy_protocol: Callable):
+    def test_UNSPEC_empty(self, setup_proxy_protocol: Callable) -> None:
         setup_proxy_protocol(self)
         assert self._send_valid(
             V2_CMD.LOCAL, AF.UNSPEC, PROTO.UNSPEC, b""
         ).same_attribs(valid=True, version=2, command=0, family=0, protocol=0, rest=b"")
 
-    def test_UNSPEC_notempty(self, setup_proxy_protocol: Callable):
+    def test_UNSPEC_notempty(self, setup_proxy_protocol: Callable) -> None:
         setup_proxy_protocol(self)
         payload = b"asdfghjkl"
         assert self._send_valid(
@@ -790,7 +790,7 @@ class TestGetV2(_TestProxyProtocolCommon):
 
     @parametrize("ttlv", [b"", b"fake_tlv"])
     @parametrize("tproto", [PROTO.STREAM, PROTO.DGRAM])
-    def test_INET4(self, setup_proxy_protocol: Callable, tproto: PROTO, ttlv: bytes):
+    def test_INET4(self, setup_proxy_protocol: Callable, tproto: PROTO, ttlv: bytes) -> None:
         setup_proxy_protocol(self)
         src_addr = IPv4Address("10.212.4.33")
         dst_addr = IPv4Address("10.11.12.13")
@@ -820,7 +820,7 @@ class TestGetV2(_TestProxyProtocolCommon):
 
     @parametrize("ttlv", [b"", b"fake_tlv"])
     @parametrize("tproto", [PROTO.STREAM, PROTO.DGRAM])
-    def test_INET6(self, setup_proxy_protocol: Callable, tproto: PROTO, ttlv: bytes):
+    def test_INET6(self, setup_proxy_protocol: Callable, tproto: PROTO, ttlv: bytes) -> None:
         setup_proxy_protocol(self)
         src_addr = IPv6Address("2020:dead::0001")
         dst_addr = IPv6Address("2021:cafe::0022")
@@ -850,7 +850,7 @@ class TestGetV2(_TestProxyProtocolCommon):
 
     @parametrize("ttlv", [b"", b"fake_tlv"])
     @parametrize("tproto", [PROTO.STREAM, PROTO.DGRAM])
-    def test_UNIX(self, setup_proxy_protocol: Callable, tproto: PROTO, ttlv: bytes):
+    def test_UNIX(self, setup_proxy_protocol: Callable, tproto: PROTO, ttlv: bytes) -> None:
         setup_proxy_protocol(self)
         src_addr = struct.pack("108s", b"/proc/source")
         dst_addr = struct.pack("108s", b"/proc/dest")
@@ -880,7 +880,7 @@ class TestGetV2(_TestProxyProtocolCommon):
             (AF.UNIX, PROTO.UNSPEC),
         ],
     )
-    def test_fallback_UNSPEC(self, setup_proxy_protocol: Callable, tfam: AF, tproto: PROTO):
+    def test_fallback_UNSPEC(self, setup_proxy_protocol: Callable, tfam: AF, tproto: PROTO) -> None:
         setup_proxy_protocol(self)
         payload = b"whatever"
         assert self._send_valid(V2_CMD.LOCAL, tfam, tproto, payload).same_attribs(
@@ -923,7 +923,7 @@ class TestGetV2(_TestProxyProtocolCommon):
             assert self.protocol.session.proxy_data.error == expect
         return self.protocol.session.proxy_data
 
-    def test_invalid_sig(self, setup_proxy_protocol: Callable):
+    def test_invalid_sig(self, setup_proxy_protocol: Callable) -> None:
         setup_proxy_protocol(self)
         ERRSIG = b"\r\n\r\n\x00\r\nQUIP\n"
         self._send_invalid(sig=ERRSIG, expect="PROXYv2 wrong signature")
@@ -943,23 +943,23 @@ class TestGetV2(_TestProxyProtocolCommon):
     #     assert not sess.proxy_data.valid
     #     assert sess.proxy_data.error == "PROXYv2 malformed header"
 
-    def test_illegal_ver(self, setup_proxy_protocol: Callable):
+    def test_illegal_ver(self, setup_proxy_protocol: Callable) -> None:
         setup_proxy_protocol(self)
         self._send_invalid(ver=3, expect="PROXYv2 illegal version")
 
-    def test_unsupported_cmd(self, setup_proxy_protocol: Callable):
+    def test_unsupported_cmd(self, setup_proxy_protocol: Callable) -> None:
         setup_proxy_protocol(self)
         self._send_invalid(cmd=2, expect="PROXYv2 unsupported command")
 
-    def test_unsupported_fam(self, setup_proxy_protocol: Callable):
+    def test_unsupported_fam(self, setup_proxy_protocol: Callable) -> None:
         setup_proxy_protocol(self)
         self._send_invalid(fam=4, expect="PROXYv2 unsupported family")
 
-    def test_unsupported_proto(self, setup_proxy_protocol: Callable):
+    def test_unsupported_proto(self, setup_proxy_protocol: Callable) -> None:
         setup_proxy_protocol(self)
         self._send_invalid(proto=3, expect="PROXYv2 unsupported protocol")
 
-    def test_wrong_proto_6shouldbe4(self, setup_proxy_protocol: Callable):
+    def test_wrong_proto_6shouldbe4(self, setup_proxy_protocol: Callable) -> None:
         setup_proxy_protocol(self)
         src_addr = IPv4Address("192.168.0.11")
         dst_addr = IPv4Address("172.16.0.22")
@@ -979,7 +979,7 @@ class TestGetV2(_TestProxyProtocolCommon):
 @controller_data(proxy_protocol_timeout=0.3)
 @handler_data(class_=ProxyPeekerHandler)
 class TestWithController:
-    def _okay(self, handshake: bytes):
+    def _okay(self, handshake: bytes) -> None:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
             sock.connect(Global.SrvAddr)
             sock.sendall(handshake)
@@ -993,12 +993,12 @@ class TestWithController:
                 assert code == 221
 
     @parametrize("handshake", HANDSHAKES.values(), ids=HANDSHAKES.keys())
-    def test_okay(self, plain_controller: Controller, handshake: bytes):
+    def test_okay(self, plain_controller: Controller, handshake: bytes) -> None:
         assert plain_controller.smtpd._proxy_timeout > 0.0
         self._okay(handshake)
 
     @parametrize("handshake", HANDSHAKES.values(), ids=HANDSHAKES.keys())
-    def test_hiccup(self, plain_controller: Controller, handshake: bytes):
+    def test_hiccup(self, plain_controller: Controller, handshake: bytes) -> None:
         assert plain_controller.smtpd._proxy_timeout > 0.0
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
             sock.connect(Global.SrvAddr)
@@ -1015,7 +1015,7 @@ class TestWithController:
                 assert code == 221
 
     @parametrize("handshake", HANDSHAKES.values(), ids=HANDSHAKES.keys())
-    def test_timeout(self, plain_controller: Controller, handshake: bytes):
+    def test_timeout(self, plain_controller: Controller, handshake: bytes) -> None:
         assert plain_controller.smtpd._proxy_timeout > 0.0
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
             sock.connect(Global.SrvAddr)
@@ -1051,7 +1051,7 @@ class TestWithController:
         self._okay(handshake)
 
     @parametrize("handshake", HANDSHAKES.values(), ids=HANDSHAKES.keys())
-    def test_incomplete(self, plain_controller: Controller, handshake: bytes):
+    def test_incomplete(self, plain_controller: Controller, handshake: bytes) -> None:
         assert plain_controller.smtpd._proxy_timeout > 0.0
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
             sock.connect(Global.SrvAddr)
@@ -1101,7 +1101,7 @@ class TestHandlerAcceptReject:
         ],
         ids=["v1", "v2"],
     )
-    def test_simple(self, plain_controller: Controller, handshake: bytes, handler_retval: bool):
+    def test_simple(self, plain_controller: Controller, handshake: bytes, handler_retval: bool) -> None:
         assert plain_controller.smtpd._proxy_timeout > 0.0
         assert isinstance(plain_controller.handler, ProxyPeekerHandler)
         plain_controller.handler.retval = handler_retval

--- a/aiosmtpd/tests/test_proxyprotocol.py
+++ b/aiosmtpd/tests/test_proxyprotocol.py
@@ -15,11 +15,12 @@ from functools import partial
 from ipaddress import IPv4Address, IPv6Address
 from smtplib import SMTP as SMTPClient
 from smtplib import SMTPServerDisconnected
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import pytest
 from pytest_mock import MockFixture
 
+from aiosmtpd.controller import Controller
 from aiosmtpd.handlers import Sink
 from aiosmtpd.proxy_protocol import (
     V2_CMD,
@@ -362,7 +363,7 @@ class TestProxyTLV:
 
 class TestModule:
     class MockAsyncReader(AsyncReader):
-        def __init__(self, data, timeout=0.4):
+        def __init__(self, data: bytes, timeout: float = 0.4):
             self.data = bytearray(data)
             self.timeout = 0.4
 
@@ -450,24 +451,24 @@ class TestModule:
 
 class TestSMTPInit:
     @parametrize("value", [int(-1), float(-1.0), int(0), float(0.0)])
-    def test_value_error(self, temp_event_loop, value):
+    def test_value_error(self, temp_event_loop: asyncio.AbstractEventLoop, value: Union[int, float]):
         with pytest.raises(ValueError, match=r"proxy_protocol_timeout must be > 0"):
             _ = SMTPServer(Sink(), proxy_protocol_timeout=value, loop=temp_event_loop)
 
-    def test_lt_3(self, caplog, temp_event_loop):
+    def test_lt_3(self, caplog: pytest.LogCaptureFixture, temp_event_loop: asyncio.AbstractEventLoop):
         _ = SMTPServer(Sink(), proxy_protocol_timeout=1, loop=temp_event_loop)
         expect = ("mail.log", logging.WARNING, "proxy_protocol_timeout < 3.0")
         assert expect in caplog.record_tuples
 
     @parametrize("value", [int(3), float(3.0), int(4), float(4.0)])
-    def test_ge_3(self, caplog, temp_event_loop, value):
+    def test_ge_3(self, caplog: pytest.LogCaptureFixture, temp_event_loop: asyncio.AbstractEventLoop, value: Union[int, float]):
         _ = SMTPServer(Sink(), proxy_protocol_timeout=value, loop=temp_event_loop)
         expect = ("mail.log", logging.WARNING, "proxy_protocol_timeout < 3.0")
         assert expect not in caplog.record_tuples
 
 
 class TestGetV1(_TestProxyProtocolCommon):
-    def test_noproxy(self, setup_proxy_protocol):
+    def test_noproxy(self, setup_proxy_protocol: Callable):
         setup_proxy_protocol(self)
         data = b"HELO example.org\r\n"
         self.protocol.data_received(data)
@@ -486,7 +487,7 @@ class TestGetV1(_TestProxyProtocolCommon):
         handler = self.protocol.event_handler
         assert handler.called
 
-    def _assert_valid(self, af, proto, srcip, dstip, srcport, dstport, testline):
+    def _assert_valid(self, af: AF, proto: PROTO, srcip: str, dstip: str, srcport: int, dstport: int, testline: str):
         self.protocol.data_received(testline.encode("ascii"))
         self.runner()
         assert self.protocol.session.proxy_data.error == ""
@@ -505,7 +506,7 @@ class TestGetV1(_TestProxyProtocolCommon):
             dst_port=dstport,
         )
 
-    def test_tcp4(self, setup_proxy_protocol):
+    def test_tcp4(self, setup_proxy_protocol: Callable):
         srcip = "1.2.3.4"
         dstip = "5.6.7.8"
         srcport = 0
@@ -516,7 +517,7 @@ class TestGetV1(_TestProxyProtocolCommon):
             AF.INET, PROTO.STREAM, srcip, dstip, srcport, dstport, prox_test
         )
 
-    def test_tcp4_random(self, setup_proxy_protocol):
+    def test_tcp4_random(self, setup_proxy_protocol: Callable):
         setup_proxy_protocol(self)
         srcip = ".".join(f"{random.getrandbits(8)}" for _ in range(0, 4))
         dstip = ".".join(f"{random.getrandbits(8)}" for _ in range(0, 4))
@@ -527,7 +528,7 @@ class TestGetV1(_TestProxyProtocolCommon):
             AF.INET, PROTO.STREAM, srcip, dstip, srcport, dstport, prox_test
         )
 
-    def test_tcp6_shortened(self, setup_proxy_protocol):
+    def test_tcp6_shortened(self, setup_proxy_protocol: Callable):
         srcip = "2020:dead::0001"
         dstip = "2021:cafe::0002"
         srcport = 8000
@@ -538,7 +539,7 @@ class TestGetV1(_TestProxyProtocolCommon):
             AF.INET6, PROTO.STREAM, srcip, dstip, srcport, dstport, prox_test
         )
 
-    def test_tcp6_random(self, setup_proxy_protocol):
+    def test_tcp6_random(self, setup_proxy_protocol: Callable):
         srcip = ":".join(f"{random.getrandbits(16):04x}" for _ in range(0, 8))
         dstip = ":".join(f"{random.getrandbits(16):04x}" for _ in range(0, 8))
         srcport = random_port()
@@ -549,7 +550,7 @@ class TestGetV1(_TestProxyProtocolCommon):
             AF.INET6, PROTO.STREAM, srcip, dstip, srcport, dstport, prox_test
         )
 
-    def test_unknown(self, setup_proxy_protocol):
+    def test_unknown(self, setup_proxy_protocol: Callable):
         prox_test = "PROXY UNKNOWN whatever\r\n"
         setup_proxy_protocol(self)
         self.protocol.data_received(prox_test.encode("ascii"))
@@ -565,7 +566,7 @@ class TestGetV1(_TestProxyProtocolCommon):
             rest=b" whatever",
         )
 
-    def test_unknown_short(self, setup_proxy_protocol):
+    def test_unknown_short(self, setup_proxy_protocol: Callable):
         prox_test = "PROXY UNKNOWN\r\n"
         setup_proxy_protocol(self)
         self.protocol.data_received(prox_test.encode("ascii"))
@@ -590,12 +591,12 @@ class TestGetV1(_TestProxyProtocolCommon):
         assert self.transport.close.called
         assert self.protocol.session.proxy_data.error == expect_err
 
-    def test_invalid_sig(self, setup_proxy_protocol):
+    def test_invalid_sig(self, setup_proxy_protocol: Callable):
         prox_test = "PROXY1 UNKNOWN whatevs\r\n"
         setup_proxy_protocol(self)
         self._assert_invalid(prox_test, "PROXYv1 wrong signature")
 
-    def test_unsupported_family(self, setup_proxy_protocol):
+    def test_unsupported_family(self, setup_proxy_protocol: Callable):
         prox_test = "PROXY TCP5 123.123.123.123 231.231.231.231 80 90\r\n"
         setup_proxy_protocol(self)
         self._assert_invalid(prox_test, "PROXYv1 unrecognized family")
@@ -603,22 +604,22 @@ class TestGetV1(_TestProxyProtocolCommon):
         setup_proxy_protocol(self)
         self._assert_invalid(prox_test, "PROXYv1 unrecognized family")
 
-    def test_unsupported_proto(self, setup_proxy_protocol):
+    def test_unsupported_proto(self, setup_proxy_protocol: Callable):
         prox_test = "PROXY UDP4 123.123.123.123 231.231.231.231 80 90\r\n"
         setup_proxy_protocol(self)
         self._assert_invalid(prox_test, "PROXYv1 unrecognized protocol")
 
-    def test_too_long(self, setup_proxy_protocol):
+    def test_too_long(self, setup_proxy_protocol: Callable):
         prox_test = "PROXY UNKNOWN " + "*" * 100 + "\r\n"
         setup_proxy_protocol(self)
         self._assert_invalid(prox_test, "PROXYv1 header too long")
 
-    def test_malformed_nocr(self, setup_proxy_protocol):
+    def test_malformed_nocr(self, setup_proxy_protocol: Callable):
         prox_test = "PROXY UNKNOWN\n"
         setup_proxy_protocol(self)
         self._assert_invalid(prox_test, "PROXYv1 malformed")
 
-    def test_malformed_notproxy(self, setup_proxy_protocol):
+    def test_malformed_notproxy(self, setup_proxy_protocol: Callable):
         srcip = "1.2.3.4"
         dstip = "5.6.7.8"
         srcport = 65535
@@ -627,7 +628,7 @@ class TestGetV1(_TestProxyProtocolCommon):
         setup_proxy_protocol(self)
         self._assert_invalid(prox_test, "PROXY unrecognized signature")
 
-    def test_malformed_wrongtype_64(self, setup_proxy_protocol):
+    def test_malformed_wrongtype_64(self, setup_proxy_protocol: Callable):
         srcip = "1.2.3.4"
         dstip = "5.6.7.8"
         srcport = 65535
@@ -636,7 +637,7 @@ class TestGetV1(_TestProxyProtocolCommon):
         setup_proxy_protocol(self)
         self._assert_invalid(prox_test, "PROXYv1 address not IPv6")
 
-    def test_malformed_wrongtype_46(self, setup_proxy_protocol):
+    def test_malformed_wrongtype_46(self, setup_proxy_protocol: Callable):
         srcip = "2020:dead::0001"
         dstip = "2021:cafe::0002"
         srcport = 65535
@@ -645,7 +646,7 @@ class TestGetV1(_TestProxyProtocolCommon):
         setup_proxy_protocol(self)
         self._assert_invalid(prox_test, "PROXYv1 address not IPv4")
 
-    def test_malformed_wrongtype_6mixed(self, setup_proxy_protocol):
+    def test_malformed_wrongtype_6mixed(self, setup_proxy_protocol: Callable):
         srcip = "1.2.3.4"
         dstip = "2021:cafe::0002"
         srcport = 65535
@@ -670,7 +671,7 @@ class TestGetV1(_TestProxyProtocolCommon):
         ],
     )
     def test_malformed_addr(
-        self, setup_proxy_protocol, srcip, dstip, srcport, dstport, whatwrong
+        self, setup_proxy_protocol: Callable, srcip: str, dstip: str, srcport: Optional[int], dstport: Optional[int], whatwrong: str
     ):
         if srcport is None:
             srcport = random_port()
@@ -687,12 +688,12 @@ class TestGetV1(_TestProxyProtocolCommon):
             param(" text", id="sptext"),
         ],
     )
-    def test_extra(self, setup_proxy_protocol, extra):
+    def test_extra(self, setup_proxy_protocol: Callable, extra: str):
         prox_test = f"PROXY TCP6 {self.IP6_dead} {self.IP6_cafe} 0 25{extra}\r\n"
         setup_proxy_protocol(self)
         self._assert_invalid(prox_test, "PROXYv1 unrecognized extraneous data")
 
-    def test_malformed_addr4(self, setup_proxy_protocol):
+    def test_malformed_addr4(self, setup_proxy_protocol: Callable):
         srcip = "1.2.3.a"
         dstip = "5.6.7.8"
         srcport = 65535
@@ -701,7 +702,7 @@ class TestGetV1(_TestProxyProtocolCommon):
         setup_proxy_protocol(self)
         self._assert_invalid(prox_test, "PROXYv1 address malformed")
 
-    def test_ports_oob(self, setup_proxy_protocol):
+    def test_ports_oob(self, setup_proxy_protocol: Callable):
         srcip = "1.2.3.4"
         dstip = "5.6.7.8"
         srcport = 65536
@@ -710,7 +711,7 @@ class TestGetV1(_TestProxyProtocolCommon):
         setup_proxy_protocol(self)
         self._assert_invalid(prox_test, "PROXYv1 src port out of bounds")
 
-    def test_portd_oob(self, setup_proxy_protocol):
+    def test_portd_oob(self, setup_proxy_protocol: Callable):
         srcip = "2020:dead::0001"
         dstip = "2021:cafe::0002"
         srcport = 10000
@@ -721,7 +722,7 @@ class TestGetV1(_TestProxyProtocolCommon):
 
 
 class TestGetV2(_TestProxyProtocolCommon):
-    def test_1(self, setup_proxy_protocol):
+    def test_1(self, setup_proxy_protocol: Callable):
         setup_proxy_protocol(self)
         self.protocol.data_received(TEST_V2_DATA1_XTRA)
         self.runner()
@@ -772,13 +773,13 @@ class TestGetV2(_TestProxyProtocolCommon):
         assert handler.called
         return handler.proxy_datas[-1]
 
-    def test_UNSPEC_empty(self, setup_proxy_protocol):
+    def test_UNSPEC_empty(self, setup_proxy_protocol: Callable):
         setup_proxy_protocol(self)
         assert self._send_valid(
             V2_CMD.LOCAL, AF.UNSPEC, PROTO.UNSPEC, b""
         ).same_attribs(valid=True, version=2, command=0, family=0, protocol=0, rest=b"")
 
-    def test_UNSPEC_notempty(self, setup_proxy_protocol):
+    def test_UNSPEC_notempty(self, setup_proxy_protocol: Callable):
         setup_proxy_protocol(self)
         payload = b"asdfghjkl"
         assert self._send_valid(
@@ -789,7 +790,7 @@ class TestGetV2(_TestProxyProtocolCommon):
 
     @parametrize("ttlv", [b"", b"fake_tlv"])
     @parametrize("tproto", [PROTO.STREAM, PROTO.DGRAM])
-    def test_INET4(self, setup_proxy_protocol, tproto, ttlv):
+    def test_INET4(self, setup_proxy_protocol: Callable, tproto: PROTO, ttlv: bytes):
         setup_proxy_protocol(self)
         src_addr = IPv4Address("10.212.4.33")
         dst_addr = IPv4Address("10.11.12.13")
@@ -819,7 +820,7 @@ class TestGetV2(_TestProxyProtocolCommon):
 
     @parametrize("ttlv", [b"", b"fake_tlv"])
     @parametrize("tproto", [PROTO.STREAM, PROTO.DGRAM])
-    def test_INET6(self, setup_proxy_protocol, tproto, ttlv):
+    def test_INET6(self, setup_proxy_protocol: Callable, tproto: PROTO, ttlv: bytes):
         setup_proxy_protocol(self)
         src_addr = IPv6Address("2020:dead::0001")
         dst_addr = IPv6Address("2021:cafe::0022")
@@ -849,7 +850,7 @@ class TestGetV2(_TestProxyProtocolCommon):
 
     @parametrize("ttlv", [b"", b"fake_tlv"])
     @parametrize("tproto", [PROTO.STREAM, PROTO.DGRAM])
-    def test_UNIX(self, setup_proxy_protocol, tproto, ttlv):
+    def test_UNIX(self, setup_proxy_protocol: Callable, tproto: PROTO, ttlv: bytes):
         setup_proxy_protocol(self)
         src_addr = struct.pack("108s", b"/proc/source")
         dst_addr = struct.pack("108s", b"/proc/dest")
@@ -879,7 +880,7 @@ class TestGetV2(_TestProxyProtocolCommon):
             (AF.UNIX, PROTO.UNSPEC),
         ],
     )
-    def test_fallback_UNSPEC(self, setup_proxy_protocol, tfam, tproto):
+    def test_fallback_UNSPEC(self, setup_proxy_protocol: Callable, tfam: AF, tproto: PROTO):
         setup_proxy_protocol(self)
         payload = b"whatever"
         assert self._send_valid(V2_CMD.LOCAL, tfam, tproto, payload).same_attribs(
@@ -922,7 +923,7 @@ class TestGetV2(_TestProxyProtocolCommon):
             assert self.protocol.session.proxy_data.error == expect
         return self.protocol.session.proxy_data
 
-    def test_invalid_sig(self, setup_proxy_protocol):
+    def test_invalid_sig(self, setup_proxy_protocol: Callable):
         setup_proxy_protocol(self)
         ERRSIG = b"\r\n\r\n\x00\r\nQUIP\n"
         self._send_invalid(sig=ERRSIG, expect="PROXYv2 wrong signature")
@@ -942,23 +943,23 @@ class TestGetV2(_TestProxyProtocolCommon):
     #     assert not sess.proxy_data.valid
     #     assert sess.proxy_data.error == "PROXYv2 malformed header"
 
-    def test_illegal_ver(self, setup_proxy_protocol):
+    def test_illegal_ver(self, setup_proxy_protocol: Callable):
         setup_proxy_protocol(self)
         self._send_invalid(ver=3, expect="PROXYv2 illegal version")
 
-    def test_unsupported_cmd(self, setup_proxy_protocol):
+    def test_unsupported_cmd(self, setup_proxy_protocol: Callable):
         setup_proxy_protocol(self)
         self._send_invalid(cmd=2, expect="PROXYv2 unsupported command")
 
-    def test_unsupported_fam(self, setup_proxy_protocol):
+    def test_unsupported_fam(self, setup_proxy_protocol: Callable):
         setup_proxy_protocol(self)
         self._send_invalid(fam=4, expect="PROXYv2 unsupported family")
 
-    def test_unsupported_proto(self, setup_proxy_protocol):
+    def test_unsupported_proto(self, setup_proxy_protocol: Callable):
         setup_proxy_protocol(self)
         self._send_invalid(proto=3, expect="PROXYv2 unsupported protocol")
 
-    def test_wrong_proto_6shouldbe4(self, setup_proxy_protocol):
+    def test_wrong_proto_6shouldbe4(self, setup_proxy_protocol: Callable):
         setup_proxy_protocol(self)
         src_addr = IPv4Address("192.168.0.11")
         dst_addr = IPv4Address("172.16.0.22")
@@ -992,12 +993,12 @@ class TestWithController:
                 assert code == 221
 
     @parametrize("handshake", HANDSHAKES.values(), ids=HANDSHAKES.keys())
-    def test_okay(self, plain_controller, handshake):
+    def test_okay(self, plain_controller: Controller, handshake: bytes):
         assert plain_controller.smtpd._proxy_timeout > 0.0
         self._okay(handshake)
 
     @parametrize("handshake", HANDSHAKES.values(), ids=HANDSHAKES.keys())
-    def test_hiccup(self, plain_controller, handshake):
+    def test_hiccup(self, plain_controller: Controller, handshake: bytes):
         assert plain_controller.smtpd._proxy_timeout > 0.0
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
             sock.connect(Global.SrvAddr)
@@ -1014,7 +1015,7 @@ class TestWithController:
                 assert code == 221
 
     @parametrize("handshake", HANDSHAKES.values(), ids=HANDSHAKES.keys())
-    def test_timeout(self, plain_controller, handshake):
+    def test_timeout(self, plain_controller: Controller, handshake: bytes):
         assert plain_controller.smtpd._proxy_timeout > 0.0
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
             sock.connect(Global.SrvAddr)
@@ -1050,7 +1051,7 @@ class TestWithController:
         self._okay(handshake)
 
     @parametrize("handshake", HANDSHAKES.values(), ids=HANDSHAKES.keys())
-    def test_incomplete(self, plain_controller, handshake):
+    def test_incomplete(self, plain_controller: Controller, handshake: bytes):
         assert plain_controller.smtpd._proxy_timeout > 0.0
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
             sock.connect(Global.SrvAddr)
@@ -1100,7 +1101,7 @@ class TestHandlerAcceptReject:
         ],
         ids=["v1", "v2"],
     )
-    def test_simple(self, plain_controller, handshake, handler_retval):
+    def test_simple(self, plain_controller: Controller, handshake: bytes, handler_retval: bool):
         assert plain_controller.smtpd._proxy_timeout > 0.0
         assert isinstance(plain_controller.handler, ProxyPeekerHandler)
         plain_controller.handler.retval = handler_retval

--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -7,6 +7,7 @@ import asyncio
 import errno
 import platform
 import socket
+import ssl
 import sys
 import time
 from contextlib import ExitStack
@@ -16,7 +17,7 @@ from pathlib import Path
 from smtplib import SMTP as SMTPClient, SMTPServerDisconnected
 from tempfile import mkdtemp
 from threading import Thread
-from typing import Generator, Optional
+from typing import Callable, Generator, Optional
 
 import pytest
 from pytest_mock import MockFixture
@@ -146,7 +147,7 @@ def assert_smtp_socket(controller: UnixSocketMixin) -> bool:
 class TestServer:
     """Tests for the aiosmtpd.smtp.SMTP class"""
 
-    def test_smtp_utf8(self, plain_controller, client):
+    def test_smtp_utf8(self, plain_controller: Controller, client: SMTPClient):
         code, mesg = client.ehlo("example.com")
         assert code == 250
         assert b"SMTPUTF8" in mesg.splitlines()
@@ -201,7 +202,7 @@ class TestController:
         finally:
             cont.stop()
 
-    def test_reuse_loop(self, temp_event_loop):
+    def test_reuse_loop(self, temp_event_loop: asyncio.AbstractEventLoop):
         cont = Controller(Sink(), loop=temp_event_loop)
         assert cont.loop is temp_event_loop
         try:
@@ -211,7 +212,9 @@ class TestController:
             cont.stop()
 
     @pytest.mark.skipif(in_wsl(), reason="WSL prevents socket collision")
-    def test_socket_error_dupe(self, plain_controller, client):
+    def test_socket_error_dupe(
+        self, plain_controller: Controller, client: SMTPClient
+    ):
         contr2 = Controller(
             Sink(),
             hostname=Global.SrvAddr.host,
@@ -320,7 +323,7 @@ class TestController:
     def test_getlocalhost(self):
         assert get_localhost() in ("127.0.0.1", "::1")
 
-    def test_getlocalhost_noipv6(self, mocker):
+    def test_getlocalhost_noipv6(self, mocker: MockFixture):
         mock_hasip6 = mocker.patch("aiosmtpd.controller._has_ipv6", return_value=False)
         assert get_localhost() == "127.0.0.1"
         assert mock_hasip6.called
@@ -336,7 +339,7 @@ class TestController:
     # Apparently errno.E* constants adapts to the OS, so on Windows they will
     # automatically use the analogous WSAE* constants
     @pytest.mark.parametrize("err", [errno.EADDRNOTAVAIL, errno.EAFNOSUPPORT])
-    def test_getlocalhost_6no(self, mocker, err):
+    def test_getlocalhost_6no(self, mocker: MockFixture, err: int):
         mock_makesock: mocker.Mock = mocker.patch(
             "aiosmtpd.controller.makesock",
             side_effect=OSError(errno.EADDRNOTAVAIL, "Mock IP4-only"),
@@ -344,7 +347,7 @@ class TestController:
         assert get_localhost() == "127.0.0.1"
         mock_makesock.assert_called_with(socket.AF_INET6, socket.SOCK_STREAM)
 
-    def test_getlocalhost_6inuse(self, mocker):
+    def test_getlocalhost_6inuse(self, mocker: MockFixture):
         mock_makesock: mocker.Mock = mocker.patch(
             "aiosmtpd.controller.makesock",
             side_effect=OSError(errno.EADDRINUSE, "Mock IP6 used"),
@@ -352,7 +355,7 @@ class TestController:
         assert get_localhost() == "::1"
         mock_makesock.assert_called_with(socket.AF_INET6, socket.SOCK_STREAM)
 
-    def test_getlocalhost_error(self, mocker):
+    def test_getlocalhost_error(self, mocker: MockFixture):
         mock_makesock: mocker.Mock = mocker.patch(
             "aiosmtpd.controller.makesock",
             side_effect=OSError(errno.EFAULT, "Mock Error"),
@@ -380,7 +383,7 @@ class TestController:
 @pytest.mark.skipif(in_cygwin(), reason="Cygwin AF_UNIX is problematic")
 @pytest.mark.skipif(in_win32(), reason="Win32 does not yet fully implement AF_UNIX")
 class TestUnixSocketController:
-    def test_server_creation(self, safe_socket_dir):
+    def test_server_creation(self, safe_socket_dir: Path):
         sockfile = safe_socket_dir / "smtp"
         cont = UnixSocketController(Sink(), unix_socket=sockfile)
         try:
@@ -389,7 +392,9 @@ class TestUnixSocketController:
         finally:
             cont.stop()
 
-    def test_server_creation_ssl(self, safe_socket_dir, ssl_context_server):
+    def test_server_creation_ssl(
+        self, safe_socket_dir: Path, ssl_context_server: ssl.SSLContext
+    ):
         sockfile = safe_socket_dir / "smtp"
         cont = UnixSocketController(
             Sink(), unix_socket=sockfile, ssl_context=ssl_context_server
@@ -405,7 +410,7 @@ class TestUnixSocketController:
 
 class TestUnthreaded:
     @pytest.fixture
-    def runner(self):
+    def runner(self) -> Callable:
         thread: Optional[Thread] = None
 
         def _runner(loop: asyncio.AbstractEventLoop):
@@ -432,7 +437,12 @@ class TestUnthreaded:
 
     @pytest.mark.skipif(in_cygwin(), reason="Cygwin AF_UNIX is problematic")
     @pytest.mark.skipif(in_win32(), reason="Win32 does not yet fully implement AF_UNIX")
-    def test_unixsocket(self, safe_socket_dir, autostop_loop, runner):
+    def test_unixsocket(
+        self,
+        safe_socket_dir: Path,
+        autostop_loop: asyncio.AbstractEventLoop,
+        runner: Callable,
+    ):
         sockfile = safe_socket_dir / "smtp"
         cont = UnixSocketUnthreadedController(
             Sink(), unix_socket=sockfile, loop=autostop_loop
@@ -463,7 +473,9 @@ class TestUnthreaded:
     @pytest.mark.filterwarnings(
         "ignore::pytest.PytestUnraisableExceptionWarning"
     )
-    def test_inet_loopstop(self, autostop_loop, runner):
+    def test_inet_loopstop(
+        self, autostop_loop: asyncio.AbstractEventLoop, runner: Callable
+    ):
         """
         Verify behavior when the loop is stopped before controller is stopped
         """
@@ -501,7 +513,9 @@ class TestUnthreaded:
     @pytest.mark.filterwarnings(
         "ignore::pytest.PytestUnraisableExceptionWarning"
     )
-    def test_inet_contstop(self, temp_event_loop, runner):
+    def test_inet_contstop(
+        self, temp_event_loop: asyncio.AbstractEventLoop, runner: Callable
+    ):
         """
         Verify behavior when the controller is stopped before loop is stopped
         """

--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -44,7 +44,7 @@ class SlowStartController(Controller):
         kwargs.setdefault("ready_timeout", 0.5)
         super().__init__(*args, **kwargs)
 
-    def _run(self, ready_event: Event):
+    def _run(self, ready_event: Event) -> None:
         time.sleep(self.ready_timeout * 1.5)
         super()._run(ready_event)
 
@@ -58,7 +58,7 @@ class SlowFactoryController(Controller):
         time.sleep(self.ready_timeout * 3)
         return super().factory()
 
-    def _factory_invoker(self):
+    def _factory_invoker(self) -> None:
         time.sleep(self.ready_timeout * 3)
         return super()._factory_invoker()
 
@@ -413,7 +413,7 @@ class TestUnthreaded:
     def runner(self) -> Callable:
         thread: Optional[Thread] = None
 
-        def _runner(loop: asyncio.AbstractEventLoop):
+        def _runner(loop: asyncio.AbstractEventLoop) -> None:
             loop.run_forever()
 
         def starter(loop: asyncio.AbstractEventLoop) -> None:

--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -40,7 +40,7 @@ from .conftest import Global, AUTOSTOP_DELAY
 
 
 class SlowStartController(Controller):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         kwargs.setdefault("ready_timeout", 0.5)
         super().__init__(*args, **kwargs)
 
@@ -50,7 +50,7 @@ class SlowStartController(Controller):
 
 
 class SlowFactoryController(Controller):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         kwargs.setdefault("ready_timeout", 0.5)
         super().__init__(*args, **kwargs)
 

--- a/aiosmtpd/tests/test_server.py
+++ b/aiosmtpd/tests/test_server.py
@@ -54,7 +54,7 @@ class SlowFactoryController(Controller):
         kwargs.setdefault("ready_timeout", 0.5)
         super().__init__(*args, **kwargs)
 
-    def factory(self):
+    def factory(self) -> Server:
         time.sleep(self.ready_timeout * 3)
         return super().factory()
 
@@ -63,11 +63,11 @@ class SlowFactoryController(Controller):
         return super()._factory_invoker()
 
 
-def in_win32():
+def in_win32() -> bool:
     return platform.system().casefold() == "windows"
 
 
-def in_wsl():
+def in_wsl() -> bool:
     # WSL 1.0 somehow allows more than one listener on one port.
     # So we have to detect when we're running on WSL so we can skip some tests.
 
@@ -77,7 +77,7 @@ def in_wsl():
     return "microsoft" in platform.release().casefold()
 
 
-def in_cygwin():
+def in_cygwin() -> bool:
     return platform.system().casefold().startswith("cygwin")
 
 
@@ -147,21 +147,21 @@ def assert_smtp_socket(controller: UnixSocketMixin) -> bool:
 class TestServer:
     """Tests for the aiosmtpd.smtp.SMTP class"""
 
-    def test_smtp_utf8(self, plain_controller: Controller, client: SMTPClient):
+    def test_smtp_utf8(self, plain_controller: Controller, client: SMTPClient) -> None:
         code, mesg = client.ehlo("example.com")
         assert code == 250
         assert b"SMTPUTF8" in mesg.splitlines()
 
-    def test_default_max_command_size_limit(self):
+    def test_default_max_command_size_limit(self) -> None:
         server = Server(Sink())
         assert server.max_command_size_limit == 512
 
-    def test_special_max_command_size_limit(self):
+    def test_special_max_command_size_limit(self) -> None:
         server = Server(Sink())
         server.command_size_limits["DATA"] = 1024
         assert server.max_command_size_limit == 1024
 
-    def test_warn_authreq_notls(self):
+    def test_warn_authreq_notls(self) -> None:
         expectedre = (
             r"Requiring AUTH while not requiring TLS can lead to "
             r"security vulnerabilities!"
@@ -175,7 +175,7 @@ class TestController:
     """Tests for the aiosmtpd.controller.Controller class"""
 
     @pytest.mark.filterwarnings("ignore")
-    def test_ready_timeout(self):
+    def test_ready_timeout(self) -> None:
         cont = SlowStartController(Sink())
         expectre = (
             "SMTP server failed to start within allotted time. "
@@ -189,7 +189,7 @@ class TestController:
             cont.stop()
 
     @pytest.mark.filterwarnings("ignore")
-    def test_factory_timeout(self):
+    def test_factory_timeout(self) -> None:
         cont = SlowFactoryController(Sink())
         expectre = (
             r"SMTP server started, but not responding within allotted time. "
@@ -202,7 +202,7 @@ class TestController:
         finally:
             cont.stop()
 
-    def test_reuse_loop(self, temp_event_loop: asyncio.AbstractEventLoop):
+    def test_reuse_loop(self, temp_event_loop: asyncio.AbstractEventLoop) -> None:
         cont = Controller(Sink(), loop=temp_event_loop)
         assert cont.loop is temp_event_loop
         try:
@@ -214,7 +214,7 @@ class TestController:
     @pytest.mark.skipif(in_wsl(), reason="WSL prevents socket collision")
     def test_socket_error_dupe(
         self, plain_controller: Controller, client: SMTPClient
-    ):
+    ) -> None:
         contr2 = Controller(
             Sink(),
             hostname=Global.SrvAddr.host,
@@ -229,7 +229,7 @@ class TestController:
             contr2.stop()
 
     @pytest.mark.skipif(in_wsl(), reason="WSL prevents socket collision")
-    def test_socket_error_default(self):
+    def test_socket_error_default(self) -> None:
         contr1 = Controller(Sink())
         contr2 = Controller(
             Sink(),
@@ -244,7 +244,7 @@ class TestController:
             contr2.stop()
             contr1.stop()
 
-    def test_server_attribute(self):
+    def test_server_attribute(self) -> None:
         controller = Controller(Sink())
         assert controller.server is None
         try:
@@ -257,7 +257,7 @@ class TestController:
     @pytest.mark.filterwarnings(
         "ignore:server_kwargs will be removed:DeprecationWarning"
     )
-    def test_enablesmtputf8_flag(self):
+    def test_enablesmtputf8_flag(self) -> None:
         # Default is True
         controller = Controller(Sink())
         assert controller.SMTP_kwargs["enable_SMTPUTF8"]
@@ -281,7 +281,7 @@ class TestController:
     @pytest.mark.filterwarnings(
         "ignore:server_kwargs will be removed:DeprecationWarning"
     )
-    def test_serverhostname_arg(self):
+    def test_serverhostname_arg(self) -> None:
         contsink = partial(Controller, Sink())
         controller = contsink()
         assert "hostname" not in controller.SMTP_kwargs
@@ -293,7 +293,7 @@ class TestController:
         controller = contsink(server_hostname="testhost3", server_kwargs=kwargs)
         assert controller.SMTP_kwargs["hostname"] == "testhost3"
 
-    def test_hostname_empty(self):
+    def test_hostname_empty(self) -> None:
         # WARNING: This test _always_ succeeds in Windows.
         cont = Controller(Sink(), hostname="")
         try:
@@ -301,14 +301,14 @@ class TestController:
         finally:
             cont.stop()
 
-    def test_hostname_none(self):
+    def test_hostname_none(self) -> None:
         cont = Controller(Sink())
         try:
             cont.start()
         finally:
             cont.stop()
 
-    def test_testconn_raises(self, mocker: MockFixture):
+    def test_testconn_raises(self, mocker: MockFixture) -> None:
         mocker.patch(
             "aiosmtpd.controller.create_connection",
             side_effect=RuntimeError("MockError"),
@@ -320,15 +320,15 @@ class TestController:
         finally:
             cont.stop()
 
-    def test_getlocalhost(self):
+    def test_getlocalhost(self) -> None:
         assert get_localhost() in ("127.0.0.1", "::1")
 
-    def test_getlocalhost_noipv6(self, mocker: MockFixture):
+    def test_getlocalhost_noipv6(self, mocker: MockFixture) -> None:
         mock_hasip6 = mocker.patch("aiosmtpd.controller._has_ipv6", return_value=False)
         assert get_localhost() == "127.0.0.1"
         assert mock_hasip6.called
 
-    def test_getlocalhost_6yes(self, mocker: MockFixture):
+    def test_getlocalhost_6yes(self, mocker: MockFixture) -> None:
         mock_sock = mocker.Mock()
         mock_makesock: mocker.Mock = mocker.patch("aiosmtpd.controller.makesock")
         mock_makesock.return_value.__enter__.return_value = mock_sock
@@ -339,7 +339,7 @@ class TestController:
     # Apparently errno.E* constants adapts to the OS, so on Windows they will
     # automatically use the analogous WSAE* constants
     @pytest.mark.parametrize("err", [errno.EADDRNOTAVAIL, errno.EAFNOSUPPORT])
-    def test_getlocalhost_6no(self, mocker: MockFixture, err: int):
+    def test_getlocalhost_6no(self, mocker: MockFixture, err: int) -> None:
         mock_makesock: mocker.Mock = mocker.patch(
             "aiosmtpd.controller.makesock",
             side_effect=OSError(errno.EADDRNOTAVAIL, "Mock IP4-only"),
@@ -347,7 +347,7 @@ class TestController:
         assert get_localhost() == "127.0.0.1"
         mock_makesock.assert_called_with(socket.AF_INET6, socket.SOCK_STREAM)
 
-    def test_getlocalhost_6inuse(self, mocker: MockFixture):
+    def test_getlocalhost_6inuse(self, mocker: MockFixture) -> None:
         mock_makesock: mocker.Mock = mocker.patch(
             "aiosmtpd.controller.makesock",
             side_effect=OSError(errno.EADDRINUSE, "Mock IP6 used"),
@@ -355,7 +355,7 @@ class TestController:
         assert get_localhost() == "::1"
         mock_makesock.assert_called_with(socket.AF_INET6, socket.SOCK_STREAM)
 
-    def test_getlocalhost_error(self, mocker: MockFixture):
+    def test_getlocalhost_error(self, mocker: MockFixture) -> None:
         mock_makesock: mocker.Mock = mocker.patch(
             "aiosmtpd.controller.makesock",
             side_effect=OSError(errno.EFAULT, "Mock Error"),
@@ -365,17 +365,17 @@ class TestController:
         assert exc.value.errno == errno.EFAULT
         mock_makesock.assert_called_with(socket.AF_INET6, socket.SOCK_STREAM)
 
-    def test_stop_default(self):
+    def test_stop_default(self) -> None:
         controller = Controller(Sink())
         with pytest.raises(AssertionError, match="SMTP daemon not running"):
             controller.stop()
 
-    def test_stop_assert(self):
+    def test_stop_assert(self) -> None:
         controller = Controller(Sink())
         with pytest.raises(AssertionError, match="SMTP daemon not running"):
             controller.stop(no_assert=False)
 
-    def test_stop_noassert(self):
+    def test_stop_noassert(self) -> None:
         controller = Controller(Sink())
         controller.stop(no_assert=True)
 
@@ -383,7 +383,7 @@ class TestController:
 @pytest.mark.skipif(in_cygwin(), reason="Cygwin AF_UNIX is problematic")
 @pytest.mark.skipif(in_win32(), reason="Win32 does not yet fully implement AF_UNIX")
 class TestUnixSocketController:
-    def test_server_creation(self, safe_socket_dir: Path):
+    def test_server_creation(self, safe_socket_dir: Path) -> None:
         sockfile = safe_socket_dir / "smtp"
         cont = UnixSocketController(Sink(), unix_socket=sockfile)
         try:
@@ -394,7 +394,7 @@ class TestUnixSocketController:
 
     def test_server_creation_ssl(
         self, safe_socket_dir: Path, ssl_context_server: ssl.SSLContext
-    ):
+    ) -> None:
         sockfile = safe_socket_dir / "smtp"
         cont = UnixSocketController(
             Sink(), unix_socket=sockfile, ssl_context=ssl_context_server
@@ -416,18 +416,18 @@ class TestUnthreaded:
         def _runner(loop: asyncio.AbstractEventLoop):
             loop.run_forever()
 
-        def starter(loop: asyncio.AbstractEventLoop):
+        def starter(loop: asyncio.AbstractEventLoop) -> None:
             nonlocal thread
             thread = Thread(target=_runner, args=(loop,))
             thread.daemon = True
             thread.start()
             catchup_delay()
 
-        def joiner(timeout: Optional[float] = None):
+        def joiner(timeout: Optional[float] = None) -> None:
             assert isinstance(thread, Thread)
             thread.join(timeout=timeout)
 
-        def is_alive():
+        def is_alive() -> bool:
             assert isinstance(thread, Thread)
             return thread.is_alive()
 
@@ -442,7 +442,7 @@ class TestUnthreaded:
         safe_socket_dir: Path,
         autostop_loop: asyncio.AbstractEventLoop,
         runner: Callable,
-    ):
+    ) -> None:
         sockfile = safe_socket_dir / "smtp"
         cont = UnixSocketUnthreadedController(
             Sink(), unix_socket=sockfile, loop=autostop_loop
@@ -475,7 +475,7 @@ class TestUnthreaded:
     )
     def test_inet_loopstop(
         self, autostop_loop: asyncio.AbstractEventLoop, runner: Callable
-    ):
+    ) -> None:
         """
         Verify behavior when the loop is stopped before controller is stopped
         """
@@ -515,7 +515,7 @@ class TestUnthreaded:
     )
     def test_inet_contstop(
         self, temp_event_loop: asyncio.AbstractEventLoop, runner: Callable
-    ):
+    ) -> None:
         """
         Verify behavior when the controller is stopped before loop is stopped
         """
@@ -558,7 +558,7 @@ class TestUnthreaded:
 
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 class TestFactory:
-    def test_normal_situation(self):
+    def test_normal_situation(self) -> None:
         cont = Controller(Sink())
         try:
             cont.start()
@@ -568,7 +568,7 @@ class TestFactory:
         finally:
             cont.stop()
 
-    def test_unknown_args_direct(self, silence_event_loop_closed: bool):
+    def test_unknown_args_direct(self, silence_event_loop_closed: bool) -> None:
         unknown = "this_is_an_unknown_kwarg"
         cont = Controller(Sink(), ready_timeout=0.3, **{unknown: True})
         expectedre = r"__init__.. got an unexpected keyword argument '" + unknown + r"'"
@@ -583,7 +583,7 @@ class TestFactory:
     @pytest.mark.filterwarnings(
         "ignore:server_kwargs will be removed:DeprecationWarning"
     )
-    def test_unknown_args_inkwargs(self, silence_event_loop_closed: bool):
+    def test_unknown_args_inkwargs(self, silence_event_loop_closed: bool) -> None:
         unknown = "this_is_an_unknown_kwarg"
         cont = Controller(Sink(), ready_timeout=0.3, server_kwargs={unknown: True})
         expectedre = r"__init__.. got an unexpected keyword argument '" + unknown + r"'"
@@ -594,7 +594,7 @@ class TestFactory:
         finally:
             cont.stop()
 
-    def test_factory_none(self, mocker: MockFixture, silence_event_loop_closed: bool):
+    def test_factory_none(self, mocker: MockFixture, silence_event_loop_closed: bool) -> None:
         # Hypothetical situation where factory() did not raise an Exception
         # but returned None instead
         mocker.patch("aiosmtpd.controller.SMTP", return_value=None)
@@ -609,12 +609,12 @@ class TestFactory:
 
     def test_noexc_smtpd_missing(
         self, mocker: MockFixture, silence_event_loop_closed: bool
-    ):
+    ) -> None:
         # Hypothetical situation where factory() failed but no
         # Exception was generated.
         cont = Controller(Sink())
 
-        def hijacker(*args, **kwargs):
+        def hijacker(*args, **kwargs) -> _FakeServer:
             cont._thread_exception = None
             # Must still return an (unmocked) _FakeServer to prevent a whole bunch
             # of messy exceptions, although they doesn't affect the test at all.
@@ -636,7 +636,7 @@ class TestFactory:
 
 
 class TestCompat:
-    def test_version(self):
+    def test_version(self) -> None:
         from aiosmtpd import __version__ as init_version
         from aiosmtpd.smtp import __version__ as smtp_version
 

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -21,7 +21,7 @@ from smtplib import (
     SMTPServerDisconnected,
 )
 from textwrap import dedent
-from typing import cast, Any, Callable, Generator, List, Optional, Tuple, Union
+from typing import cast, Any, Callable, Generator, List, Literal, Optional, Tuple, Union
 
 import pytest
 from pytest_mock import MockFixture
@@ -38,6 +38,7 @@ from aiosmtpd.smtp import (
     Envelope as SMTPEnvelope,
     LoginPassword,
     Session as SMTPSession,
+    _Missing,
     __ident__ as GREETING,
     auth_mechanism,
 )
@@ -68,7 +69,7 @@ def auth_callback(mechanism: str, login: bytes, password: bytes) -> bool:
     return login and login.decode() == "goodlogin"
 
 
-def assert_nopassleak(passwd: str, record_tuples: List[Tuple[str, int, str]]):
+def assert_nopassleak(passwd: str, record_tuples: List[Tuple[str, int, str]]) -> None:
     """
     :param passwd: The password we're looking for in the logs
     :param record_tuples: Usually caplog.record_tuples
@@ -87,7 +88,7 @@ class UndescribableError(Exception):
 class ErrorSMTP(Server):
     exception_type = ValueError
 
-    async def smtp_HELO(self, hostname: str):
+    async def smtp_HELO(self, hostname: str) -> None:
         raise self.exception_type("test")
 
 
@@ -146,20 +147,20 @@ class PeekerHandler:
         self.sess = session
         return S.S250_OK.to_str()
 
-    async def auth_DENYMISSING(self, server: Server, args: List[str]):
+    async def auth_DENYMISSING(self, server: Server, args: List[str]) -> _Missing:
         return MISSING
 
-    async def auth_DENYFALSE(self, server: Server, args: List[str]):
+    async def auth_DENYFALSE(self, server: Server, args: List[str]) -> bool:
         return False
 
-    async def auth_NONE(self, server: Server, args: List[str]):
+    async def auth_NONE(self, server: Server, args: List[str]) -> None:
         await server.push(S.S235_AUTH_SUCCESS.to_str())
         return None
 
-    async def auth_NULL(self, server: Server, args: List[str]):
+    async def auth_NULL(self, server: Server, args: List[str]) -> Literal["NULL_login"]:
         return "NULL_login"
 
-    async def auth_DONT(self, server: Server, args: List[str]):
+    async def auth_DONT(self, server: Server, args: List[str]) -> _Missing:
         return MISSING
 
     async def auth_WITH_UNDERSCORE(self, server: Server, args: List[str]) -> str:
@@ -173,10 +174,10 @@ class PeekerHandler:
         return "250 OK"
 
     @auth_mechanism("with-dash")
-    async def auth_WITH_DASH(self, server: Server, args: List[str]):
+    async def auth_WITH_DASH(self, server: Server, args: List[str]) -> str:
         return "250 OK"
 
-    async def auth_WITH__MULTI__DASH(self, server: Server, args: List[str]):
+    async def auth_WITH__MULTI__DASH(self, server: Server, args: List[str]) -> str:
         return "250 OK"
 
 
@@ -214,17 +215,17 @@ class ErroringHandler:
 class ErroringHandlerConnectionLost:
     error = None
 
-    async def handle_DATA(self, server: Server, session: SMTPSession, envelope: SMTPEnvelope):
+    async def handle_DATA(self, server: Server, session: SMTPSession, envelope: SMTPEnvelope) -> None:
         raise ConnectionResetError("ErroringHandlerConnectionLost test")
 
-    async def handle_exception(self, error: Exception):
+    async def handle_exception(self, error: Exception) -> None:
         self.error = error
 
 
 class ErroringErrorHandler:
     error = None
 
-    async def handle_exception(self, error: Exception):
+    async def handle_exception(self, error: Exception) -> None:
         self.error = error
         raise ValueError("ErroringErrorHandler test")
 
@@ -232,7 +233,7 @@ class ErroringErrorHandler:
 class UndescribableErrorHandler:
     error = None
 
-    async def handle_exception(self, error: Exception):
+    async def handle_exception(self, error: Exception) -> None:
         self.error = error
         raise UndescribableError()
 
@@ -262,26 +263,26 @@ class SleepingHeloHandler:
 class TimeoutController(Controller):
     Delay: float = 1.0
 
-    def factory(self):
+    def factory(self) -> Server:
         return Server(self.handler, timeout=self.Delay)
 
 
 class ErrorController(Controller):
-    def factory(self):
+    def factory(self) -> Server:
         return ErrorSMTP(self.handler)
 
 
 class CustomHostnameController(Controller):
     custom_name = "custom.localhost"
 
-    def factory(self):
+    def factory(self) -> Server:
         return Server(self.handler, hostname=self.custom_name)
 
 
 class CustomIdentController(Controller):
     ident: bytes = b"Identifying SMTP v2112"
 
-    def factory(self):
+    def factory(self) -> Server:
         return Server(self.handler, ident=self.ident.decode())
 
 
@@ -419,7 +420,7 @@ class _CommonMethods:
 class TestProtocol:
     def test_honors_mail_delimiters(
         self, temp_event_loop: asyncio.AbstractEventLoop, transport_resp: Tuple[Transport, list], get_protocol: Callable
-    ):
+    ) -> None:
         handler = ReceivingHandler()
         protocol = get_protocol(handler)
         data = b"test\r\nmail\rdelimiters\nsaved\r\n"
@@ -442,7 +443,7 @@ class TestProtocol:
         assert len(handler.box) == 1
         assert handler.box[0].content == data
 
-    def test_empty_email(self, temp_event_loop: asyncio.AbstractEventLoop, transport_resp: Tuple[Transport, list], get_protocol: Callable):
+    def test_empty_email(self, temp_event_loop: asyncio.AbstractEventLoop, transport_resp: Tuple[Transport, list], get_protocol: Callable) -> None:
         handler = ReceivingHandler()
         protocol = get_protocol(handler)
         protocol.data_received(
@@ -537,31 +538,31 @@ class TestSMTP(_CommonMethods):
     ]
 
     @pytest.mark.parametrize("data", [b"\x80FAIL\r\n", b"\x80 FAIL\r\n"])
-    def test_binary(self, client: SMTPClient, data: bytes):
+    def test_binary(self, client: SMTPClient, data: bytes) -> None:
         client.sock.send(data)
         assert client.getreply() == S.S500_BAD_SYNTAX
 
-    def test_helo(self, client: SMTPClient):
+    def test_helo(self, client: SMTPClient) -> None:
         resp = client.helo("example.com")
         assert resp == S.S250_FQDN
 
-    def test_close_then_continue(self, client: SMTPClient):
+    def test_close_then_continue(self, client: SMTPClient) -> None:
         self._helo(client)
         client.close()
         client.connect(*Global.SrvAddr)
         resp = client.docmd("MAIL FROM: <anne@example.com>")
         assert resp == S.S503_HELO_FIRST
 
-    def test_helo_no_hostname(self, client: SMTPClient):
+    def test_helo_no_hostname(self, client: SMTPClient) -> None:
         client.local_hostname = ""
         resp = client.helo("")
         assert resp == S.S501_SYNTAX_HELO
 
-    def test_helo_duplicate(self, client: SMTPClient):
+    def test_helo_duplicate(self, client: SMTPClient) -> None:
         self._helo(client, "example.org")
         self._helo(client, "example.com")
 
-    def test_ehlo(self, client: SMTPClient):
+    def test_ehlo(self, client: SMTPClient) -> None:
         code, mesg = client.ehlo("example.com")
         lines = mesg.splitlines()
         assert lines == [
@@ -571,41 +572,41 @@ class TestSMTP(_CommonMethods):
             b"HELP",
         ]
 
-    def test_ehlo_duplicate(self, client: SMTPClient):
+    def test_ehlo_duplicate(self, client: SMTPClient) -> None:
         self._ehlo(client, "example.com")
         self._ehlo(client, "example.org")
 
-    def test_ehlo_no_hostname(self, client: SMTPClient):
+    def test_ehlo_no_hostname(self, client: SMTPClient) -> None:
         client.local_hostname = ""
         resp = client.ehlo("")
         assert resp == S.S501_SYNTAX_EHLO
 
-    def test_helo_then_ehlo(self, client: SMTPClient):
+    def test_helo_then_ehlo(self, client: SMTPClient) -> None:
         self._helo(client, "example.com")
         self._ehlo(client, "example.org")
 
-    def test_ehlo_then_helo(self, client: SMTPClient):
+    def test_ehlo_then_helo(self, client: SMTPClient) -> None:
         self._ehlo(client, "example.org")
         self._helo(client, "example.com")
 
-    def test_noop(self, client: SMTPClient):
+    def test_noop(self, client: SMTPClient) -> None:
         resp = client.noop()
         assert resp == S.S250_OK
 
-    def test_noop_with_arg(self, plain_controller: Controller, client: SMTPClient):
+    def test_noop_with_arg(self, plain_controller: Controller, client: SMTPClient) -> None:
         # smtplib.SMTP.noop() doesn't accept args
         resp = client.docmd("NOOP ok")
         assert resp == S.S250_OK
 
-    def test_quit(self, client: SMTPClient):
+    def test_quit(self, client: SMTPClient) -> None:
         resp = client.quit()
         assert resp == S.S221_BYE
 
-    def test_quit_with_args(self, client: SMTPClient):
+    def test_quit_with_args(self, client: SMTPClient) -> None:
         resp = client.docmd("QUIT oops")
         assert resp == S.S501_SYNTAX_QUIT
 
-    def test_help(self, client: SMTPClient):
+    def test_help(self, client: SMTPClient) -> None:
         resp = client.docmd("HELP")
         assert resp == S.S250_SUPPCMD_NOTLS
 
@@ -624,7 +625,7 @@ class TestSMTP(_CommonMethods):
             "AUTH",
         ],
     )
-    def test_help_(self, client: SMTPClient, command: str):
+    def test_help_(self, client: SMTPClient, command: str) -> None:
         resp = client.docmd(f"HELP {command}")
         syntax = getattr(S, f"S250_SYNTAX_{command}")
         assert resp == syntax
@@ -636,17 +637,17 @@ class TestSMTP(_CommonMethods):
             "RCPT",
         ],
     )
-    def test_help_esmtp(self, client: SMTPClient, command: str):
+    def test_help_esmtp(self, client: SMTPClient, command: str) -> None:
         self._ehlo(client)
         resp = client.docmd(f"HELP {command}")
         syntax = getattr(S, f"S250_SYNTAX_{command}_E")
         assert resp == syntax
 
-    def test_help_bad_arg(self, client: SMTPClient):
+    def test_help_bad_arg(self, client: SMTPClient) -> None:
         resp = client.docmd("HELP me!")
         assert resp == S.S501_SUPPCMD_NOTLS
 
-    def test_expn(self, client: SMTPClient):
+    def test_expn(self, client: SMTPClient) -> None:
         resp = client.expn("anne@example.com")
         assert resp == S.S502_EXPN_NOTIMPL
 
@@ -655,7 +656,7 @@ class TestSMTP(_CommonMethods):
         ["MAIL FROM: <anne@example.com>", "RCPT TO: <anne@example.com>", "DATA"],
         ids=lambda x: x.split()[0],
     )
-    def test_no_helo(self, client: SMTPClient, command: str):
+    def test_no_helo(self, client: SMTPClient, command: str) -> None:
         resp = client.docmd(command)
         assert resp == S.S503_HELO_FIRST
 
@@ -664,7 +665,7 @@ class TestSMTP(_CommonMethods):
         valid_mailfrom_addresses,
         ids=itertools.count(),
     )
-    def test_mail_valid_address(self, client: SMTPClient, address: str):
+    def test_mail_valid_address(self, client: SMTPClient, address: str) -> None:
         self._ehlo(client)
         resp = client.docmd(f"MAIL FROM:{address}")
         assert resp == S.S250_OK
@@ -680,7 +681,7 @@ class TestSMTP(_CommonMethods):
         ],
         ids=["noarg", "nofrom", "noaddr", "params_noesmtp", "malformed"],
     )
-    def test_mail_smtp_errsyntax(self, client: SMTPClient, command: str):
+    def test_mail_smtp_errsyntax(self, client: SMTPClient, command: str) -> None:
         self._helo(client)
         resp = client.docmd(command)
         assert resp == S.S501_SYNTAX_MAIL
@@ -694,12 +695,12 @@ class TestSMTP(_CommonMethods):
         ],
         ids=["norm", "extralead", "extratail"],
     )
-    def test_mail_params_esmtp(self, client: SMTPClient, param: str):
+    def test_mail_params_esmtp(self, client: SMTPClient, param: str) -> None:
         self._ehlo(client)
         resp = client.docmd("MAIL FROM: <anne@example.com> " + param)
         assert resp == S.S250_OK
 
-    def test_mail_from_twice(self, client: SMTPClient):
+    def test_mail_from_twice(self, client: SMTPClient) -> None:
         self._helo(client)
         resp = client.docmd("MAIL FROM: <anne@example.com>")
         assert resp == S.S250_OK
@@ -716,17 +717,17 @@ class TestSMTP(_CommonMethods):
         ],
         ids=["malformed", "missing", "badsyntax", "space"],
     )
-    def test_mail_esmtp_errsyntax(self, client: SMTPClient, command: str):
+    def test_mail_esmtp_errsyntax(self, client: SMTPClient, command: str) -> None:
         self._ehlo(client)
         resp = client.docmd(command)
         assert resp == S.S501_SYNTAX_MAIL_E
 
-    def test_mail_esmtp_params_unrecognized(self, client: SMTPClient):
+    def test_mail_esmtp_params_unrecognized(self, client: SMTPClient) -> None:
         self._ehlo(client)
         resp = client.docmd("MAIL FROM: <anne@example.com> FOO=BAR")
         assert resp == S.S555_MAIL_PARAMS_UNRECOG
 
-    def test_bpo27931fix_smtp(self, client: SMTPClient):
+    def test_bpo27931fix_smtp(self, client: SMTPClient) -> None:
         self._helo(client)
         resp = client.docmd('MAIL FROM: <""@example.com>')
         assert resp == S.S250_OK
@@ -738,18 +739,18 @@ class TestSMTP(_CommonMethods):
         invalid_email_addresses,
         ids=itertools.count(),
     )
-    def test_mail_invalid_address(self, client: SMTPClient, address: str):
+    def test_mail_invalid_address(self, client: SMTPClient, address: str) -> None:
         self._helo(client)
         resp = client.docmd(f"MAIL FROM: {address}")
         assert resp == S.S553_MALFORMED
 
     @pytest.mark.parametrize("address", invalid_email_addresses, ids=itertools.count())
-    def test_mail_esmtp_invalid_address(self, client: SMTPClient, address: str):
+    def test_mail_esmtp_invalid_address(self, client: SMTPClient, address: str) -> None:
         self._ehlo(client)
         resp = client.docmd(f"MAIL FROM: {address} SIZE=28113")
         assert resp == S.S553_MALFORMED
 
-    def test_rcpt_no_mail(self, client: SMTPClient):
+    def test_rcpt_no_mail(self, client: SMTPClient) -> None:
         self._helo(client)
         resp = client.docmd("RCPT TO: <anne@example.com>")
         assert resp == S.S503_MAIL_NEEDED
@@ -765,7 +766,7 @@ class TestSMTP(_CommonMethods):
         ],
         ids=["noarg", "noto", "noaddr", "params", "malformed"],
     )
-    def test_rcpt_smtp_errsyntax(self, client: SMTPClient, command: str):
+    def test_rcpt_smtp_errsyntax(self, client: SMTPClient, command: str) -> None:
         self._helo(client)
         resp = client.docmd("MAIL FROM: <anne@example.com>")
         assert resp == S.S250_OK
@@ -783,14 +784,14 @@ class TestSMTP(_CommonMethods):
         ],
         ids=["noarg", "noto", "noaddr", "badparams", "malformed"],
     )
-    def test_rcpt_esmtp_errsyntax(self, client: SMTPClient, command: str):
+    def test_rcpt_esmtp_errsyntax(self, client: SMTPClient, command: str) -> None:
         self._ehlo(client)
         resp = client.docmd("MAIL FROM: <anne@example.com>")
         assert resp == S.S250_OK
         resp = client.docmd(command)
         assert resp == S.S501_SYNTAX_RCPT_E
 
-    def test_rcpt_unknown_params(self, client: SMTPClient):
+    def test_rcpt_unknown_params(self, client: SMTPClient) -> None:
         self._ehlo(client)
         resp = client.docmd("MAIL FROM: <anne@example.com>")
         assert resp == S.S250_OK
@@ -798,7 +799,7 @@ class TestSMTP(_CommonMethods):
         assert resp == S.S555_RCPT_PARAMS_UNRECOG
 
     @pytest.mark.parametrize("address", valid_rcptto_addresses, ids=itertools.count())
-    def test_rcpt_valid_address(self, client: SMTPClient, address: str):
+    def test_rcpt_valid_address(self, client: SMTPClient, address: str) -> None:
         self._ehlo(client)
         resp = client.docmd("MAIL FROM: <anne@example.com>")
         assert resp == S.S250_OK
@@ -806,46 +807,46 @@ class TestSMTP(_CommonMethods):
         assert resp == S.S250_OK
 
     @pytest.mark.parametrize("address", invalid_email_addresses, ids=itertools.count())
-    def test_rcpt_invalid_address(self, client: SMTPClient, address: str):
+    def test_rcpt_invalid_address(self, client: SMTPClient, address: str) -> None:
         self._ehlo(client)
         resp = client.docmd("MAIL FROM: <anne@example.com>")
         assert resp == S.S250_OK
         resp = client.docmd(f"RCPT TO: {address}")
         assert resp == S.S553_MALFORMED
 
-    def test_bpo27931fix_esmtp(self, client: SMTPClient):
+    def test_bpo27931fix_esmtp(self, client: SMTPClient) -> None:
         self._ehlo(client)
         resp = client.docmd('MAIL FROM: <""@example.com> SIZE=28113')
         assert resp == S.S250_OK
         resp = client.docmd('RCPT TO: <""@example.org>')
         assert resp == S.S250_OK
 
-    def test_rset(self, client: SMTPClient):
+    def test_rset(self, client: SMTPClient) -> None:
         resp = client.rset()
         assert resp == S.S250_OK
 
-    def test_rset_with_arg(self, client: SMTPClient):
+    def test_rset_with_arg(self, client: SMTPClient) -> None:
         resp = client.docmd("RSET FOO")
         assert resp == S.S501_SYNTAX_RSET
 
-    def test_vrfy(self, client: SMTPClient):
+    def test_vrfy(self, client: SMTPClient) -> None:
         resp = client.docmd("VRFY <anne@example.com>")
         assert resp == S.S252_CANNOT_VRFY
 
-    def test_vrfy_no_arg(self, client: SMTPClient):
+    def test_vrfy_no_arg(self, client: SMTPClient) -> None:
         resp = client.docmd("VRFY")
         assert resp == S.S501_SYNTAX_VRFY
 
-    def test_vrfy_not_address(self, client: SMTPClient):
+    def test_vrfy_not_address(self, client: SMTPClient) -> None:
         resp = client.docmd("VRFY @@")
         assert resp == S.S502_VRFY_COULDNT(b"@@")
 
-    def test_data_no_rcpt(self, client: SMTPClient):
+    def test_data_no_rcpt(self, client: SMTPClient) -> None:
         self._helo(client)
         resp = client.docmd("DATA")
         assert resp == S.S503_RCPT_NEEDED
 
-    def test_data_354(self, plain_controller: Controller, client: SMTPClient):
+    def test_data_354(self, plain_controller: Controller, client: SMTPClient) -> None:
         self._helo(client)
         resp = client.docmd("MAIL FROM: <alice@example.org>")
         assert resp == S.S250_OK
@@ -860,7 +861,7 @@ class TestSMTP(_CommonMethods):
         finally:
             plain_controller.stop()
 
-    def test_data_invalid_params(self, client: SMTPClient):
+    def test_data_invalid_params(self, client: SMTPClient) -> None:
         self._helo(client)
         resp = client.docmd("MAIL FROM: <anne@example.com>")
         assert resp == S.S250_OK
@@ -869,15 +870,15 @@ class TestSMTP(_CommonMethods):
         resp = client.docmd("DATA FOOBAR")
         assert resp == S.S501_SYNTAX_DATA
 
-    def test_empty_command(self, client: SMTPClient):
+    def test_empty_command(self, client: SMTPClient) -> None:
         resp = client.docmd("")
         assert resp == S.S500_BAD_SYNTAX
 
-    def test_too_long_command(self, client: SMTPClient):
+    def test_too_long_command(self, client: SMTPClient) -> None:
         resp = client.docmd("a" * 513)
         assert resp == S.S500_CMD_TOO_LONG
 
-    def test_way_too_long_command(self, client: SMTPClient):
+    def test_way_too_long_command(self, client: SMTPClient) -> None:
         # Send a very large string to ensure it is broken
         # into several packets, which hits the inner
         # LimitOverrunError code path in _handle_client.
@@ -887,14 +888,14 @@ class TestSMTP(_CommonMethods):
         response = client.docmd("NOOP")
         assert response == S.S250_OK
 
-    def test_unknown_command(self, client: SMTPClient):
+    def test_unknown_command(self, client: SMTPClient) -> None:
         resp = client.docmd("FOOBAR")
         assert resp == S.S500_CMD_UNRECOG(b"FOOBAR")
 
 
 class TestSMTPNonDecoding(_CommonMethods):
     @controller_data(decode_data=False)
-    def test_mail_invalid_body_param(self, plain_controller: Controller, client: SMTPClient):
+    def test_mail_invalid_body_param(self, plain_controller: Controller, client: SMTPClient) -> None:
         self._ehlo(client)
         resp = client.docmd("MAIL FROM: <anne@example.com> BODY=FOOBAR")
         assert resp == S.S501_MAIL_BODY
@@ -902,21 +903,21 @@ class TestSMTPNonDecoding(_CommonMethods):
 
 @pytest.mark.usefixtures("decoding_authnotls_controller")
 class TestSMTPAuth(_CommonMethods):
-    def test_no_ehlo(self, client: SMTPClient):
+    def test_no_ehlo(self, client: SMTPClient) -> None:
         resp = client.docmd("AUTH")
         assert resp == S.S503_EHLO_FIRST
 
-    def test_helo(self, client: SMTPClient):
+    def test_helo(self, client: SMTPClient) -> None:
         self._helo(client)
         resp = client.docmd("AUTH")
         assert resp == S.S500_AUTH_UNRECOG
 
-    def test_not_enough_values(self, client: SMTPClient):
+    def test_not_enough_values(self, client: SMTPClient) -> None:
         self._ehlo(client)
         resp = client.docmd("AUTH")
         assert resp == S.S501_TOO_FEW
 
-    def test_already_authenticated(self, caplog: pytest.LogCaptureFixture, client: SMTPClient):
+    def test_already_authenticated(self, caplog: pytest.LogCaptureFixture, client: SMTPClient) -> None:
         PW = "goodpasswd"
         self._ehlo(client)
         resp = client.docmd(
@@ -929,7 +930,7 @@ class TestSMTPAuth(_CommonMethods):
         assert resp == S.S250_OK
         assert_nopassleak(PW, caplog.record_tuples)
 
-    def test_auth_individually(self, caplog: pytest.LogCaptureFixture, client: SMTPClient):
+    def test_auth_individually(self, caplog: pytest.LogCaptureFixture, client: SMTPClient) -> None:
         """AUTH state of different clients must be independent"""
         PW = "goodpasswd"
         client1 = client
@@ -940,7 +941,7 @@ class TestSMTPAuth(_CommonMethods):
                 assert resp == S.S235_AUTH_SUCCESS
         assert_nopassleak(PW, caplog.record_tuples)
 
-    def test_rset_maintain_authenticated(self, caplog: pytest.LogCaptureFixture, client: SMTPClient):
+    def test_rset_maintain_authenticated(self, caplog: pytest.LogCaptureFixture, client: SMTPClient) -> None:
         """RSET resets only Envelope not Session"""
         PW = "goodpasswd"
         self._ehlo(client, "example.com")
@@ -955,7 +956,7 @@ class TestSMTPAuth(_CommonMethods):
         assert_nopassleak(PW, caplog.record_tuples)
 
     @handler_data(class_=PeekerHandler)
-    def test_auth_loginteract_warning(self, client: SMTPClient):
+    def test_auth_loginteract_warning(self, client: SMTPClient) -> None:
         client.ehlo("example.com")
         resp = client.docmd("AUTH WITH_UNDERSCORE")
         assert resp == (334, b"challenge")
@@ -996,7 +997,7 @@ class TestAuthMechanisms(_CommonMethods):
         do.client = client
         return do
 
-    def test_ehlo(self, client: SMTPClient):
+    def test_ehlo(self, client: SMTPClient) -> None:
         code, mesg = client.ehlo("example.com")
         assert code == 250
         lines = mesg.splitlines()
@@ -1012,17 +1013,17 @@ class TestAuthMechanisms(_CommonMethods):
         ]
 
     @pytest.mark.parametrize("mechanism", ["GSSAPI", "DIGEST-MD5", "MD5", "CRAM-MD5"])
-    def test_not_supported_mechanism(self, client: SMTPClient, mechanism: str):
+    def test_not_supported_mechanism(self, client: SMTPClient, mechanism: str) -> None:
         self._ehlo(client)
         resp = client.docmd("AUTH " + mechanism)
         assert resp == S.S504_AUTH_UNRECOG
 
-    def test_custom_mechanism(self, client: SMTPClient):
+    def test_custom_mechanism(self, client: SMTPClient) -> None:
         self._ehlo(client)
         resp = client.docmd("AUTH NULL")
         assert resp == S.S235_AUTH_SUCCESS
 
-    def test_disabled_mechanism(self, client: SMTPClient):
+    def test_disabled_mechanism(self, client: SMTPClient) -> None:
         self._ehlo(client)
         resp = client.docmd("AUTH DONT")
         assert resp == S.S504_AUTH_UNRECOG
@@ -1031,7 +1032,7 @@ class TestAuthMechanisms(_CommonMethods):
     @pytest.mark.parametrize("mechanism", ["login", "plain"])
     def test_byclient(
         self, caplog: pytest.LogCaptureFixture, auth_peeker_controller: Controller, client: SMTPClient, mechanism: str, init_resp: bool
-    ):
+    ) -> None:
         self._ehlo(client)
         PW = "goodpasswd"
         client.user = "goodlogin"
@@ -1054,33 +1055,33 @@ class TestAuthMechanisms(_CommonMethods):
         assert peeker.password == PW.encode("ascii")
         assert_nopassleak(PW, caplog.record_tuples)
 
-    def test_plain1_bad_base64_encoding(self, do_auth_plain1: Callable):
+    def test_plain1_bad_base64_encoding(self, do_auth_plain1: Callable) -> None:
         resp = do_auth_plain1("not-b64")
         assert resp == S.S501_AUTH_NOTB64
 
-    def test_plain1_bad_base64_length(self, do_auth_plain1: Callable):
+    def test_plain1_bad_base64_length(self, do_auth_plain1: Callable) -> None:
         resp = do_auth_plain1(b64encode(b"\0onlylogin").decode())
         assert resp == S.S501_AUTH_CANTSPLIT
 
-    def test_plain1_too_many_values(self, do_auth_plain1: Callable):
+    def test_plain1_too_many_values(self, do_auth_plain1: Callable) -> None:
         resp = do_auth_plain1("NONE NONE")
         assert resp == S.S501_TOO_MANY
 
-    def test_plain1_bad_username(self, do_auth_plain1: Callable):
+    def test_plain1_bad_username(self, do_auth_plain1: Callable) -> None:
         resp = do_auth_plain1(b64encode(b"\0badlogin\0goodpasswd").decode())
         assert resp == S.S535_AUTH_INVALID
 
-    def test_plain1_bad_password(self, do_auth_plain1: Callable):
+    def test_plain1_bad_password(self, do_auth_plain1: Callable) -> None:
         resp = do_auth_plain1(b64encode(b"\0goodlogin\0badpasswd").decode())
         assert resp == S.S535_AUTH_INVALID
 
-    def test_plain1_empty(self, do_auth_plain1: Callable):
+    def test_plain1_empty(self, do_auth_plain1: Callable) -> None:
         resp = do_auth_plain1(B64EQUALS)
         assert resp == S.S501_AUTH_CANTSPLIT
 
     def test_plain1_good_credentials(
         self, caplog: pytest.LogCaptureFixture, auth_peeker_controller: Controller, do_auth_plain1: Callable
-    ):
+    ) -> None:
         PW = "goodpasswd"
         PWb = PW.encode("ascii")
         resp = do_auth_plain1(b64encode(b"\0goodlogin\0" + PWb).decode())
@@ -1094,7 +1095,7 @@ class TestAuthMechanisms(_CommonMethods):
         assert resp == S.S250_OK
         assert_nopassleak(PW, caplog.record_tuples)
 
-    def test_plain1_goodcreds_sanitized_log(self, caplog: pytest.LogCaptureFixture, client: SMTPClient):
+    def test_plain1_goodcreds_sanitized_log(self, caplog: pytest.LogCaptureFixture, client: SMTPClient) -> None:
         caplog.set_level("DEBUG")
         client.ehlo("example.com")
         PW = "goodpasswd"
@@ -1119,7 +1120,7 @@ class TestAuthMechanisms(_CommonMethods):
 
     def test_plain2_good_credentials(
         self, caplog: pytest.LogCaptureFixture, auth_peeker_controller: Controller, client_auth_plain2: SMTPClient
-    ):
+    ) -> None:
         PW = "goodpasswd"
         PWb = PW.encode("ascii")
         resp = client_auth_plain2.docmd(b64encode(b"\0goodlogin\0" + PWb).decode())
@@ -1132,28 +1133,28 @@ class TestAuthMechanisms(_CommonMethods):
         assert resp == S.S250_OK
         assert_nopassleak(PW, caplog.record_tuples)
 
-    def test_plain2_bad_credentials(self, client_auth_plain2: SMTPClient):
+    def test_plain2_bad_credentials(self, client_auth_plain2: SMTPClient) -> None:
         resp = client_auth_plain2.docmd(b64encode(b"\0badlogin\0badpasswd").decode())
         assert resp == S.S535_AUTH_INVALID
 
-    def test_plain2_no_credentials(self, client_auth_plain2: SMTPClient):
+    def test_plain2_no_credentials(self, client_auth_plain2: SMTPClient) -> None:
         resp = client_auth_plain2.docmd(B64EQUALS)
         assert resp == S.S501_AUTH_CANTSPLIT
 
-    def test_plain2_abort(self, client_auth_plain2: SMTPClient):
+    def test_plain2_abort(self, client_auth_plain2: SMTPClient) -> None:
         resp = client_auth_plain2.docmd("*")
         assert resp == S.S501_AUTH_ABORTED
 
-    def test_plain2_bad_base64_encoding(self, client_auth_plain2: SMTPClient):
+    def test_plain2_bad_base64_encoding(self, client_auth_plain2: SMTPClient) -> None:
         resp = client_auth_plain2.docmd("ab@%")
         assert resp == S.S501_AUTH_NOTB64
 
-    def test_login2_bad_base64(self, auth_peeker_controller: Controller, client: SMTPClient):
+    def test_login2_bad_base64(self, auth_peeker_controller: Controller, client: SMTPClient) -> None:
         self._ehlo(client)
         resp = client.docmd("AUTH LOGIN ab@%")
         assert resp == S.S501_AUTH_NOTB64
 
-    def test_login2_good_credentials(self, caplog: pytest.LogCaptureFixture, auth_peeker_controller: Controller, client: SMTPClient):
+    def test_login2_good_credentials(self, caplog: pytest.LogCaptureFixture, auth_peeker_controller: Controller, client: SMTPClient) -> None:
         self._ehlo(client)
         PW = "goodpasswd"
         PWb = PW.encode("ascii")
@@ -1173,7 +1174,7 @@ class TestAuthMechanisms(_CommonMethods):
 
     def test_login3_good_credentials(
         self, caplog: pytest.LogCaptureFixture, auth_peeker_controller: Controller, do_auth_login3: Callable
-    ):
+    ) -> None:
         PW = "goodpasswd"
         PWb = PW.encode("ascii")
         resp = do_auth_login3(b64encode(b"goodlogin").decode())
@@ -1189,49 +1190,49 @@ class TestAuthMechanisms(_CommonMethods):
         assert resp == S.S250_OK
         assert_nopassleak(PW, caplog.record_tuples)
 
-    def test_login3_bad_base64(self, do_auth_login3: Callable):
+    def test_login3_bad_base64(self, do_auth_login3: Callable) -> None:
         resp = do_auth_login3("not-b64")
         assert resp == S.S501_AUTH_NOTB64
 
-    def test_login3_bad_username(self, do_auth_login3: Callable):
+    def test_login3_bad_username(self, do_auth_login3: Callable) -> None:
         resp = do_auth_login3(b64encode(b"badlogin").decode())
         assert resp == S.S334_AUTH_PASSWORD
         resp = do_auth_login3(b64encode(b"goodpasswd").decode())
         assert resp == S.S535_AUTH_INVALID
 
-    def test_login3_bad_password(self, do_auth_login3: Callable):
+    def test_login3_bad_password(self, do_auth_login3: Callable) -> None:
         resp = do_auth_login3(b64encode(b"goodlogin").decode())
         assert resp == S.S334_AUTH_PASSWORD
         resp = do_auth_login3(b64encode(b"badpasswd").decode())
         assert resp == S.S535_AUTH_INVALID
 
-    def test_login3_empty_credentials(self, do_auth_login3: Callable):
+    def test_login3_empty_credentials(self, do_auth_login3: Callable) -> None:
         resp = do_auth_login3(B64EQUALS)
         assert resp == S.S334_AUTH_PASSWORD
         resp = do_auth_login3(B64EQUALS)
         assert resp == S.S535_AUTH_INVALID
 
-    def test_login3_abort_username(self, do_auth_login3: Callable):
+    def test_login3_abort_username(self, do_auth_login3: Callable) -> None:
         resp = do_auth_login3("*")
         assert resp == S.S501_AUTH_ABORTED
 
-    def test_login3_abort_password(self, do_auth_login3: Callable):
+    def test_login3_abort_password(self, do_auth_login3: Callable) -> None:
         resp = do_auth_login3(B64EQUALS)
         assert resp == S.S334_AUTH_PASSWORD
         resp = do_auth_login3("*")
         assert resp == S.S501_AUTH_ABORTED
 
-    def test_DENYFALSE(self, client: SMTPClient):
+    def test_DENYFALSE(self, client: SMTPClient) -> None:
         self._ehlo(client)
         resp = client.docmd("AUTH DENYFALSE")
         assert resp == S.S535_AUTH_INVALID
 
-    def test_DENYMISSING(self, client: SMTPClient):
+    def test_DENYMISSING(self, client: SMTPClient) -> None:
         self._ehlo(client)
         resp = client.docmd("AUTH DENYMISSING")
         assert resp == S.S535_AUTH_INVALID
 
-    def test_NONE(self, client: SMTPClient):
+    def test_NONE(self, client: SMTPClient) -> None:
         self._ehlo(client)
         resp = client.docmd("AUTH NONE")
         assert resp == S.S235_AUTH_SUCCESS
@@ -1239,7 +1240,7 @@ class TestAuthMechanisms(_CommonMethods):
 
 # noinspection HardcodedPassword
 class TestAuthenticator(_CommonMethods):
-    def test_success(self, caplog: pytest.LogCaptureFixture, authenticator_peeker_controller: Controller, client: SMTPClient):
+    def test_success(self, caplog: pytest.LogCaptureFixture, authenticator_peeker_controller: Controller, client: SMTPClient) -> None:
         PW = "goodpasswd"
         client.user = "gooduser"
         client.password = PW
@@ -1254,7 +1255,7 @@ class TestAuthenticator(_CommonMethods):
         assert auth_peeker.login_data == (b"gooduser", PW.encode("ascii"))
         assert_nopassleak(PW, caplog.record_tuples)
 
-    def test_fail_withmesg(self, caplog: pytest.LogCaptureFixture, authenticator_peeker_controller: Controller, client: SMTPClient):
+    def test_fail_withmesg(self, caplog: pytest.LogCaptureFixture, authenticator_peeker_controller: Controller, client: SMTPClient) -> None:
         PW = "anypass"
         client.user = "failme_with454"
         client.password = PW
@@ -1286,56 +1287,56 @@ class TestRequiredAuthentication(_CommonMethods):
         resp = client.login("goodlogin", "goodpasswd")
         assert resp == S.S235_AUTH_SUCCESS
 
-    def test_help_unauthenticated(self, client: SMTPClient):
+    def test_help_unauthenticated(self, client: SMTPClient) -> None:
         resp = client.docmd("HELP")
         assert resp == S.S530_AUTH_REQUIRED
 
-    def test_help_authenticated(self, client: SMTPClient):
+    def test_help_authenticated(self, client: SMTPClient) -> None:
         self._login(client)
         resp = client.docmd("HELP")
         assert resp == S.S250_SUPPCMD_NOTLS
 
-    def test_vrfy_unauthenticated(self, client: SMTPClient):
+    def test_vrfy_unauthenticated(self, client: SMTPClient) -> None:
         resp = client.docmd("VRFY <anne@example.com>")
         assert resp == S.S530_AUTH_REQUIRED
 
-    def test_mail_unauthenticated(self, client: SMTPClient):
+    def test_mail_unauthenticated(self, client: SMTPClient) -> None:
         self._ehlo(client)
         resp = client.docmd("MAIL FROM: <anne@example.com>")
         assert resp == S.S530_AUTH_REQUIRED
 
-    def test_rcpt_unauthenticated(self, client: SMTPClient):
+    def test_rcpt_unauthenticated(self, client: SMTPClient) -> None:
         self._ehlo(client)
         resp = client.docmd("RCPT TO: <anne@example.com>")
         assert resp == S.S530_AUTH_REQUIRED
 
-    def test_rcpt_nomail_authenticated(self, client: SMTPClient):
+    def test_rcpt_nomail_authenticated(self, client: SMTPClient) -> None:
         self._login(client)
         resp = client.docmd("RCPT TO: <anne@example.com>")
         assert resp == S.S503_MAIL_NEEDED
 
-    def test_data_unauthenticated(self, client: SMTPClient):
+    def test_data_unauthenticated(self, client: SMTPClient) -> None:
         self._ehlo(client)
         resp = client.docmd("DATA")
         assert resp == S.S530_AUTH_REQUIRED
 
-    def test_data_authenticated(self, client: SMTPClient):
+    def test_data_authenticated(self, client: SMTPClient) -> None:
         self._ehlo(client, "example.com")
         client.login("goodlogin", "goodpassword")
         resp = client.docmd("DATA")
         assert resp != S.S530_AUTH_REQUIRED
 
-    def test_vrfy_authenticated(self, client: SMTPClient):
+    def test_vrfy_authenticated(self, client: SMTPClient) -> None:
         self._login(client)
         resp = client.docmd("VRFY <anne@example.com>")
         assert resp == S.S252_CANNOT_VRFY
 
-    def test_mail_authenticated(self, client: SMTPClient):
+    def test_mail_authenticated(self, client: SMTPClient) -> None:
         self._login(client)
         resp = client.docmd("MAIL FROM: <anne@example.com>")
         assert resp, S.S250_OK
 
-    def test_data_norcpt_authenticated(self, client: SMTPClient):
+    def test_data_norcpt_authenticated(self, client: SMTPClient) -> None:
         self._login(client)
         resp = client.docmd("DATA")
         assert resp == S.S503_RCPT_NEEDED
@@ -1371,7 +1372,7 @@ class TestResetCommands:
             client.rcpt(rcpt)
 
     @handler_data(class_=StoreEnvelopeOnVRFYHandler)
-    def test_helo(self, decoding_authnotls_controller: Controller, client: SMTPClient):
+    def test_helo(self, decoding_authnotls_controller: Controller, client: SMTPClient) -> None:
         handler = decoding_authnotls_controller.handler
         assert isinstance(handler, StoreEnvelopeOnVRFYHandler)
         # Each time through the loop, the HELO will reset the envelope.
@@ -1387,7 +1388,7 @@ class TestResetCommands:
             assert handler.envelope.rcpt_tos == data["rcpt_tos"]
 
     @handler_data(class_=StoreEnvelopeOnVRFYHandler)
-    def test_ehlo(self, decoding_authnotls_controller: Controller, client: SMTPClient):
+    def test_ehlo(self, decoding_authnotls_controller: Controller, client: SMTPClient) -> None:
         handler = decoding_authnotls_controller.handler
         assert isinstance(handler, StoreEnvelopeOnVRFYHandler)
         # Each time through the loop, the EHLO will reset the envelope.
@@ -1403,7 +1404,7 @@ class TestResetCommands:
             assert handler.envelope.rcpt_tos == data["rcpt_tos"]
 
     @handler_data(class_=StoreEnvelopeOnVRFYHandler)
-    def test_rset(self, decoding_authnotls_controller: Controller, client: SMTPClient):
+    def test_rset(self, decoding_authnotls_controller: Controller, client: SMTPClient) -> None:
         handler = decoding_authnotls_controller.handler
         assert isinstance(handler, StoreEnvelopeOnVRFYHandler)
         client.helo("example.com")
@@ -1423,13 +1424,13 @@ class TestResetCommands:
 
 class TestSMTPWithController(_CommonMethods):
     @controller_data(data_size_limit=9999)
-    def test_mail_with_size_too_large(self, plain_controller: Controller, client: SMTPClient):
+    def test_mail_with_size_too_large(self, plain_controller: Controller, client: SMTPClient) -> None:
         self._ehlo(client)
         resp = client.docmd("MAIL FROM: <anne@example.com> SIZE=10000")
         assert resp == S.S552_EXCEED_SIZE
 
     @handler_data(class_=ReceivingHandler)
-    def test_mail_with_compatible_smtputf8(self, plain_controller: Controller, client: SMTPClient):
+    def test_mail_with_compatible_smtputf8(self, plain_controller: Controller, client: SMTPClient) -> None:
         receiving_handler = plain_controller.handler
         assert isinstance(receiving_handler, ReceivingHandler)
         sender = "anne\xCB@example.com"
@@ -1444,29 +1445,29 @@ class TestSMTPWithController(_CommonMethods):
         assert receiving_handler.box[0].mail_from == sender
         assert receiving_handler.box[0].rcpt_tos == [recipient]
 
-    def test_mail_with_unrequited_smtputf8(self, plain_controller: Controller, client: SMTPClient):
+    def test_mail_with_unrequited_smtputf8(self, plain_controller: Controller, client: SMTPClient) -> None:
         self._ehlo(client)
         resp = client.docmd("MAIL FROM: <anne@example.com>")
         assert resp == S.S250_OK
 
-    def test_mail_with_incompatible_smtputf8(self, plain_controller: Controller, client: SMTPClient):
+    def test_mail_with_incompatible_smtputf8(self, plain_controller: Controller, client: SMTPClient) -> None:
         self._ehlo(client)
         resp = client.docmd("MAIL FROM: <anne@example.com> SMTPUTF8=YES")
         assert resp == S.S501_SMTPUTF8_NOARG
 
-    def test_mail_invalid_body(self, plain_controller: Controller, client: SMTPClient):
+    def test_mail_invalid_body(self, plain_controller: Controller, client: SMTPClient) -> None:
         self._ehlo(client)
         resp = client.docmd("MAIL FROM: <anne@example.com> BODY 9BIT")
         assert resp == S.S501_MAIL_BODY
 
     @controller_data(data_size_limit=None)
-    def test_esmtp_no_size_limit(self, plain_controller: Controller, client: SMTPClient):
+    def test_esmtp_no_size_limit(self, plain_controller: Controller, client: SMTPClient) -> None:
         code, mesg = client.ehlo("example.com")
         for ln in mesg.splitlines():
             assert not ln.startswith(b"SIZE")
 
     @handler_data(class_=ErroringHandler)
-    def test_process_message_error(self, error_controller: Controller, client: SMTPClient):
+    def test_process_message_error(self, error_controller: Controller, client: SMTPClient) -> None:
         self._ehlo(client)
         with pytest.raises(SMTPDataError) as excinfo:
             client.sendmail(
@@ -1485,7 +1486,7 @@ class TestSMTPWithController(_CommonMethods):
         assert excinfo.value.args == (499, b"Could not accept the message")
 
     @controller_data(data_size_limit=100)
-    def test_too_long_message_body(self, plain_controller: Controller, client: SMTPClient):
+    def test_too_long_message_body(self, plain_controller: Controller, client: SMTPClient) -> None:
         self._helo(client)
         mail = "\r\n".join(["z" * 20] * 10)
         with pytest.raises(SMTPResponseException) as excinfo:
@@ -1493,7 +1494,7 @@ class TestSMTPWithController(_CommonMethods):
         assert excinfo.value.args == S.S552_DATA_TOO_MUCH
 
     @handler_data(class_=ReceivingHandler)
-    def test_dots_escaped(self, decoding_authnotls_controller: Controller, client: SMTPClient):
+    def test_dots_escaped(self, decoding_authnotls_controller: Controller, client: SMTPClient) -> None:
         receiving_handler = decoding_authnotls_controller.handler
         assert isinstance(receiving_handler, ReceivingHandler)
         self._helo(client)
@@ -1503,21 +1504,21 @@ class TestSMTPWithController(_CommonMethods):
         assert receiving_handler.box[0].content == mail + CRLF
 
     @handler_data(class_=ErroringHandler)
-    def test_unexpected_errors(self, error_controller: Controller, client: SMTPClient):
+    def test_unexpected_errors(self, error_controller: Controller, client: SMTPClient) -> None:
         handler = error_controller.handler
         resp = client.helo("example.com")
         assert resp == (500, b"ErroringHandler handling error")
         exception_type = ErrorSMTP.exception_type
         assert isinstance(handler.error, exception_type)
 
-    def test_unexpected_errors_unhandled(self, error_controller: Controller, client: SMTPClient):
+    def test_unexpected_errors_unhandled(self, error_controller: Controller, client: SMTPClient) -> None:
         resp = client.helo("example.com")
         exception_type = ErrorSMTP.exception_type
         exception_nameb = exception_type.__name__.encode("ascii")
         assert resp == (500, b"Error: (" + exception_nameb + b") test")
 
     @handler_data(class_=ErroringHandler)
-    def test_unexpected_errors_custom_response(self, error_controller: Controller, client: SMTPClient):
+    def test_unexpected_errors_custom_response(self, error_controller: Controller, client: SMTPClient) -> None:
         erroring_handler = error_controller.handler
         erroring_handler.custom_response = True
         resp = client.helo("example.com")
@@ -1527,7 +1528,7 @@ class TestSMTPWithController(_CommonMethods):
         assert resp == (451, b"Temporary error: (" + exception_nameb + b") test")
 
     @handler_data(class_=ErroringErrorHandler)
-    def test_exception_handler_exception(self, error_controller: Controller, client: SMTPClient):
+    def test_exception_handler_exception(self, error_controller: Controller, client: SMTPClient) -> None:
         handler = error_controller.handler
         resp = client.helo("example.com")
         assert resp == (500, b"Error: (ValueError) ErroringErrorHandler test")
@@ -1535,7 +1536,7 @@ class TestSMTPWithController(_CommonMethods):
         assert isinstance(handler.error, exception_type)
 
     @handler_data(class_=UndescribableErrorHandler)
-    def test_exception_handler_undescribable(self, error_controller: Controller, client: SMTPClient):
+    def test_exception_handler_undescribable(self, error_controller: Controller, client: SMTPClient) -> None:
         handler = error_controller.handler
         resp = client.helo("example.com")
         assert resp == (500, b"Error: Cannot describe error")
@@ -1545,7 +1546,7 @@ class TestSMTPWithController(_CommonMethods):
     @handler_data(class_=ErroringHandlerConnectionLost)
     def test_exception_handler_multiple_connections_lost(
         self, error_controller: Controller, client: SMTPClient
-    ):
+    ) -> None:
         client1 = client
         code, mesg = client1.ehlo("example.com")
         assert code == 250
@@ -1566,7 +1567,7 @@ class TestSMTPWithController(_CommonMethods):
         assert resp == S.S250_OK
 
     @handler_data(class_=ReceivingHandler)
-    def test_bad_encodings(self, decoding_authnotls_controller: Controller, client: SMTPClient):
+    def test_bad_encodings(self, decoding_authnotls_controller: Controller, client: SMTPClient) -> None:
         handler: ReceivingHandler = decoding_authnotls_controller.handler
         self._helo(client)
         mail_from = b"anne\xFF@example.com"
@@ -1585,7 +1586,7 @@ class TestSMTPWithController(_CommonMethods):
         assert mail_to2 == mail_to
 
     @controller_data(decode_data=False)
-    def test_data_line_too_long(self, plain_controller: Controller, client: SMTPClient):
+    def test_data_line_too_long(self, plain_controller: Controller, client: SMTPClient) -> None:
         self._helo(client)
         client.helo("example.com")
         mail = b"\r\n".join([b"a" * 5555] * 3)
@@ -1594,7 +1595,7 @@ class TestSMTPWithController(_CommonMethods):
         assert exc.value.args == S.S500_DATALINE_TOO_LONG
 
     @controller_data(data_size_limit=10000)
-    def test_long_line_double_count(self, plain_controller: Controller, client: SMTPClient):
+    def test_long_line_double_count(self, plain_controller: Controller, client: SMTPClient) -> None:
         # With a read limit of 1001 bytes in aiosmtp.SMTP, asyncio.StreamReader
         # returns too-long lines of length up to 2002 bytes.
         # This test ensures that bytes in partial lines are only counted once.
@@ -1608,7 +1609,7 @@ class TestSMTPWithController(_CommonMethods):
 
     def test_long_line_leak(
         self, mocker: MockFixture, plain_controller: Controller, client: SMTPClient
-    ):
+    ) -> None:
         # Simulates situation where readuntil() does not raise LimitOverrunError,
         # but somehow the line_fragments when join()ed resulted in a too-long line
 
@@ -1626,7 +1627,7 @@ class TestSMTPWithController(_CommonMethods):
         #                  b'Line too long (see RFC5321 4.5.3.1.6)')
 
     @controller_data(data_size_limit=20)
-    def test_too_long_body_delay_error(self, plain_controller: Controller):
+    def test_too_long_body_delay_error(self, plain_controller: Controller) -> None:
         with socket.socket() as sock:
             sock.connect((plain_controller.hostname, plain_controller.port))
             rslt = send_recv(sock, b"EHLO example.com")
@@ -1645,7 +1646,7 @@ class TestSMTPWithController(_CommonMethods):
             assert rslt == b"552 Error: Too much mail data\r\n"
 
     @controller_data(data_size_limit=700)
-    def test_too_long_body_then_too_long_lines(self, plain_controller: Controller, client: SMTPClient):
+    def test_too_long_body_then_too_long_lines(self, plain_controller: Controller, client: SMTPClient) -> None:
         # If "too much mail" state was reached before "too long line" gets received,
         # SMTP should respond with '552' instead of '500'
         client.helo("example.com")
@@ -1654,7 +1655,7 @@ class TestSMTPWithController(_CommonMethods):
             client.sendmail("anne@example.com", ["bart@example.com"], mail)
         assert exc.value.args == S.S552_DATA_TOO_MUCH
 
-    def test_too_long_line_delay_error(self, plain_controller: Controller):
+    def test_too_long_line_delay_error(self, plain_controller: Controller) -> None:
         with socket.socket() as sock:
             sock.connect((plain_controller.hostname, plain_controller.port))
             rslt = send_recv(sock, b"EHLO example.com")
@@ -1673,7 +1674,7 @@ class TestSMTPWithController(_CommonMethods):
             assert rslt == S.S500_DATALINE_TOO_LONG.to_bytes(crlf=True)
 
     @controller_data(data_size_limit=2000)
-    def test_too_long_lines_then_too_long_body(self, plain_controller: Controller, client: SMTPClient):
+    def test_too_long_lines_then_too_long_body(self, plain_controller: Controller, client: SMTPClient) -> None:
         # If "too long line" state was reached before "too much data" happens,
         # SMTP should respond with '500' instead of '552'
         client.helo("example.com")
@@ -1685,12 +1686,12 @@ class TestSMTPWithController(_CommonMethods):
 
 class TestCustomization(_CommonMethods):
     @controller_data(class_=CustomHostnameController)
-    def test_custom_hostname(self, plain_controller: Controller, client: SMTPClient):
+    def test_custom_hostname(self, plain_controller: Controller, client: SMTPClient) -> None:
         code, mesg = client.helo("example.com")
         assert code == 250
         assert mesg == CustomHostnameController.custom_name.encode("ascii")
 
-    def test_default_greeting(self, plain_controller: Controller, client: SMTPClient):
+    def test_default_greeting(self, plain_controller: Controller, client: SMTPClient) -> None:
         controller = plain_controller
         code, mesg = client.connect(controller.hostname, controller.port)
         assert code == 220
@@ -1698,7 +1699,7 @@ class TestCustomization(_CommonMethods):
         assert mesg.endswith(bytes(GREETING, "utf-8"))
 
     @controller_data(class_=CustomIdentController)
-    def test_custom_greeting(self, plain_controller: Controller, client: SMTPClient):
+    def test_custom_greeting(self, plain_controller: Controller, client: SMTPClient) -> None:
         controller = plain_controller
         code, mesg = client.connect(controller.hostname, controller.port)
         assert code == 220
@@ -1706,12 +1707,12 @@ class TestCustomization(_CommonMethods):
         assert mesg.endswith(CustomIdentController.ident)
 
     @controller_data(decode_data=False)
-    def test_mail_invalid_body_param(self, plain_controller: Controller, client: SMTPClient):
+    def test_mail_invalid_body_param(self, plain_controller: Controller, client: SMTPClient) -> None:
         client.ehlo("example.com")
         resp = client.docmd("MAIL FROM: <anne@example.com> BODY=FOOBAR")
         assert resp == S.S501_MAIL_BODY
 
-    def test_limitlocalpart(self, plain_controller: Controller, client: SMTPClient):
+    def test_limitlocalpart(self, plain_controller: Controller, client: SMTPClient) -> None:
         plain_controller.smtpd.local_part_limit = 64
         client.ehlo("example.com")
         locpart = "a" * 64
@@ -1725,7 +1726,7 @@ class TestCustomization(_CommonMethods):
 class TestClientCrash(_CommonMethods):
     def test_connection_reset_during_DATA(
         self, mocker: MockFixture, plain_controller: Controller, client: SMTPClient
-    ):
+    ) -> None:
         # Trigger factory() to produce the smtpd server
         self._helo(client)
         smtpd: Server = plain_controller.smtpd
@@ -1753,7 +1754,7 @@ class TestClientCrash(_CommonMethods):
 
     def test_connection_reset_during_command(
         self, mocker: MockFixture, plain_controller: Controller, client: SMTPClient
-    ):
+    ) -> None:
         # Trigger factory() to produce the smtpd server
         self._helo(client)
         smtpd: Server = plain_controller.smtpd
@@ -1768,7 +1769,7 @@ class TestClientCrash(_CommonMethods):
         # Should be called at least once. (In practice, almost certainly just once.)
         assert spy.call_count > 0
 
-    def test_connection_reset_in_long_command(self, plain_controller: Controller, client: SMTPClient):
+    def test_connection_reset_in_long_command(self, plain_controller: Controller, client: SMTPClient) -> None:
         client.send("F" + 5555 * "O")  # without CRLF
         reset_connection(client)
         catchup_delay()
@@ -1780,7 +1781,7 @@ class TestClientCrash(_CommonMethods):
         # and still == True if transport is closed.
         assert writer.transport.is_closing()
 
-    def test_close_in_command(self, plain_controller: Controller, client: SMTPClient):
+    def test_close_in_command(self, plain_controller: Controller, client: SMTPClient) -> None:
         # Don't include the CRLF.
         client.send("FOO")
         client.close()
@@ -1795,7 +1796,7 @@ class TestClientCrash(_CommonMethods):
 
     def test_close_in_command_2(
         self, mocker: MockFixture, plain_controller: Controller, client: SMTPClient
-    ):
+    ) -> None:
         self._helo(client)
         catchup_delay()
         smtpd: Server = plain_controller.smtpd
@@ -1811,7 +1812,7 @@ class TestClientCrash(_CommonMethods):
         # and still == True if transport is closed.
         assert writer.transport.is_closing()
 
-    def test_close_in_long_command(self, plain_controller: Controller, client: SMTPClient):
+    def test_close_in_long_command(self, plain_controller: Controller, client: SMTPClient) -> None:
         client.send("F" + 5555 * "O")  # without CRLF
         client.close()
         catchup_delay()
@@ -1825,7 +1826,7 @@ class TestClientCrash(_CommonMethods):
 
     def test_close_in_data(
         self, mocker: MockFixture, plain_controller: Controller, client: SMTPClient
-    ):
+    ) -> None:
         self._helo(client)
         smtpd: Server = plain_controller.smtpd
         writer = smtpd._writer
@@ -1853,7 +1854,7 @@ class TestClientCrash(_CommonMethods):
 
     def test_sockclose_after_helo(
         self, mocker: MockFixture, plain_controller: Controller, client: SMTPClient
-    ):
+    ) -> None:
         client.send("HELO example.com\r\n")
         catchup_delay()
         smtpd: Server = plain_controller.smtpd
@@ -1872,21 +1873,21 @@ class TestClientCrash(_CommonMethods):
 @pytest.mark.usefixtures("plain_controller")
 @controller_data(enable_SMTPUTF8=False, decode_data=True)
 class TestStrictASCII(_CommonMethods):
-    def test_ehlo(self, client: SMTPClient):
+    def test_ehlo(self, client: SMTPClient) -> None:
         blines = self._ehlo(client)
         assert b"SMTPUTF8" not in blines
 
-    def test_bad_encoded_param(self, client: SMTPClient):
+    def test_bad_encoded_param(self, client: SMTPClient) -> None:
         self._ehlo(client)
         client.send(b"MAIL FROM: <anne\xFF@example.com>\r\n")
         assert client.getreply() == S.S500_STRICT_ASCII
 
-    def test_mail_param(self, client: SMTPClient):
+    def test_mail_param(self, client: SMTPClient) -> None:
         self._ehlo(client)
         resp = client.docmd("MAIL FROM: <anne@example.com> SMTPUTF8")
         assert resp == S.S501_SMTPUTF8_DISABLED
 
-    def test_data(self, client: SMTPClient):
+    def test_data(self, client: SMTPClient) -> None:
         self._ehlo(client)
         with pytest.raises(SMTPDataError) as excinfo:
             client.sendmail(
@@ -1906,7 +1907,7 @@ class TestSleepingHandler(_CommonMethods):
 
     @controller_data(decode_data=False)
     @handler_data(class_=SleepingHeloHandler)
-    def test_close_after_helo(self, plain_controller: Controller, client: SMTPClient):
+    def test_close_after_helo(self, plain_controller: Controller, client: SMTPClient) -> None:
         #
         # What are we actually testing?
         #
@@ -1918,7 +1919,7 @@ class TestSleepingHandler(_CommonMethods):
 
 class TestTimeout(_CommonMethods):
     @controller_data(class_=TimeoutController)
-    def test_timeout(self, plain_controller: Controller, client: SMTPClient):
+    def test_timeout(self, plain_controller: Controller, client: SMTPClient) -> None:
         # This one is rapid, it must succeed
         self._ehlo(client)
         time.sleep(0.1 + TimeoutController.Delay)
@@ -1927,7 +1928,7 @@ class TestTimeout(_CommonMethods):
 
 
 class TestAuthArgs:
-    def test_warn_authreqnotls(self, caplog: pytest.LogCaptureFixture):
+    def test_warn_authreqnotls(self, caplog: pytest.LogCaptureFixture) -> None:
         with pytest.warns(UserWarning, match="Requiring AUTH") as record:
             _ = Server(Sink(), auth_required=True, auth_require_tls=False)
         for warning in record:
@@ -1946,7 +1947,7 @@ class TestAuthArgs:
             "auth_required == True but auth_require_tls == False",
         )
 
-    def test_log_authmechanisms(self, caplog: pytest.LogCaptureFixture):
+    def test_log_authmechanisms(self, caplog: pytest.LogCaptureFixture) -> None:
         caplog.set_level(logging.INFO)
         server = Server(Sink())
         auth_mechs = sorted(
@@ -1968,7 +1969,7 @@ class TestAuthArgs:
             "has\\backslash",
         ],
     )
-    def test_authmechname_decorator_badname(self, name: str):
+    def test_authmechname_decorator_badname(self, name: str) -> None:
         expectre = r"Invalid AUTH mechanism name"
         with pytest.raises(ValueError, match=expectre):
             auth_mechanism(name)
@@ -1993,24 +1994,24 @@ class TestLimits(_CommonMethods):
         with pytest.raises(SMTPServerDisconnected):
             client.noop()
 
-    def test_limit_wrong_type(self):
+    def test_limit_wrong_type(self) -> None:
         with pytest.raises(TypeError) as exc:
             # noinspection PyTypeChecker
             _ = Server(Sink(), command_call_limit="invalid")
         assert exc.value.args[0] == "command_call_limit must be int or Dict[str, int]"
 
-    def test_limit_wrong_value_type(self):
+    def test_limit_wrong_value_type(self) -> None:
         with pytest.raises(TypeError) as exc:
             # noinspection PyTypeChecker
             _ = Server(Sink(), command_call_limit={"NOOP": "invalid"})
         assert exc.value.args[0] == "All command_call_limit values must be int"
 
     @controller_data(command_call_limit=15)
-    def test_all_limit_15(self, plain_controller: Controller, client: SMTPClient):
+    def test_all_limit_15(self, plain_controller: Controller, client: SMTPClient) -> None:
         self._consume_budget(client, 15, "noop")
 
     @controller_data(command_call_limit={"NOOP": 15, "EXPN": 5})
-    def test_different_limits(self, plain_controller: Controller, client: SMTPClient):
+    def test_different_limits(self, plain_controller: Controller, client: SMTPClient) -> None:
         srv_ip_port = plain_controller.hostname, plain_controller.port
 
         self._consume_budget(client, 15, "noop")
@@ -2030,7 +2031,7 @@ class TestLimits(_CommonMethods):
         )
 
     @controller_data(command_call_limit={"NOOP": 7, "EXPN": 5, "*": 25})
-    def test_different_limits_custom_default(self, plain_controller: Controller, client: SMTPClient):
+    def test_different_limits_custom_default(self, plain_controller: Controller, client: SMTPClient) -> None:
         # Important: make sure default_max > CALL_LIMIT_DEFAULT
         # Others can be set small to cut down on testing time, but must be different
         assert plain_controller.smtpd._call_limit_default > CALL_LIMIT_DEFAULT
@@ -2053,7 +2054,7 @@ class TestLimits(_CommonMethods):
         )
 
     @controller_data(command_call_limit=7)
-    def test_limit_bogus(self, plain_controller: Controller, client: SMTPClient):
+    def test_limit_bogus(self, plain_controller: Controller, client: SMTPClient) -> None:
         assert plain_controller.smtpd._call_limit_default > BOGUS_LIMIT
         code, mesg = client.ehlo("example.com")
         assert code == 250
@@ -2066,13 +2067,13 @@ class TestLimits(_CommonMethods):
 
 
 class TestSanitize:
-    def test_loginpassword(self):
+    def test_loginpassword(self) -> None:
         lp = LoginPassword(b"user", b"pass")
         expect = "LoginPassword(login='user', password=...)"
         assert repr(lp) == expect
         assert str(lp) == expect
 
-    def test_authresult(self):
+    def test_authresult(self) -> None:
         ar = AuthResult(success=True, auth_data="user:pass")
         expect = "AuthResult(success=True, handled=True, message=None, auth_data=...)"
         assert repr(ar) == expect

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -1282,7 +1282,7 @@ class TestAuthenticator(_CommonMethods):
     auth_required=True,
 )
 class TestRequiredAuthentication(_CommonMethods):
-    def _login(self, client: SMTPClient):
+    def _login(self, client: SMTPClient) -> None:
         self._ehlo(client)
         resp = client.login("goodlogin", "goodpasswd")
         assert resp == S.S235_AUTH_SUCCESS
@@ -1366,7 +1366,7 @@ class TestResetCommands:
         client: SMTPClient,
         mail_from: str,
         rcpt_tos: List[str],
-    ):
+    ) -> None:
         client.mail(mail_from)
         for rcpt in rcpt_tos:
             client.rcpt(rcpt)
@@ -1983,7 +1983,7 @@ class TestLimits(_CommonMethods):
         cmd: str,
         *args,
         ok_expected: Optional[StatusCode] = None
-    ):
+    ) -> None:
         code, _ = client.ehlo("example.com")
         assert code == 250
         func = getattr(client, cmd)

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -21,7 +21,7 @@ from smtplib import (
     SMTPServerDisconnected,
 )
 from textwrap import dedent
-from typing import cast, Any, Callable, Generator, List, Tuple, Union
+from typing import cast, Any, Callable, Generator, List, Optional, Tuple, Union
 
 import pytest
 from pytest_mock import MockFixture
@@ -47,7 +47,7 @@ from aiosmtpd.testing.helpers import (
     reset_connection,
     send_recv,
 )
-from aiosmtpd.testing.statuscodes import SMTP_STATUS_CODES as S
+from aiosmtpd.testing.statuscodes import StatusCode, SMTP_STATUS_CODES as S
 
 CRLF = "\r\n"
 BCRLF = b"\r\n"
@@ -64,7 +64,7 @@ B64EQUALS = b64encode(b"=").decode()
 # region #### Test Helpers ############################################################
 
 
-def auth_callback(mechanism, login, password) -> bool:
+def auth_callback(mechanism: str, login: bytes, password: bytes) -> bool:
     return login and login.decode() == "goodlogin"
 
 
@@ -152,7 +152,7 @@ class PeekerHandler:
     async def auth_DENYFALSE(self, server, args):
         return False
 
-    async def auth_NONE(self, server: Server, args):
+    async def auth_NONE(self, server: Server, args: List[str]):
         await server.push(S.S235_AUTH_SUCCESS.to_str())
         return None
 
@@ -162,7 +162,7 @@ class PeekerHandler:
     async def auth_DONT(self, server, args):
         return MISSING
 
-    async def auth_WITH_UNDERSCORE(self, server: Server, args) -> str:
+    async def auth_WITH_UNDERSCORE(self, server: Server, args: List[str]) -> str:
         """
         Be careful when using this AUTH mechanism; log_client_response is set to
         True, and this will raise some severe warnings.
@@ -196,10 +196,12 @@ class ErroringHandler:
     error = None
     custom_response = False
 
-    async def handle_DATA(self, server, session, envelope) -> str:
+    async def handle_DATA(
+        self, server: Server, session: SMTPSession, envelope: SMTPEnvelope
+    ) -> str:
         return "499 Could not accept the message"
 
-    async def handle_exception(self, error) -> str:
+    async def handle_exception(self, error: Exception) -> str:
         self.error = error
         if not self.custom_response:
             return "500 ErroringHandler handling error"
@@ -970,7 +972,7 @@ class TestSMTPAuth(_CommonMethods):
 class TestAuthMechanisms(_CommonMethods):
     @pytest.fixture
     def do_auth_plain1(
-        self, client
+        self, client: SMTPClient
     ) -> Callable[[str], Tuple[int, bytes]]:
         self._ehlo(client)
 
@@ -982,7 +984,7 @@ class TestAuthMechanisms(_CommonMethods):
 
     @pytest.fixture
     def do_auth_login3(
-        self, client
+        self, client: SMTPClient
     ) -> Callable[[str], Tuple[int, bytes]]:
         self._ehlo(client)
         resp = client.docmd("AUTH LOGIN")
@@ -1109,7 +1111,7 @@ class TestAuthMechanisms(_CommonMethods):
         assert_nopassleak(PW, caplog.record_tuples)
 
     @pytest.fixture
-    def client_auth_plain2(self, client) -> SMTPClient:
+    def client_auth_plain2(self, client: SMTPClient) -> SMTPClient:
         self._ehlo(client)
         resp = client.docmd("AUTH PLAIN")
         assert resp == S.S334_AUTH_EMPTYPROMPT
@@ -1604,7 +1606,9 @@ class TestSMTPWithController(_CommonMethods):
             client.sendmail("anne@example.com", ["bart@example.com"], mail)
         assert exc.value.args == S.S500_DATALINE_TOO_LONG
 
-    def test_long_line_leak(self, mocker: MockFixture, plain_controller, client):
+    def test_long_line_leak(
+        self, mocker: MockFixture, plain_controller: Controller, client: SMTPClient
+    ):
         # Simulates situation where readuntil() does not raise LimitOverrunError,
         # but somehow the line_fragments when join()ed resulted in a too-long line
 
@@ -1720,7 +1724,7 @@ class TestCustomization(_CommonMethods):
 
 class TestClientCrash(_CommonMethods):
     def test_connection_reset_during_DATA(
-        self, mocker: MockFixture, plain_controller, client
+        self, mocker: MockFixture, plain_controller: Controller, client: SMTPClient
     ):
         # Trigger factory() to produce the smtpd server
         self._helo(client)
@@ -1748,7 +1752,7 @@ class TestClientCrash(_CommonMethods):
             plain_controller.stop()
 
     def test_connection_reset_during_command(
-        self, mocker: MockFixture, plain_controller, client
+        self, mocker: MockFixture, plain_controller: Controller, client: SMTPClient
     ):
         # Trigger factory() to produce the smtpd server
         self._helo(client)
@@ -1789,7 +1793,9 @@ class TestClientCrash(_CommonMethods):
         # and still == True if transport is closed.
         assert writer.transport.is_closing()
 
-    def test_close_in_command_2(self, mocker: MockFixture, plain_controller, client):
+    def test_close_in_command_2(
+        self, mocker: MockFixture, plain_controller: Controller, client: SMTPClient
+    ):
         self._helo(client)
         catchup_delay()
         smtpd: Server = plain_controller.smtpd
@@ -1817,7 +1823,9 @@ class TestClientCrash(_CommonMethods):
         # and still == True if transport is closed.
         assert writer.transport.is_closing()
 
-    def test_close_in_data(self, mocker: MockFixture, plain_controller, client):
+    def test_close_in_data(
+        self, mocker: MockFixture, plain_controller: Controller, client: SMTPClient
+    ):
         self._helo(client)
         smtpd: Server = plain_controller.smtpd
         writer = smtpd._writer
@@ -1843,7 +1851,9 @@ class TestClientCrash(_CommonMethods):
         finally:
             plain_controller.stop()
 
-    def test_sockclose_after_helo(self, mocker: MockFixture, plain_controller, client):
+    def test_sockclose_after_helo(
+        self, mocker: MockFixture, plain_controller: Controller, client: SMTPClient
+    ):
         client.send("HELO example.com\r\n")
         catchup_delay()
         smtpd: Server = plain_controller.smtpd
@@ -1966,7 +1976,12 @@ class TestAuthArgs:
 
 class TestLimits(_CommonMethods):
     def _consume_budget(
-        self, client: SMTPClient, nums: int, cmd: str, *args, ok_expected=None
+        self,
+        client: SMTPClient,
+        nums: int,
+        cmd: str,
+        *args,
+        ok_expected: Optional[StatusCode] = None
     ):
         code, _ = client.ehlo("example.com")
         assert code == 250

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -81,7 +81,7 @@ def assert_nopassleak(passwd: str, record_tuples: List[Tuple[str, int, str]]) ->
 
 
 class UndescribableError(Exception):
-    def __str__(self):
+    def __str__(self) -> str:
         raise Exception()
 
 

--- a/aiosmtpd/tests/test_smtp.py
+++ b/aiosmtpd/tests/test_smtp.py
@@ -146,20 +146,20 @@ class PeekerHandler:
         self.sess = session
         return S.S250_OK.to_str()
 
-    async def auth_DENYMISSING(self, server, args):
+    async def auth_DENYMISSING(self, server: Server, args: List[str]):
         return MISSING
 
-    async def auth_DENYFALSE(self, server, args):
+    async def auth_DENYFALSE(self, server: Server, args: List[str]):
         return False
 
     async def auth_NONE(self, server: Server, args: List[str]):
         await server.push(S.S235_AUTH_SUCCESS.to_str())
         return None
 
-    async def auth_NULL(self, server, args):
+    async def auth_NULL(self, server: Server, args: List[str]):
         return "NULL_login"
 
-    async def auth_DONT(self, server, args):
+    async def auth_DONT(self, server: Server, args: List[str]):
         return MISSING
 
     async def auth_WITH_UNDERSCORE(self, server: Server, args: List[str]) -> str:
@@ -173,10 +173,10 @@ class PeekerHandler:
         return "250 OK"
 
     @auth_mechanism("with-dash")
-    async def auth_WITH_DASH(self, server, args):
+    async def auth_WITH_DASH(self, server: Server, args: List[str]):
         return "250 OK"
 
-    async def auth_WITH__MULTI__DASH(self, server, args):
+    async def auth_WITH__MULTI__DASH(self, server: Server, args: List[str]):
         return "250 OK"
 
 
@@ -214,10 +214,10 @@ class ErroringHandler:
 class ErroringHandlerConnectionLost:
     error = None
 
-    async def handle_DATA(self, server, session, envelope):
+    async def handle_DATA(self, server: Server, session: SMTPSession, envelope: SMTPEnvelope):
         raise ConnectionResetError("ErroringHandlerConnectionLost test")
 
-    async def handle_exception(self, error):
+    async def handle_exception(self, error: Exception):
         self.error = error
 
 
@@ -418,7 +418,7 @@ class _CommonMethods:
 
 class TestProtocol:
     def test_honors_mail_delimiters(
-        self, temp_event_loop, transport_resp, get_protocol
+        self, temp_event_loop: asyncio.AbstractEventLoop, transport_resp: Tuple[Transport, list], get_protocol: Callable
     ):
         handler = ReceivingHandler()
         protocol = get_protocol(handler)
@@ -442,7 +442,7 @@ class TestProtocol:
         assert len(handler.box) == 1
         assert handler.box[0].content == data
 
-    def test_empty_email(self, temp_event_loop, transport_resp, get_protocol):
+    def test_empty_email(self, temp_event_loop: asyncio.AbstractEventLoop, transport_resp: Tuple[Transport, list], get_protocol: Callable):
         handler = ReceivingHandler()
         protocol = get_protocol(handler)
         protocol.data_received(
@@ -537,31 +537,31 @@ class TestSMTP(_CommonMethods):
     ]
 
     @pytest.mark.parametrize("data", [b"\x80FAIL\r\n", b"\x80 FAIL\r\n"])
-    def test_binary(self, client, data):
+    def test_binary(self, client: SMTPClient, data: bytes):
         client.sock.send(data)
         assert client.getreply() == S.S500_BAD_SYNTAX
 
-    def test_helo(self, client):
+    def test_helo(self, client: SMTPClient):
         resp = client.helo("example.com")
         assert resp == S.S250_FQDN
 
-    def test_close_then_continue(self, client):
+    def test_close_then_continue(self, client: SMTPClient):
         self._helo(client)
         client.close()
         client.connect(*Global.SrvAddr)
         resp = client.docmd("MAIL FROM: <anne@example.com>")
         assert resp == S.S503_HELO_FIRST
 
-    def test_helo_no_hostname(self, client):
+    def test_helo_no_hostname(self, client: SMTPClient):
         client.local_hostname = ""
         resp = client.helo("")
         assert resp == S.S501_SYNTAX_HELO
 
-    def test_helo_duplicate(self, client):
+    def test_helo_duplicate(self, client: SMTPClient):
         self._helo(client, "example.org")
         self._helo(client, "example.com")
 
-    def test_ehlo(self, client):
+    def test_ehlo(self, client: SMTPClient):
         code, mesg = client.ehlo("example.com")
         lines = mesg.splitlines()
         assert lines == [
@@ -571,41 +571,41 @@ class TestSMTP(_CommonMethods):
             b"HELP",
         ]
 
-    def test_ehlo_duplicate(self, client):
+    def test_ehlo_duplicate(self, client: SMTPClient):
         self._ehlo(client, "example.com")
         self._ehlo(client, "example.org")
 
-    def test_ehlo_no_hostname(self, client):
+    def test_ehlo_no_hostname(self, client: SMTPClient):
         client.local_hostname = ""
         resp = client.ehlo("")
         assert resp == S.S501_SYNTAX_EHLO
 
-    def test_helo_then_ehlo(self, client):
+    def test_helo_then_ehlo(self, client: SMTPClient):
         self._helo(client, "example.com")
         self._ehlo(client, "example.org")
 
-    def test_ehlo_then_helo(self, client):
+    def test_ehlo_then_helo(self, client: SMTPClient):
         self._ehlo(client, "example.org")
         self._helo(client, "example.com")
 
-    def test_noop(self, client):
+    def test_noop(self, client: SMTPClient):
         resp = client.noop()
         assert resp == S.S250_OK
 
-    def test_noop_with_arg(self, plain_controller, client):
+    def test_noop_with_arg(self, plain_controller: Controller, client: SMTPClient):
         # smtplib.SMTP.noop() doesn't accept args
         resp = client.docmd("NOOP ok")
         assert resp == S.S250_OK
 
-    def test_quit(self, client):
+    def test_quit(self, client: SMTPClient):
         resp = client.quit()
         assert resp == S.S221_BYE
 
-    def test_quit_with_args(self, client):
+    def test_quit_with_args(self, client: SMTPClient):
         resp = client.docmd("QUIT oops")
         assert resp == S.S501_SYNTAX_QUIT
 
-    def test_help(self, client):
+    def test_help(self, client: SMTPClient):
         resp = client.docmd("HELP")
         assert resp == S.S250_SUPPCMD_NOTLS
 
@@ -624,7 +624,7 @@ class TestSMTP(_CommonMethods):
             "AUTH",
         ],
     )
-    def test_help_(self, client, command):
+    def test_help_(self, client: SMTPClient, command: str):
         resp = client.docmd(f"HELP {command}")
         syntax = getattr(S, f"S250_SYNTAX_{command}")
         assert resp == syntax
@@ -636,17 +636,17 @@ class TestSMTP(_CommonMethods):
             "RCPT",
         ],
     )
-    def test_help_esmtp(self, client, command):
+    def test_help_esmtp(self, client: SMTPClient, command: str):
         self._ehlo(client)
         resp = client.docmd(f"HELP {command}")
         syntax = getattr(S, f"S250_SYNTAX_{command}_E")
         assert resp == syntax
 
-    def test_help_bad_arg(self, client):
+    def test_help_bad_arg(self, client: SMTPClient):
         resp = client.docmd("HELP me!")
         assert resp == S.S501_SUPPCMD_NOTLS
 
-    def test_expn(self, client):
+    def test_expn(self, client: SMTPClient):
         resp = client.expn("anne@example.com")
         assert resp == S.S502_EXPN_NOTIMPL
 
@@ -655,7 +655,7 @@ class TestSMTP(_CommonMethods):
         ["MAIL FROM: <anne@example.com>", "RCPT TO: <anne@example.com>", "DATA"],
         ids=lambda x: x.split()[0],
     )
-    def test_no_helo(self, client, command):
+    def test_no_helo(self, client: SMTPClient, command: str):
         resp = client.docmd(command)
         assert resp == S.S503_HELO_FIRST
 
@@ -664,7 +664,7 @@ class TestSMTP(_CommonMethods):
         valid_mailfrom_addresses,
         ids=itertools.count(),
     )
-    def test_mail_valid_address(self, client, address):
+    def test_mail_valid_address(self, client: SMTPClient, address: str):
         self._ehlo(client)
         resp = client.docmd(f"MAIL FROM:{address}")
         assert resp == S.S250_OK
@@ -680,7 +680,7 @@ class TestSMTP(_CommonMethods):
         ],
         ids=["noarg", "nofrom", "noaddr", "params_noesmtp", "malformed"],
     )
-    def test_mail_smtp_errsyntax(self, client, command):
+    def test_mail_smtp_errsyntax(self, client: SMTPClient, command: str):
         self._helo(client)
         resp = client.docmd(command)
         assert resp == S.S501_SYNTAX_MAIL
@@ -694,12 +694,12 @@ class TestSMTP(_CommonMethods):
         ],
         ids=["norm", "extralead", "extratail"],
     )
-    def test_mail_params_esmtp(self, client, param):
+    def test_mail_params_esmtp(self, client: SMTPClient, param: str):
         self._ehlo(client)
         resp = client.docmd("MAIL FROM: <anne@example.com> " + param)
         assert resp == S.S250_OK
 
-    def test_mail_from_twice(self, client):
+    def test_mail_from_twice(self, client: SMTPClient):
         self._helo(client)
         resp = client.docmd("MAIL FROM: <anne@example.com>")
         assert resp == S.S250_OK
@@ -716,17 +716,17 @@ class TestSMTP(_CommonMethods):
         ],
         ids=["malformed", "missing", "badsyntax", "space"],
     )
-    def test_mail_esmtp_errsyntax(self, client, command):
+    def test_mail_esmtp_errsyntax(self, client: SMTPClient, command: str):
         self._ehlo(client)
         resp = client.docmd(command)
         assert resp == S.S501_SYNTAX_MAIL_E
 
-    def test_mail_esmtp_params_unrecognized(self, client):
+    def test_mail_esmtp_params_unrecognized(self, client: SMTPClient):
         self._ehlo(client)
         resp = client.docmd("MAIL FROM: <anne@example.com> FOO=BAR")
         assert resp == S.S555_MAIL_PARAMS_UNRECOG
 
-    def test_bpo27931fix_smtp(self, client):
+    def test_bpo27931fix_smtp(self, client: SMTPClient):
         self._helo(client)
         resp = client.docmd('MAIL FROM: <""@example.com>')
         assert resp == S.S250_OK
@@ -738,18 +738,18 @@ class TestSMTP(_CommonMethods):
         invalid_email_addresses,
         ids=itertools.count(),
     )
-    def test_mail_invalid_address(self, client, address):
+    def test_mail_invalid_address(self, client: SMTPClient, address: str):
         self._helo(client)
         resp = client.docmd(f"MAIL FROM: {address}")
         assert resp == S.S553_MALFORMED
 
     @pytest.mark.parametrize("address", invalid_email_addresses, ids=itertools.count())
-    def test_mail_esmtp_invalid_address(self, client, address):
+    def test_mail_esmtp_invalid_address(self, client: SMTPClient, address: str):
         self._ehlo(client)
         resp = client.docmd(f"MAIL FROM: {address} SIZE=28113")
         assert resp == S.S553_MALFORMED
 
-    def test_rcpt_no_mail(self, client):
+    def test_rcpt_no_mail(self, client: SMTPClient):
         self._helo(client)
         resp = client.docmd("RCPT TO: <anne@example.com>")
         assert resp == S.S503_MAIL_NEEDED
@@ -765,7 +765,7 @@ class TestSMTP(_CommonMethods):
         ],
         ids=["noarg", "noto", "noaddr", "params", "malformed"],
     )
-    def test_rcpt_smtp_errsyntax(self, client, command):
+    def test_rcpt_smtp_errsyntax(self, client: SMTPClient, command: str):
         self._helo(client)
         resp = client.docmd("MAIL FROM: <anne@example.com>")
         assert resp == S.S250_OK
@@ -783,14 +783,14 @@ class TestSMTP(_CommonMethods):
         ],
         ids=["noarg", "noto", "noaddr", "badparams", "malformed"],
     )
-    def test_rcpt_esmtp_errsyntax(self, client, command):
+    def test_rcpt_esmtp_errsyntax(self, client: SMTPClient, command: str):
         self._ehlo(client)
         resp = client.docmd("MAIL FROM: <anne@example.com>")
         assert resp == S.S250_OK
         resp = client.docmd(command)
         assert resp == S.S501_SYNTAX_RCPT_E
 
-    def test_rcpt_unknown_params(self, client):
+    def test_rcpt_unknown_params(self, client: SMTPClient):
         self._ehlo(client)
         resp = client.docmd("MAIL FROM: <anne@example.com>")
         assert resp == S.S250_OK
@@ -798,7 +798,7 @@ class TestSMTP(_CommonMethods):
         assert resp == S.S555_RCPT_PARAMS_UNRECOG
 
     @pytest.mark.parametrize("address", valid_rcptto_addresses, ids=itertools.count())
-    def test_rcpt_valid_address(self, client, address):
+    def test_rcpt_valid_address(self, client: SMTPClient, address: str):
         self._ehlo(client)
         resp = client.docmd("MAIL FROM: <anne@example.com>")
         assert resp == S.S250_OK
@@ -806,46 +806,46 @@ class TestSMTP(_CommonMethods):
         assert resp == S.S250_OK
 
     @pytest.mark.parametrize("address", invalid_email_addresses, ids=itertools.count())
-    def test_rcpt_invalid_address(self, client, address):
+    def test_rcpt_invalid_address(self, client: SMTPClient, address: str):
         self._ehlo(client)
         resp = client.docmd("MAIL FROM: <anne@example.com>")
         assert resp == S.S250_OK
         resp = client.docmd(f"RCPT TO: {address}")
         assert resp == S.S553_MALFORMED
 
-    def test_bpo27931fix_esmtp(self, client):
+    def test_bpo27931fix_esmtp(self, client: SMTPClient):
         self._ehlo(client)
         resp = client.docmd('MAIL FROM: <""@example.com> SIZE=28113')
         assert resp == S.S250_OK
         resp = client.docmd('RCPT TO: <""@example.org>')
         assert resp == S.S250_OK
 
-    def test_rset(self, client):
+    def test_rset(self, client: SMTPClient):
         resp = client.rset()
         assert resp == S.S250_OK
 
-    def test_rset_with_arg(self, client):
+    def test_rset_with_arg(self, client: SMTPClient):
         resp = client.docmd("RSET FOO")
         assert resp == S.S501_SYNTAX_RSET
 
-    def test_vrfy(self, client):
+    def test_vrfy(self, client: SMTPClient):
         resp = client.docmd("VRFY <anne@example.com>")
         assert resp == S.S252_CANNOT_VRFY
 
-    def test_vrfy_no_arg(self, client):
+    def test_vrfy_no_arg(self, client: SMTPClient):
         resp = client.docmd("VRFY")
         assert resp == S.S501_SYNTAX_VRFY
 
-    def test_vrfy_not_address(self, client):
+    def test_vrfy_not_address(self, client: SMTPClient):
         resp = client.docmd("VRFY @@")
         assert resp == S.S502_VRFY_COULDNT(b"@@")
 
-    def test_data_no_rcpt(self, client):
+    def test_data_no_rcpt(self, client: SMTPClient):
         self._helo(client)
         resp = client.docmd("DATA")
         assert resp == S.S503_RCPT_NEEDED
 
-    def test_data_354(self, plain_controller, client):
+    def test_data_354(self, plain_controller: Controller, client: SMTPClient):
         self._helo(client)
         resp = client.docmd("MAIL FROM: <alice@example.org>")
         assert resp == S.S250_OK
@@ -860,7 +860,7 @@ class TestSMTP(_CommonMethods):
         finally:
             plain_controller.stop()
 
-    def test_data_invalid_params(self, client):
+    def test_data_invalid_params(self, client: SMTPClient):
         self._helo(client)
         resp = client.docmd("MAIL FROM: <anne@example.com>")
         assert resp == S.S250_OK
@@ -869,15 +869,15 @@ class TestSMTP(_CommonMethods):
         resp = client.docmd("DATA FOOBAR")
         assert resp == S.S501_SYNTAX_DATA
 
-    def test_empty_command(self, client):
+    def test_empty_command(self, client: SMTPClient):
         resp = client.docmd("")
         assert resp == S.S500_BAD_SYNTAX
 
-    def test_too_long_command(self, client):
+    def test_too_long_command(self, client: SMTPClient):
         resp = client.docmd("a" * 513)
         assert resp == S.S500_CMD_TOO_LONG
 
-    def test_way_too_long_command(self, client):
+    def test_way_too_long_command(self, client: SMTPClient):
         # Send a very large string to ensure it is broken
         # into several packets, which hits the inner
         # LimitOverrunError code path in _handle_client.
@@ -887,14 +887,14 @@ class TestSMTP(_CommonMethods):
         response = client.docmd("NOOP")
         assert response == S.S250_OK
 
-    def test_unknown_command(self, client):
+    def test_unknown_command(self, client: SMTPClient):
         resp = client.docmd("FOOBAR")
         assert resp == S.S500_CMD_UNRECOG(b"FOOBAR")
 
 
 class TestSMTPNonDecoding(_CommonMethods):
     @controller_data(decode_data=False)
-    def test_mail_invalid_body_param(self, plain_controller, client):
+    def test_mail_invalid_body_param(self, plain_controller: Controller, client: SMTPClient):
         self._ehlo(client)
         resp = client.docmd("MAIL FROM: <anne@example.com> BODY=FOOBAR")
         assert resp == S.S501_MAIL_BODY
@@ -902,21 +902,21 @@ class TestSMTPNonDecoding(_CommonMethods):
 
 @pytest.mark.usefixtures("decoding_authnotls_controller")
 class TestSMTPAuth(_CommonMethods):
-    def test_no_ehlo(self, client):
+    def test_no_ehlo(self, client: SMTPClient):
         resp = client.docmd("AUTH")
         assert resp == S.S503_EHLO_FIRST
 
-    def test_helo(self, client):
+    def test_helo(self, client: SMTPClient):
         self._helo(client)
         resp = client.docmd("AUTH")
         assert resp == S.S500_AUTH_UNRECOG
 
-    def test_not_enough_values(self, client):
+    def test_not_enough_values(self, client: SMTPClient):
         self._ehlo(client)
         resp = client.docmd("AUTH")
         assert resp == S.S501_TOO_FEW
 
-    def test_already_authenticated(self, caplog, client):
+    def test_already_authenticated(self, caplog: pytest.LogCaptureFixture, client: SMTPClient):
         PW = "goodpasswd"
         self._ehlo(client)
         resp = client.docmd(
@@ -929,7 +929,7 @@ class TestSMTPAuth(_CommonMethods):
         assert resp == S.S250_OK
         assert_nopassleak(PW, caplog.record_tuples)
 
-    def test_auth_individually(self, caplog, client):
+    def test_auth_individually(self, caplog: pytest.LogCaptureFixture, client: SMTPClient):
         """AUTH state of different clients must be independent"""
         PW = "goodpasswd"
         client1 = client
@@ -940,7 +940,7 @@ class TestSMTPAuth(_CommonMethods):
                 assert resp == S.S235_AUTH_SUCCESS
         assert_nopassleak(PW, caplog.record_tuples)
 
-    def test_rset_maintain_authenticated(self, caplog, client):
+    def test_rset_maintain_authenticated(self, caplog: pytest.LogCaptureFixture, client: SMTPClient):
         """RSET resets only Envelope not Session"""
         PW = "goodpasswd"
         self._ehlo(client, "example.com")
@@ -955,7 +955,7 @@ class TestSMTPAuth(_CommonMethods):
         assert_nopassleak(PW, caplog.record_tuples)
 
     @handler_data(class_=PeekerHandler)
-    def test_auth_loginteract_warning(self, client):
+    def test_auth_loginteract_warning(self, client: SMTPClient):
         client.ehlo("example.com")
         resp = client.docmd("AUTH WITH_UNDERSCORE")
         assert resp == (334, b"challenge")
@@ -996,7 +996,7 @@ class TestAuthMechanisms(_CommonMethods):
         do.client = client
         return do
 
-    def test_ehlo(self, client):
+    def test_ehlo(self, client: SMTPClient):
         code, mesg = client.ehlo("example.com")
         assert code == 250
         lines = mesg.splitlines()
@@ -1012,17 +1012,17 @@ class TestAuthMechanisms(_CommonMethods):
         ]
 
     @pytest.mark.parametrize("mechanism", ["GSSAPI", "DIGEST-MD5", "MD5", "CRAM-MD5"])
-    def test_not_supported_mechanism(self, client, mechanism):
+    def test_not_supported_mechanism(self, client: SMTPClient, mechanism: str):
         self._ehlo(client)
         resp = client.docmd("AUTH " + mechanism)
         assert resp == S.S504_AUTH_UNRECOG
 
-    def test_custom_mechanism(self, client):
+    def test_custom_mechanism(self, client: SMTPClient):
         self._ehlo(client)
         resp = client.docmd("AUTH NULL")
         assert resp == S.S235_AUTH_SUCCESS
 
-    def test_disabled_mechanism(self, client):
+    def test_disabled_mechanism(self, client: SMTPClient):
         self._ehlo(client)
         resp = client.docmd("AUTH DONT")
         assert resp == S.S504_AUTH_UNRECOG
@@ -1030,7 +1030,7 @@ class TestAuthMechanisms(_CommonMethods):
     @pytest.mark.parametrize("init_resp", [True, False])
     @pytest.mark.parametrize("mechanism", ["login", "plain"])
     def test_byclient(
-        self, caplog, auth_peeker_controller, client, mechanism, init_resp
+        self, caplog: pytest.LogCaptureFixture, auth_peeker_controller: Controller, client: SMTPClient, mechanism: str, init_resp: bool
     ):
         self._ehlo(client)
         PW = "goodpasswd"
@@ -1054,32 +1054,32 @@ class TestAuthMechanisms(_CommonMethods):
         assert peeker.password == PW.encode("ascii")
         assert_nopassleak(PW, caplog.record_tuples)
 
-    def test_plain1_bad_base64_encoding(self, do_auth_plain1):
+    def test_plain1_bad_base64_encoding(self, do_auth_plain1: Callable):
         resp = do_auth_plain1("not-b64")
         assert resp == S.S501_AUTH_NOTB64
 
-    def test_plain1_bad_base64_length(self, do_auth_plain1):
+    def test_plain1_bad_base64_length(self, do_auth_plain1: Callable):
         resp = do_auth_plain1(b64encode(b"\0onlylogin").decode())
         assert resp == S.S501_AUTH_CANTSPLIT
 
-    def test_plain1_too_many_values(self, do_auth_plain1):
+    def test_plain1_too_many_values(self, do_auth_plain1: Callable):
         resp = do_auth_plain1("NONE NONE")
         assert resp == S.S501_TOO_MANY
 
-    def test_plain1_bad_username(self, do_auth_plain1):
+    def test_plain1_bad_username(self, do_auth_plain1: Callable):
         resp = do_auth_plain1(b64encode(b"\0badlogin\0goodpasswd").decode())
         assert resp == S.S535_AUTH_INVALID
 
-    def test_plain1_bad_password(self, do_auth_plain1):
+    def test_plain1_bad_password(self, do_auth_plain1: Callable):
         resp = do_auth_plain1(b64encode(b"\0goodlogin\0badpasswd").decode())
         assert resp == S.S535_AUTH_INVALID
 
-    def test_plain1_empty(self, do_auth_plain1):
+    def test_plain1_empty(self, do_auth_plain1: Callable):
         resp = do_auth_plain1(B64EQUALS)
         assert resp == S.S501_AUTH_CANTSPLIT
 
     def test_plain1_good_credentials(
-        self, caplog, auth_peeker_controller, do_auth_plain1
+        self, caplog: pytest.LogCaptureFixture, auth_peeker_controller: Controller, do_auth_plain1: Callable
     ):
         PW = "goodpasswd"
         PWb = PW.encode("ascii")
@@ -1094,7 +1094,7 @@ class TestAuthMechanisms(_CommonMethods):
         assert resp == S.S250_OK
         assert_nopassleak(PW, caplog.record_tuples)
 
-    def test_plain1_goodcreds_sanitized_log(self, caplog, client):
+    def test_plain1_goodcreds_sanitized_log(self, caplog: pytest.LogCaptureFixture, client: SMTPClient):
         caplog.set_level("DEBUG")
         client.ehlo("example.com")
         PW = "goodpasswd"
@@ -1118,7 +1118,7 @@ class TestAuthMechanisms(_CommonMethods):
         return client
 
     def test_plain2_good_credentials(
-        self, caplog, auth_peeker_controller, client_auth_plain2
+        self, caplog: pytest.LogCaptureFixture, auth_peeker_controller: Controller, client_auth_plain2: SMTPClient
     ):
         PW = "goodpasswd"
         PWb = PW.encode("ascii")
@@ -1132,28 +1132,28 @@ class TestAuthMechanisms(_CommonMethods):
         assert resp == S.S250_OK
         assert_nopassleak(PW, caplog.record_tuples)
 
-    def test_plain2_bad_credentials(self, client_auth_plain2):
+    def test_plain2_bad_credentials(self, client_auth_plain2: SMTPClient):
         resp = client_auth_plain2.docmd(b64encode(b"\0badlogin\0badpasswd").decode())
         assert resp == S.S535_AUTH_INVALID
 
-    def test_plain2_no_credentials(self, client_auth_plain2):
+    def test_plain2_no_credentials(self, client_auth_plain2: SMTPClient):
         resp = client_auth_plain2.docmd(B64EQUALS)
         assert resp == S.S501_AUTH_CANTSPLIT
 
-    def test_plain2_abort(self, client_auth_plain2):
+    def test_plain2_abort(self, client_auth_plain2: SMTPClient):
         resp = client_auth_plain2.docmd("*")
         assert resp == S.S501_AUTH_ABORTED
 
-    def test_plain2_bad_base64_encoding(self, client_auth_plain2):
+    def test_plain2_bad_base64_encoding(self, client_auth_plain2: SMTPClient):
         resp = client_auth_plain2.docmd("ab@%")
         assert resp == S.S501_AUTH_NOTB64
 
-    def test_login2_bad_base64(self, auth_peeker_controller, client):
+    def test_login2_bad_base64(self, auth_peeker_controller: Controller, client: SMTPClient):
         self._ehlo(client)
         resp = client.docmd("AUTH LOGIN ab@%")
         assert resp == S.S501_AUTH_NOTB64
 
-    def test_login2_good_credentials(self, caplog, auth_peeker_controller, client):
+    def test_login2_good_credentials(self, caplog: pytest.LogCaptureFixture, auth_peeker_controller: Controller, client: SMTPClient):
         self._ehlo(client)
         PW = "goodpasswd"
         PWb = PW.encode("ascii")
@@ -1172,7 +1172,7 @@ class TestAuthMechanisms(_CommonMethods):
         assert_nopassleak(PW, caplog.record_tuples)
 
     def test_login3_good_credentials(
-        self, caplog, auth_peeker_controller, do_auth_login3
+        self, caplog: pytest.LogCaptureFixture, auth_peeker_controller: Controller, do_auth_login3: Callable
     ):
         PW = "goodpasswd"
         PWb = PW.encode("ascii")
@@ -1189,49 +1189,49 @@ class TestAuthMechanisms(_CommonMethods):
         assert resp == S.S250_OK
         assert_nopassleak(PW, caplog.record_tuples)
 
-    def test_login3_bad_base64(self, do_auth_login3):
+    def test_login3_bad_base64(self, do_auth_login3: Callable):
         resp = do_auth_login3("not-b64")
         assert resp == S.S501_AUTH_NOTB64
 
-    def test_login3_bad_username(self, do_auth_login3):
+    def test_login3_bad_username(self, do_auth_login3: Callable):
         resp = do_auth_login3(b64encode(b"badlogin").decode())
         assert resp == S.S334_AUTH_PASSWORD
         resp = do_auth_login3(b64encode(b"goodpasswd").decode())
         assert resp == S.S535_AUTH_INVALID
 
-    def test_login3_bad_password(self, do_auth_login3):
+    def test_login3_bad_password(self, do_auth_login3: Callable):
         resp = do_auth_login3(b64encode(b"goodlogin").decode())
         assert resp == S.S334_AUTH_PASSWORD
         resp = do_auth_login3(b64encode(b"badpasswd").decode())
         assert resp == S.S535_AUTH_INVALID
 
-    def test_login3_empty_credentials(self, do_auth_login3):
+    def test_login3_empty_credentials(self, do_auth_login3: Callable):
         resp = do_auth_login3(B64EQUALS)
         assert resp == S.S334_AUTH_PASSWORD
         resp = do_auth_login3(B64EQUALS)
         assert resp == S.S535_AUTH_INVALID
 
-    def test_login3_abort_username(self, do_auth_login3):
+    def test_login3_abort_username(self, do_auth_login3: Callable):
         resp = do_auth_login3("*")
         assert resp == S.S501_AUTH_ABORTED
 
-    def test_login3_abort_password(self, do_auth_login3):
+    def test_login3_abort_password(self, do_auth_login3: Callable):
         resp = do_auth_login3(B64EQUALS)
         assert resp == S.S334_AUTH_PASSWORD
         resp = do_auth_login3("*")
         assert resp == S.S501_AUTH_ABORTED
 
-    def test_DENYFALSE(self, client):
+    def test_DENYFALSE(self, client: SMTPClient):
         self._ehlo(client)
         resp = client.docmd("AUTH DENYFALSE")
         assert resp == S.S535_AUTH_INVALID
 
-    def test_DENYMISSING(self, client):
+    def test_DENYMISSING(self, client: SMTPClient):
         self._ehlo(client)
         resp = client.docmd("AUTH DENYMISSING")
         assert resp == S.S535_AUTH_INVALID
 
-    def test_NONE(self, client):
+    def test_NONE(self, client: SMTPClient):
         self._ehlo(client)
         resp = client.docmd("AUTH NONE")
         assert resp == S.S235_AUTH_SUCCESS
@@ -1239,7 +1239,7 @@ class TestAuthMechanisms(_CommonMethods):
 
 # noinspection HardcodedPassword
 class TestAuthenticator(_CommonMethods):
-    def test_success(self, caplog, authenticator_peeker_controller, client):
+    def test_success(self, caplog: pytest.LogCaptureFixture, authenticator_peeker_controller: Controller, client: SMTPClient):
         PW = "goodpasswd"
         client.user = "gooduser"
         client.password = PW
@@ -1254,7 +1254,7 @@ class TestAuthenticator(_CommonMethods):
         assert auth_peeker.login_data == (b"gooduser", PW.encode("ascii"))
         assert_nopassleak(PW, caplog.record_tuples)
 
-    def test_fail_withmesg(self, caplog, authenticator_peeker_controller, client):
+    def test_fail_withmesg(self, caplog: pytest.LogCaptureFixture, authenticator_peeker_controller: Controller, client: SMTPClient):
         PW = "anypass"
         client.user = "failme_with454"
         client.password = PW
@@ -1286,56 +1286,56 @@ class TestRequiredAuthentication(_CommonMethods):
         resp = client.login("goodlogin", "goodpasswd")
         assert resp == S.S235_AUTH_SUCCESS
 
-    def test_help_unauthenticated(self, client):
+    def test_help_unauthenticated(self, client: SMTPClient):
         resp = client.docmd("HELP")
         assert resp == S.S530_AUTH_REQUIRED
 
-    def test_help_authenticated(self, client):
+    def test_help_authenticated(self, client: SMTPClient):
         self._login(client)
         resp = client.docmd("HELP")
         assert resp == S.S250_SUPPCMD_NOTLS
 
-    def test_vrfy_unauthenticated(self, client):
+    def test_vrfy_unauthenticated(self, client: SMTPClient):
         resp = client.docmd("VRFY <anne@example.com>")
         assert resp == S.S530_AUTH_REQUIRED
 
-    def test_mail_unauthenticated(self, client):
+    def test_mail_unauthenticated(self, client: SMTPClient):
         self._ehlo(client)
         resp = client.docmd("MAIL FROM: <anne@example.com>")
         assert resp == S.S530_AUTH_REQUIRED
 
-    def test_rcpt_unauthenticated(self, client):
+    def test_rcpt_unauthenticated(self, client: SMTPClient):
         self._ehlo(client)
         resp = client.docmd("RCPT TO: <anne@example.com>")
         assert resp == S.S530_AUTH_REQUIRED
 
-    def test_rcpt_nomail_authenticated(self, client):
+    def test_rcpt_nomail_authenticated(self, client: SMTPClient):
         self._login(client)
         resp = client.docmd("RCPT TO: <anne@example.com>")
         assert resp == S.S503_MAIL_NEEDED
 
-    def test_data_unauthenticated(self, client):
+    def test_data_unauthenticated(self, client: SMTPClient):
         self._ehlo(client)
         resp = client.docmd("DATA")
         assert resp == S.S530_AUTH_REQUIRED
 
-    def test_data_authenticated(self, client):
+    def test_data_authenticated(self, client: SMTPClient):
         self._ehlo(client, "example.com")
         client.login("goodlogin", "goodpassword")
         resp = client.docmd("DATA")
         assert resp != S.S530_AUTH_REQUIRED
 
-    def test_vrfy_authenticated(self, client):
+    def test_vrfy_authenticated(self, client: SMTPClient):
         self._login(client)
         resp = client.docmd("VRFY <anne@example.com>")
         assert resp == S.S252_CANNOT_VRFY
 
-    def test_mail_authenticated(self, client):
+    def test_mail_authenticated(self, client: SMTPClient):
         self._login(client)
         resp = client.docmd("MAIL FROM: <anne@example.com>")
         assert resp, S.S250_OK
 
-    def test_data_norcpt_authenticated(self, client):
+    def test_data_norcpt_authenticated(self, client: SMTPClient):
         self._login(client)
         resp = client.docmd("DATA")
         assert resp == S.S503_RCPT_NEEDED
@@ -1371,7 +1371,7 @@ class TestResetCommands:
             client.rcpt(rcpt)
 
     @handler_data(class_=StoreEnvelopeOnVRFYHandler)
-    def test_helo(self, decoding_authnotls_controller, client):
+    def test_helo(self, decoding_authnotls_controller: Controller, client: SMTPClient):
         handler = decoding_authnotls_controller.handler
         assert isinstance(handler, StoreEnvelopeOnVRFYHandler)
         # Each time through the loop, the HELO will reset the envelope.
@@ -1387,7 +1387,7 @@ class TestResetCommands:
             assert handler.envelope.rcpt_tos == data["rcpt_tos"]
 
     @handler_data(class_=StoreEnvelopeOnVRFYHandler)
-    def test_ehlo(self, decoding_authnotls_controller, client):
+    def test_ehlo(self, decoding_authnotls_controller: Controller, client: SMTPClient):
         handler = decoding_authnotls_controller.handler
         assert isinstance(handler, StoreEnvelopeOnVRFYHandler)
         # Each time through the loop, the EHLO will reset the envelope.
@@ -1403,7 +1403,7 @@ class TestResetCommands:
             assert handler.envelope.rcpt_tos == data["rcpt_tos"]
 
     @handler_data(class_=StoreEnvelopeOnVRFYHandler)
-    def test_rset(self, decoding_authnotls_controller, client):
+    def test_rset(self, decoding_authnotls_controller: Controller, client: SMTPClient):
         handler = decoding_authnotls_controller.handler
         assert isinstance(handler, StoreEnvelopeOnVRFYHandler)
         client.helo("example.com")
@@ -1423,13 +1423,13 @@ class TestResetCommands:
 
 class TestSMTPWithController(_CommonMethods):
     @controller_data(data_size_limit=9999)
-    def test_mail_with_size_too_large(self, plain_controller, client):
+    def test_mail_with_size_too_large(self, plain_controller: Controller, client: SMTPClient):
         self._ehlo(client)
         resp = client.docmd("MAIL FROM: <anne@example.com> SIZE=10000")
         assert resp == S.S552_EXCEED_SIZE
 
     @handler_data(class_=ReceivingHandler)
-    def test_mail_with_compatible_smtputf8(self, plain_controller, client):
+    def test_mail_with_compatible_smtputf8(self, plain_controller: Controller, client: SMTPClient):
         receiving_handler = plain_controller.handler
         assert isinstance(receiving_handler, ReceivingHandler)
         sender = "anne\xCB@example.com"
@@ -1444,29 +1444,29 @@ class TestSMTPWithController(_CommonMethods):
         assert receiving_handler.box[0].mail_from == sender
         assert receiving_handler.box[0].rcpt_tos == [recipient]
 
-    def test_mail_with_unrequited_smtputf8(self, plain_controller, client):
+    def test_mail_with_unrequited_smtputf8(self, plain_controller: Controller, client: SMTPClient):
         self._ehlo(client)
         resp = client.docmd("MAIL FROM: <anne@example.com>")
         assert resp == S.S250_OK
 
-    def test_mail_with_incompatible_smtputf8(self, plain_controller, client):
+    def test_mail_with_incompatible_smtputf8(self, plain_controller: Controller, client: SMTPClient):
         self._ehlo(client)
         resp = client.docmd("MAIL FROM: <anne@example.com> SMTPUTF8=YES")
         assert resp == S.S501_SMTPUTF8_NOARG
 
-    def test_mail_invalid_body(self, plain_controller, client):
+    def test_mail_invalid_body(self, plain_controller: Controller, client: SMTPClient):
         self._ehlo(client)
         resp = client.docmd("MAIL FROM: <anne@example.com> BODY 9BIT")
         assert resp == S.S501_MAIL_BODY
 
     @controller_data(data_size_limit=None)
-    def test_esmtp_no_size_limit(self, plain_controller, client):
+    def test_esmtp_no_size_limit(self, plain_controller: Controller, client: SMTPClient):
         code, mesg = client.ehlo("example.com")
         for ln in mesg.splitlines():
             assert not ln.startswith(b"SIZE")
 
     @handler_data(class_=ErroringHandler)
-    def test_process_message_error(self, error_controller, client):
+    def test_process_message_error(self, error_controller: Controller, client: SMTPClient):
         self._ehlo(client)
         with pytest.raises(SMTPDataError) as excinfo:
             client.sendmail(
@@ -1485,7 +1485,7 @@ class TestSMTPWithController(_CommonMethods):
         assert excinfo.value.args == (499, b"Could not accept the message")
 
     @controller_data(data_size_limit=100)
-    def test_too_long_message_body(self, plain_controller, client):
+    def test_too_long_message_body(self, plain_controller: Controller, client: SMTPClient):
         self._helo(client)
         mail = "\r\n".join(["z" * 20] * 10)
         with pytest.raises(SMTPResponseException) as excinfo:
@@ -1493,7 +1493,7 @@ class TestSMTPWithController(_CommonMethods):
         assert excinfo.value.args == S.S552_DATA_TOO_MUCH
 
     @handler_data(class_=ReceivingHandler)
-    def test_dots_escaped(self, decoding_authnotls_controller, client):
+    def test_dots_escaped(self, decoding_authnotls_controller: Controller, client: SMTPClient):
         receiving_handler = decoding_authnotls_controller.handler
         assert isinstance(receiving_handler, ReceivingHandler)
         self._helo(client)
@@ -1503,21 +1503,21 @@ class TestSMTPWithController(_CommonMethods):
         assert receiving_handler.box[0].content == mail + CRLF
 
     @handler_data(class_=ErroringHandler)
-    def test_unexpected_errors(self, error_controller, client):
+    def test_unexpected_errors(self, error_controller: Controller, client: SMTPClient):
         handler = error_controller.handler
         resp = client.helo("example.com")
         assert resp == (500, b"ErroringHandler handling error")
         exception_type = ErrorSMTP.exception_type
         assert isinstance(handler.error, exception_type)
 
-    def test_unexpected_errors_unhandled(self, error_controller, client):
+    def test_unexpected_errors_unhandled(self, error_controller: Controller, client: SMTPClient):
         resp = client.helo("example.com")
         exception_type = ErrorSMTP.exception_type
         exception_nameb = exception_type.__name__.encode("ascii")
         assert resp == (500, b"Error: (" + exception_nameb + b") test")
 
     @handler_data(class_=ErroringHandler)
-    def test_unexpected_errors_custom_response(self, error_controller, client):
+    def test_unexpected_errors_custom_response(self, error_controller: Controller, client: SMTPClient):
         erroring_handler = error_controller.handler
         erroring_handler.custom_response = True
         resp = client.helo("example.com")
@@ -1527,7 +1527,7 @@ class TestSMTPWithController(_CommonMethods):
         assert resp == (451, b"Temporary error: (" + exception_nameb + b") test")
 
     @handler_data(class_=ErroringErrorHandler)
-    def test_exception_handler_exception(self, error_controller, client):
+    def test_exception_handler_exception(self, error_controller: Controller, client: SMTPClient):
         handler = error_controller.handler
         resp = client.helo("example.com")
         assert resp == (500, b"Error: (ValueError) ErroringErrorHandler test")
@@ -1535,7 +1535,7 @@ class TestSMTPWithController(_CommonMethods):
         assert isinstance(handler.error, exception_type)
 
     @handler_data(class_=UndescribableErrorHandler)
-    def test_exception_handler_undescribable(self, error_controller, client):
+    def test_exception_handler_undescribable(self, error_controller: Controller, client: SMTPClient):
         handler = error_controller.handler
         resp = client.helo("example.com")
         assert resp == (500, b"Error: Cannot describe error")
@@ -1544,7 +1544,7 @@ class TestSMTPWithController(_CommonMethods):
 
     @handler_data(class_=ErroringHandlerConnectionLost)
     def test_exception_handler_multiple_connections_lost(
-        self, error_controller, client
+        self, error_controller: Controller, client: SMTPClient
     ):
         client1 = client
         code, mesg = client1.ehlo("example.com")
@@ -1566,7 +1566,7 @@ class TestSMTPWithController(_CommonMethods):
         assert resp == S.S250_OK
 
     @handler_data(class_=ReceivingHandler)
-    def test_bad_encodings(self, decoding_authnotls_controller, client):
+    def test_bad_encodings(self, decoding_authnotls_controller: Controller, client: SMTPClient):
         handler: ReceivingHandler = decoding_authnotls_controller.handler
         self._helo(client)
         mail_from = b"anne\xFF@example.com"
@@ -1585,7 +1585,7 @@ class TestSMTPWithController(_CommonMethods):
         assert mail_to2 == mail_to
 
     @controller_data(decode_data=False)
-    def test_data_line_too_long(self, plain_controller, client):
+    def test_data_line_too_long(self, plain_controller: Controller, client: SMTPClient):
         self._helo(client)
         client.helo("example.com")
         mail = b"\r\n".join([b"a" * 5555] * 3)
@@ -1594,7 +1594,7 @@ class TestSMTPWithController(_CommonMethods):
         assert exc.value.args == S.S500_DATALINE_TOO_LONG
 
     @controller_data(data_size_limit=10000)
-    def test_long_line_double_count(self, plain_controller, client):
+    def test_long_line_double_count(self, plain_controller: Controller, client: SMTPClient):
         # With a read limit of 1001 bytes in aiosmtp.SMTP, asyncio.StreamReader
         # returns too-long lines of length up to 2002 bytes.
         # This test ensures that bytes in partial lines are only counted once.
@@ -1626,7 +1626,7 @@ class TestSMTPWithController(_CommonMethods):
         #                  b'Line too long (see RFC5321 4.5.3.1.6)')
 
     @controller_data(data_size_limit=20)
-    def test_too_long_body_delay_error(self, plain_controller):
+    def test_too_long_body_delay_error(self, plain_controller: Controller):
         with socket.socket() as sock:
             sock.connect((plain_controller.hostname, plain_controller.port))
             rslt = send_recv(sock, b"EHLO example.com")
@@ -1645,7 +1645,7 @@ class TestSMTPWithController(_CommonMethods):
             assert rslt == b"552 Error: Too much mail data\r\n"
 
     @controller_data(data_size_limit=700)
-    def test_too_long_body_then_too_long_lines(self, plain_controller, client):
+    def test_too_long_body_then_too_long_lines(self, plain_controller: Controller, client: SMTPClient):
         # If "too much mail" state was reached before "too long line" gets received,
         # SMTP should respond with '552' instead of '500'
         client.helo("example.com")
@@ -1654,7 +1654,7 @@ class TestSMTPWithController(_CommonMethods):
             client.sendmail("anne@example.com", ["bart@example.com"], mail)
         assert exc.value.args == S.S552_DATA_TOO_MUCH
 
-    def test_too_long_line_delay_error(self, plain_controller):
+    def test_too_long_line_delay_error(self, plain_controller: Controller):
         with socket.socket() as sock:
             sock.connect((plain_controller.hostname, plain_controller.port))
             rslt = send_recv(sock, b"EHLO example.com")
@@ -1673,7 +1673,7 @@ class TestSMTPWithController(_CommonMethods):
             assert rslt == S.S500_DATALINE_TOO_LONG.to_bytes(crlf=True)
 
     @controller_data(data_size_limit=2000)
-    def test_too_long_lines_then_too_long_body(self, plain_controller, client):
+    def test_too_long_lines_then_too_long_body(self, plain_controller: Controller, client: SMTPClient):
         # If "too long line" state was reached before "too much data" happens,
         # SMTP should respond with '500' instead of '552'
         client.helo("example.com")
@@ -1685,12 +1685,12 @@ class TestSMTPWithController(_CommonMethods):
 
 class TestCustomization(_CommonMethods):
     @controller_data(class_=CustomHostnameController)
-    def test_custom_hostname(self, plain_controller, client):
+    def test_custom_hostname(self, plain_controller: Controller, client: SMTPClient):
         code, mesg = client.helo("example.com")
         assert code == 250
         assert mesg == CustomHostnameController.custom_name.encode("ascii")
 
-    def test_default_greeting(self, plain_controller, client):
+    def test_default_greeting(self, plain_controller: Controller, client: SMTPClient):
         controller = plain_controller
         code, mesg = client.connect(controller.hostname, controller.port)
         assert code == 220
@@ -1698,7 +1698,7 @@ class TestCustomization(_CommonMethods):
         assert mesg.endswith(bytes(GREETING, "utf-8"))
 
     @controller_data(class_=CustomIdentController)
-    def test_custom_greeting(self, plain_controller, client):
+    def test_custom_greeting(self, plain_controller: Controller, client: SMTPClient):
         controller = plain_controller
         code, mesg = client.connect(controller.hostname, controller.port)
         assert code == 220
@@ -1706,12 +1706,12 @@ class TestCustomization(_CommonMethods):
         assert mesg.endswith(CustomIdentController.ident)
 
     @controller_data(decode_data=False)
-    def test_mail_invalid_body_param(self, plain_controller, client):
+    def test_mail_invalid_body_param(self, plain_controller: Controller, client: SMTPClient):
         client.ehlo("example.com")
         resp = client.docmd("MAIL FROM: <anne@example.com> BODY=FOOBAR")
         assert resp == S.S501_MAIL_BODY
 
-    def test_limitlocalpart(self, plain_controller, client):
+    def test_limitlocalpart(self, plain_controller: Controller, client: SMTPClient):
         plain_controller.smtpd.local_part_limit = 64
         client.ehlo("example.com")
         locpart = "a" * 64
@@ -1768,7 +1768,7 @@ class TestClientCrash(_CommonMethods):
         # Should be called at least once. (In practice, almost certainly just once.)
         assert spy.call_count > 0
 
-    def test_connection_reset_in_long_command(self, plain_controller, client):
+    def test_connection_reset_in_long_command(self, plain_controller: Controller, client: SMTPClient):
         client.send("F" + 5555 * "O")  # without CRLF
         reset_connection(client)
         catchup_delay()
@@ -1780,7 +1780,7 @@ class TestClientCrash(_CommonMethods):
         # and still == True if transport is closed.
         assert writer.transport.is_closing()
 
-    def test_close_in_command(self, plain_controller, client):
+    def test_close_in_command(self, plain_controller: Controller, client: SMTPClient):
         # Don't include the CRLF.
         client.send("FOO")
         client.close()
@@ -1811,7 +1811,7 @@ class TestClientCrash(_CommonMethods):
         # and still == True if transport is closed.
         assert writer.transport.is_closing()
 
-    def test_close_in_long_command(self, plain_controller, client):
+    def test_close_in_long_command(self, plain_controller: Controller, client: SMTPClient):
         client.send("F" + 5555 * "O")  # without CRLF
         client.close()
         catchup_delay()
@@ -1872,21 +1872,21 @@ class TestClientCrash(_CommonMethods):
 @pytest.mark.usefixtures("plain_controller")
 @controller_data(enable_SMTPUTF8=False, decode_data=True)
 class TestStrictASCII(_CommonMethods):
-    def test_ehlo(self, client):
+    def test_ehlo(self, client: SMTPClient):
         blines = self._ehlo(client)
         assert b"SMTPUTF8" not in blines
 
-    def test_bad_encoded_param(self, client):
+    def test_bad_encoded_param(self, client: SMTPClient):
         self._ehlo(client)
         client.send(b"MAIL FROM: <anne\xFF@example.com>\r\n")
         assert client.getreply() == S.S500_STRICT_ASCII
 
-    def test_mail_param(self, client):
+    def test_mail_param(self, client: SMTPClient):
         self._ehlo(client)
         resp = client.docmd("MAIL FROM: <anne@example.com> SMTPUTF8")
         assert resp == S.S501_SMTPUTF8_DISABLED
 
-    def test_data(self, client):
+    def test_data(self, client: SMTPClient):
         self._ehlo(client)
         with pytest.raises(SMTPDataError) as excinfo:
             client.sendmail(
@@ -1906,7 +1906,7 @@ class TestSleepingHandler(_CommonMethods):
 
     @controller_data(decode_data=False)
     @handler_data(class_=SleepingHeloHandler)
-    def test_close_after_helo(self, plain_controller, client):
+    def test_close_after_helo(self, plain_controller: Controller, client: SMTPClient):
         #
         # What are we actually testing?
         #
@@ -1918,7 +1918,7 @@ class TestSleepingHandler(_CommonMethods):
 
 class TestTimeout(_CommonMethods):
     @controller_data(class_=TimeoutController)
-    def test_timeout(self, plain_controller, client):
+    def test_timeout(self, plain_controller: Controller, client: SMTPClient):
         # This one is rapid, it must succeed
         self._ehlo(client)
         time.sleep(0.1 + TimeoutController.Delay)
@@ -1927,7 +1927,7 @@ class TestTimeout(_CommonMethods):
 
 
 class TestAuthArgs:
-    def test_warn_authreqnotls(self, caplog):
+    def test_warn_authreqnotls(self, caplog: pytest.LogCaptureFixture):
         with pytest.warns(UserWarning, match="Requiring AUTH") as record:
             _ = Server(Sink(), auth_required=True, auth_require_tls=False)
         for warning in record:
@@ -1946,7 +1946,7 @@ class TestAuthArgs:
             "auth_required == True but auth_require_tls == False",
         )
 
-    def test_log_authmechanisms(self, caplog):
+    def test_log_authmechanisms(self, caplog: pytest.LogCaptureFixture):
         caplog.set_level(logging.INFO)
         server = Server(Sink())
         auth_mechs = sorted(
@@ -1968,7 +1968,7 @@ class TestAuthArgs:
             "has\\backslash",
         ],
     )
-    def test_authmechname_decorator_badname(self, name):
+    def test_authmechname_decorator_badname(self, name: str):
         expectre = r"Invalid AUTH mechanism name"
         with pytest.raises(ValueError, match=expectre):
             auth_mechanism(name)
@@ -2006,11 +2006,11 @@ class TestLimits(_CommonMethods):
         assert exc.value.args[0] == "All command_call_limit values must be int"
 
     @controller_data(command_call_limit=15)
-    def test_all_limit_15(self, plain_controller, client):
+    def test_all_limit_15(self, plain_controller: Controller, client: SMTPClient):
         self._consume_budget(client, 15, "noop")
 
     @controller_data(command_call_limit={"NOOP": 15, "EXPN": 5})
-    def test_different_limits(self, plain_controller, client):
+    def test_different_limits(self, plain_controller: Controller, client: SMTPClient):
         srv_ip_port = plain_controller.hostname, plain_controller.port
 
         self._consume_budget(client, 15, "noop")
@@ -2030,7 +2030,7 @@ class TestLimits(_CommonMethods):
         )
 
     @controller_data(command_call_limit={"NOOP": 7, "EXPN": 5, "*": 25})
-    def test_different_limits_custom_default(self, plain_controller, client):
+    def test_different_limits_custom_default(self, plain_controller: Controller, client: SMTPClient):
         # Important: make sure default_max > CALL_LIMIT_DEFAULT
         # Others can be set small to cut down on testing time, but must be different
         assert plain_controller.smtpd._call_limit_default > CALL_LIMIT_DEFAULT
@@ -2053,7 +2053,7 @@ class TestLimits(_CommonMethods):
         )
 
     @controller_data(command_call_limit=7)
-    def test_limit_bogus(self, plain_controller, client):
+    def test_limit_bogus(self, plain_controller: Controller, client: SMTPClient):
         assert plain_controller.smtpd._call_limit_default > BOGUS_LIMIT
         code, mesg = client.ehlo("example.com")
         assert code == 250

--- a/aiosmtpd/tests/test_smtps.py
+++ b/aiosmtpd/tests/test_smtps.py
@@ -3,9 +3,11 @@
 
 """Test SMTP over SSL/TLS."""
 
+import ssl
+
 from email.mime.text import MIMEText
 from smtplib import SMTP, SMTP_SSL
-from typing import Generator, Union
+from typing import Callable, Generator, Union
 
 import pytest
 
@@ -18,7 +20,7 @@ from .conftest import Global
 
 @pytest.fixture
 def ssl_controller(
-    get_controller, ssl_context_server
+    get_controller: Callable[..., Controller], ssl_context_server: ssl.SSLContext
 ) -> Generator[Controller, None, None]:
     handler = ReceivingHandler()
     controller = get_controller(handler, ssl_context=ssl_context_server)
@@ -31,14 +33,18 @@ def ssl_controller(
 
 
 @pytest.fixture
-def smtps_client(ssl_context_client) -> Generator[Union[SMTP_SSL, SMTP], None, None]:
+def smtps_client(
+    ssl_context_client: ssl.SSLContext,
+) -> Generator[Union[SMTP_SSL, SMTP], None, None]:
     context = ssl_context_client
     with SMTP_SSL(*Global.SrvAddr, context=context) as client:
         yield client
 
 
 class TestSMTPS:
-    def test_smtps(self, ssl_controller, smtps_client):
+    def test_smtps(
+        self, ssl_controller: Controller, smtps_client: Union[SMTP_SSL, SMTP]
+    ) -> None:
         sender = "sender@example.com"
         recipients = ["rcpt1@example.com"]
         resp = smtps_client.helo("example.com")

--- a/aiosmtpd/tests/test_starttls.py
+++ b/aiosmtpd/tests/test_starttls.py
@@ -125,7 +125,7 @@ def auth_req_tls_controller(
 
 
 class TestNoTLS:
-    def test_disabled_tls(self, plain_controller: Controller, client: SMTPClient):
+    def test_disabled_tls(self, plain_controller: Controller, client: SMTPClient) -> None:
         code, _ = client.ehlo("example.com")
         assert code == 250
         resp = client.docmd("STARTTLS")
@@ -134,16 +134,16 @@ class TestNoTLS:
 
 @pytest.mark.usefixtures("tls_controller")
 class TestStartTLS:
-    def test_help_starttls(self, tls_controller: Controller, client: SMTPClient):
+    def test_help_starttls(self, tls_controller: Controller, client: SMTPClient) -> None:
         resp = client.docmd("HELP STARTTLS")
         assert resp == S.S250_SYNTAX_STARTTLS
 
-    def test_starttls_arg(self, tls_controller: Controller, client: SMTPClient):
+    def test_starttls_arg(self, tls_controller: Controller, client: SMTPClient) -> None:
         resp = client.docmd("STARTTLS arg")
         assert resp == S.S501_SYNTAX_STARTTLS
 
     @handler_data(class_=ReceivingHandler)
-    def test_starttls(self, tls_controller: Controller, client: SMTPClient):
+    def test_starttls(self, tls_controller: Controller, client: SMTPClient) -> None:
         sender = "sender@example.com"
         recipients = ["rcpt1@example.com"]
         code, _ = client.ehlo("example.com")
@@ -157,7 +157,7 @@ class TestStartTLS:
         assert handler.box[0].mail_from == sender
         assert handler.box[0].rcpt_tos == recipients
 
-    def test_starttls_quit(self, tls_controller: Controller, client: SMTPClient):
+    def test_starttls_quit(self, tls_controller: Controller, client: SMTPClient) -> None:
         code, _ = client.ehlo("example.com")
         assert code == 250
         resp = client.starttls()
@@ -167,7 +167,7 @@ class TestStartTLS:
         client.close()
 
     @handler_data(class_=HandshakeFailingHandler)
-    def test_failed_handshake(self, client: SMTPClient):
+    def test_failed_handshake(self, client: SMTPClient) -> None:
         code, _ = client.ehlo("example.com")
         assert code == 250
         resp = client.starttls()
@@ -179,24 +179,24 @@ class TestStartTLS:
 
     def test_tls_handshake_stopcontroller(
         self, tls_controller: Controller, client: SMTPClient
-    ):
+    ) -> None:
         client.ehlo("example.com")
         code, response = client.docmd("STARTTLS")
         tls_controller.stop()
         with pytest.raises(SMTPServerDisconnected):
             client.quit()
 
-    def test_tls_bad_syntax(self, client: SMTPClient):
+    def test_tls_bad_syntax(self, client: SMTPClient) -> None:
         code, _ = client.ehlo("example.com")
         assert code == 250
         resp = client.docmd("STARTTLS", "TRUE")
         assert resp == S.S501_SYNTAX_STARTTLS
 
-    def test_help_after_starttls(self, client: SMTPClient):
+    def test_help_after_starttls(self, client: SMTPClient) -> None:
         resp = client.docmd("HELP")
         assert resp == S.S250_SUPPCMD_TLS
 
-    def test_helo_starttls(self, tls_controller: Controller, client: SMTPClient):
+    def test_helo_starttls(self, tls_controller: Controller, client: SMTPClient) -> None:
         resp = client.helo("example.com")
         assert resp == S.S250_FQDN
         # Entering portion of code where hang is possible (upon assertion fail), so
@@ -218,7 +218,7 @@ class ExceptionCaptureHandler:
 
 class TestTLSEnding:
     @handler_data(class_=EOFingHandler)
-    def test_eof_received(self, tls_controller: Controller, client: SMTPClient):
+    def test_eof_received(self, tls_controller: Controller, client: SMTPClient) -> None:
         # I don't like this. It's too intimately involved with the innards of the SMTP
         # class. But for the life of me, I can't figure out why coverage there fail
         # intermittently.
@@ -249,7 +249,7 @@ class TestTLSEnding:
     @handler_data(class_=ExceptionCaptureHandler)
     def test_tls_handshake_failing(
         self, tls_controller: Controller, client: SMTPClient
-    ):
+    ) -> None:
         handler = tls_controller.handler
         assert isinstance(handler, ExceptionCaptureHandler)
         try:
@@ -265,14 +265,14 @@ class TestTLSEnding:
 
 @pytest.mark.usefixtures("tls_controller")
 class TestTLSForgetsSessionData:
-    def test_forget_ehlo(self, client: SMTPClient):
+    def test_forget_ehlo(self, client: SMTPClient) -> None:
         resp = client.starttls()
         assert resp == S.S220_READY_TLS
         resp = client.mail("sender@example.com")
         assert resp == S.S503_HELO_FIRST
 
     @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
-    def test_forget_mail(self, client: SMTPClient):
+    def test_forget_mail(self, client: SMTPClient) -> None:
         code, _ = client.ehlo("example.com")
         assert code == 250
         resp = client.mail("sender@example.com")
@@ -284,7 +284,7 @@ class TestTLSForgetsSessionData:
         resp = client.rcpt("rcpt@example.com")
         assert resp == S.S503_MAIL_NEEDED
 
-    def test_forget_rcpt(self, client: SMTPClient):
+    def test_forget_rcpt(self, client: SMTPClient) -> None:
         code, _ = client.ehlo("example.com")
         assert code == 250
         resp = client.mail("sender@example.com")
@@ -303,61 +303,61 @@ class TestTLSForgetsSessionData:
 
 @pytest.mark.usefixtures("tls_req_controller")
 class TestRequireTLS:
-    def test_helo_fails(self, client: SMTPClient):
+    def test_helo_fails(self, client: SMTPClient) -> None:
         resp = client.helo("example.com")
         assert resp == S.S530_STARTTLS_FIRST
 
-    def test_help_fails(self, client: SMTPClient):
+    def test_help_fails(self, client: SMTPClient) -> None:
         resp = client.docmd("HELP", "HELO")
         assert resp == S.S530_STARTTLS_FIRST
 
-    def test_ehlo(self, client: SMTPClient):
+    def test_ehlo(self, client: SMTPClient) -> None:
         code, _ = client.ehlo("example.com")
         assert code == 250
         assert "starttls" in client.esmtp_features
 
-    def test_mail_fails(self, client: SMTPClient):
+    def test_mail_fails(self, client: SMTPClient) -> None:
         code, _ = client.ehlo("example.com")
         assert code == 250
         resp = client.mail("sender@example.com")
         assert resp == S.S530_STARTTLS_FIRST
 
-    def test_rcpt_fails(self, client: SMTPClient):
+    def test_rcpt_fails(self, client: SMTPClient) -> None:
         code, _ = client.ehlo("example.com")
         assert code == 250
         resp = client.rcpt("recipient@example.com")
         assert resp == S.S530_STARTTLS_FIRST
 
-    def test_vrfy_fails(self, client: SMTPClient):
+    def test_vrfy_fails(self, client: SMTPClient) -> None:
         code, _ = client.ehlo("example.com")
         assert code == 250
         resp = client.vrfy("sender@exapmle.com")
         assert resp == S.S530_STARTTLS_FIRST
 
-    def test_data_fails(self, client: SMTPClient):
+    def test_data_fails(self, client: SMTPClient) -> None:
         code, _ = client.ehlo("example.com")
         assert code == 250
         resp = client.docmd("DATA")
         assert resp == S.S530_STARTTLS_FIRST
 
-    def test_noop_okay(self, client: SMTPClient):
+    def test_noop_okay(self, client: SMTPClient) -> None:
         client.ehlo("example.com")
         assert client.docmd("NOOP") == S.S250_OK
 
-    def test_quit_okay(self, client: SMTPClient):
+    def test_quit_okay(self, client: SMTPClient) -> None:
         client.ehlo("example.com")
         assert client.docmd("QUIT") == S.S221_BYE
 
 
 @pytest.mark.usefixtures("auth_req_tls_controller")
 class TestRequireTLSAUTH:
-    def test_auth_notls(self, client: SMTPClient):
+    def test_auth_notls(self, client: SMTPClient) -> None:
         code, _ = client.ehlo("example.com")
         assert code == 250
         resp = client.docmd("AUTH ")
         assert resp == S.S538_AUTH_ENCRYPTREQ
 
-    def test_auth_tls(self, client: SMTPClient):
+    def test_auth_tls(self, client: SMTPClient) -> None:
         resp = client.starttls()
         assert resp == S.S220_READY_TLS
         code, _ = client.ehlo("example.com")
@@ -367,7 +367,7 @@ class TestRequireTLSAUTH:
 
 
 class TestTLSContext:
-    def test_verify_mode_nochange(self, ssl_context_server: ssl.SSLContext):
+    def test_verify_mode_nochange(self, ssl_context_server: ssl.SSLContext) -> None:
         context = ssl_context_server
         for mode in (ssl.CERT_NONE, ssl.CERT_OPTIONAL):  # noqa: DUO122
             context.verify_mode = mode
@@ -376,7 +376,7 @@ class TestTLSContext:
 
     def test_certreq_warn(
         self, caplog: pytest.LogCaptureFixture, ssl_context_server: ssl.SSLContext
-    ):
+    ) -> None:
         context = ssl_context_server
         context.verify_mode = ssl.CERT_REQUIRED
         _ = Server(Sink(), tls_context=context)
@@ -387,7 +387,7 @@ class TestTLSContext:
 
     def test_nocertreq_chkhost_warn(
         self, caplog: pytest.LogCaptureFixture, ssl_context_server: ssl.SSLContext
-    ):
+    ) -> None:
         context = ssl_context_server
         context.verify_mode = ssl.CERT_OPTIONAL  # noqa: DUO122
         context.check_hostname = True

--- a/aiosmtpd/tests/test_starttls.py
+++ b/aiosmtpd/tests/test_starttls.py
@@ -5,7 +5,7 @@ import ssl
 from contextlib import suppress
 from email.mime.text import MIMEText
 from smtplib import SMTPServerDisconnected
-from typing import Generator
+from typing import Callable, Generator
 
 import pytest
 
@@ -42,7 +42,7 @@ class EOFingHandler:
 
 class HandshakeFailingHandler:
     def handle_STARTTLS(
-            self, server: Server, session: Sess_, envelope: Envelope
+        self, server: Server, session: Sess_, envelope: Envelope
     ) -> bool:
         return False
 
@@ -55,7 +55,9 @@ class HandshakeFailingHandler:
 
 @pytest.fixture
 def tls_controller(
-    get_handler, get_controller, ssl_context_server
+    get_handler: Callable,
+    get_controller: Callable[..., Controller],
+    ssl_context_server: ssl.SSLContext,
 ) -> Generator[Controller, None, None]:
     handler = get_handler()
     # controller = TLSController(handler)
@@ -79,7 +81,9 @@ def tls_controller(
 
 @pytest.fixture
 def tls_req_controller(
-    get_handler, get_controller, ssl_context_server
+    get_handler: Callable,
+    get_controller: Callable[..., Controller],
+    ssl_context_server: ssl.SSLContext,
 ) -> Generator[Controller, None, None]:
     handler = get_handler()
     controller = get_controller(
@@ -98,7 +102,9 @@ def tls_req_controller(
 
 @pytest.fixture
 def auth_req_tls_controller(
-    get_handler, get_controller, ssl_context_server
+    get_handler: Callable,
+    get_controller: Callable[..., Controller],
+    ssl_context_server: ssl.SSLContext,
 ) -> Generator[Controller, None, None]:
     handler = get_handler()
     controller = get_controller(

--- a/aiosmtpd/tests/test_starttls.py
+++ b/aiosmtpd/tests/test_starttls.py
@@ -4,7 +4,7 @@
 import ssl
 from contextlib import suppress
 from email.mime.text import MIMEText
-from smtplib import SMTPServerDisconnected
+from smtplib import SMTP as SMTPClient, SMTPServerDisconnected
 from typing import Callable, Generator
 
 import pytest
@@ -125,7 +125,7 @@ def auth_req_tls_controller(
 
 
 class TestNoTLS:
-    def test_disabled_tls(self, plain_controller, client):
+    def test_disabled_tls(self, plain_controller: Controller, client: SMTPClient):
         code, _ = client.ehlo("example.com")
         assert code == 250
         resp = client.docmd("STARTTLS")
@@ -134,16 +134,16 @@ class TestNoTLS:
 
 @pytest.mark.usefixtures("tls_controller")
 class TestStartTLS:
-    def test_help_starttls(self, tls_controller, client):
+    def test_help_starttls(self, tls_controller: Controller, client: SMTPClient):
         resp = client.docmd("HELP STARTTLS")
         assert resp == S.S250_SYNTAX_STARTTLS
 
-    def test_starttls_arg(self, tls_controller, client):
+    def test_starttls_arg(self, tls_controller: Controller, client: SMTPClient):
         resp = client.docmd("STARTTLS arg")
         assert resp == S.S501_SYNTAX_STARTTLS
 
     @handler_data(class_=ReceivingHandler)
-    def test_starttls(self, tls_controller, client):
+    def test_starttls(self, tls_controller: Controller, client: SMTPClient):
         sender = "sender@example.com"
         recipients = ["rcpt1@example.com"]
         code, _ = client.ehlo("example.com")
@@ -157,7 +157,7 @@ class TestStartTLS:
         assert handler.box[0].mail_from == sender
         assert handler.box[0].rcpt_tos == recipients
 
-    def test_starttls_quit(self, tls_controller, client):
+    def test_starttls_quit(self, tls_controller: Controller, client: SMTPClient):
         code, _ = client.ehlo("example.com")
         assert code == 250
         resp = client.starttls()
@@ -167,7 +167,7 @@ class TestStartTLS:
         client.close()
 
     @handler_data(class_=HandshakeFailingHandler)
-    def test_failed_handshake(self, client):
+    def test_failed_handshake(self, client: SMTPClient):
         code, _ = client.ehlo("example.com")
         assert code == 250
         resp = client.starttls()
@@ -177,24 +177,26 @@ class TestStartTLS:
         resp = client.rcpt("rcpt@example.com")
         assert resp == S.S554_LACK_SECURITY
 
-    def test_tls_handshake_stopcontroller(self, tls_controller, client):
+    def test_tls_handshake_stopcontroller(
+        self, tls_controller: Controller, client: SMTPClient
+    ):
         client.ehlo("example.com")
         code, response = client.docmd("STARTTLS")
         tls_controller.stop()
         with pytest.raises(SMTPServerDisconnected):
             client.quit()
 
-    def test_tls_bad_syntax(self, client):
+    def test_tls_bad_syntax(self, client: SMTPClient):
         code, _ = client.ehlo("example.com")
         assert code == 250
         resp = client.docmd("STARTTLS", "TRUE")
         assert resp == S.S501_SYNTAX_STARTTLS
 
-    def test_help_after_starttls(self, client):
+    def test_help_after_starttls(self, client: SMTPClient):
         resp = client.docmd("HELP")
         assert resp == S.S250_SUPPCMD_TLS
 
-    def test_helo_starttls(self, tls_controller, client):
+    def test_helo_starttls(self, tls_controller: Controller, client: SMTPClient):
         resp = client.helo("example.com")
         assert resp == S.S250_FQDN
         # Entering portion of code where hang is possible (upon assertion fail), so
@@ -216,7 +218,7 @@ class ExceptionCaptureHandler:
 
 class TestTLSEnding:
     @handler_data(class_=EOFingHandler)
-    def test_eof_received(self, tls_controller, client):
+    def test_eof_received(self, tls_controller: Controller, client: SMTPClient):
         # I don't like this. It's too intimately involved with the innards of the SMTP
         # class. But for the life of me, I can't figure out why coverage there fail
         # intermittently.
@@ -245,7 +247,9 @@ class TestTLSEnding:
             tls_controller.stop()
 
     @handler_data(class_=ExceptionCaptureHandler)
-    def test_tls_handshake_failing(self, tls_controller, client):
+    def test_tls_handshake_failing(
+        self, tls_controller: Controller, client: SMTPClient
+    ):
         handler = tls_controller.handler
         assert isinstance(handler, ExceptionCaptureHandler)
         try:
@@ -261,14 +265,14 @@ class TestTLSEnding:
 
 @pytest.mark.usefixtures("tls_controller")
 class TestTLSForgetsSessionData:
-    def test_forget_ehlo(self, client):
+    def test_forget_ehlo(self, client: SMTPClient):
         resp = client.starttls()
         assert resp == S.S220_READY_TLS
         resp = client.mail("sender@example.com")
         assert resp == S.S503_HELO_FIRST
 
     @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
-    def test_forget_mail(self, client):
+    def test_forget_mail(self, client: SMTPClient):
         code, _ = client.ehlo("example.com")
         assert code == 250
         resp = client.mail("sender@example.com")
@@ -280,7 +284,7 @@ class TestTLSForgetsSessionData:
         resp = client.rcpt("rcpt@example.com")
         assert resp == S.S503_MAIL_NEEDED
 
-    def test_forget_rcpt(self, client):
+    def test_forget_rcpt(self, client: SMTPClient):
         code, _ = client.ehlo("example.com")
         assert code == 250
         resp = client.mail("sender@example.com")
@@ -299,61 +303,61 @@ class TestTLSForgetsSessionData:
 
 @pytest.mark.usefixtures("tls_req_controller")
 class TestRequireTLS:
-    def test_helo_fails(self, client):
+    def test_helo_fails(self, client: SMTPClient):
         resp = client.helo("example.com")
         assert resp == S.S530_STARTTLS_FIRST
 
-    def test_help_fails(self, client):
+    def test_help_fails(self, client: SMTPClient):
         resp = client.docmd("HELP", "HELO")
         assert resp == S.S530_STARTTLS_FIRST
 
-    def test_ehlo(self, client):
+    def test_ehlo(self, client: SMTPClient):
         code, _ = client.ehlo("example.com")
         assert code == 250
         assert "starttls" in client.esmtp_features
 
-    def test_mail_fails(self, client):
+    def test_mail_fails(self, client: SMTPClient):
         code, _ = client.ehlo("example.com")
         assert code == 250
         resp = client.mail("sender@example.com")
         assert resp == S.S530_STARTTLS_FIRST
 
-    def test_rcpt_fails(self, client):
+    def test_rcpt_fails(self, client: SMTPClient):
         code, _ = client.ehlo("example.com")
         assert code == 250
         resp = client.rcpt("recipient@example.com")
         assert resp == S.S530_STARTTLS_FIRST
 
-    def test_vrfy_fails(self, client):
+    def test_vrfy_fails(self, client: SMTPClient):
         code, _ = client.ehlo("example.com")
         assert code == 250
         resp = client.vrfy("sender@exapmle.com")
         assert resp == S.S530_STARTTLS_FIRST
 
-    def test_data_fails(self, client):
+    def test_data_fails(self, client: SMTPClient):
         code, _ = client.ehlo("example.com")
         assert code == 250
         resp = client.docmd("DATA")
         assert resp == S.S530_STARTTLS_FIRST
 
-    def test_noop_okay(self, client):
+    def test_noop_okay(self, client: SMTPClient):
         client.ehlo("example.com")
         assert client.docmd("NOOP") == S.S250_OK
 
-    def test_quit_okay(self, client):
+    def test_quit_okay(self, client: SMTPClient):
         client.ehlo("example.com")
         assert client.docmd("QUIT") == S.S221_BYE
 
 
 @pytest.mark.usefixtures("auth_req_tls_controller")
 class TestRequireTLSAUTH:
-    def test_auth_notls(self, client):
+    def test_auth_notls(self, client: SMTPClient):
         code, _ = client.ehlo("example.com")
         assert code == 250
         resp = client.docmd("AUTH ")
         assert resp == S.S538_AUTH_ENCRYPTREQ
 
-    def test_auth_tls(self, client):
+    def test_auth_tls(self, client: SMTPClient):
         resp = client.starttls()
         assert resp == S.S220_READY_TLS
         code, _ = client.ehlo("example.com")
@@ -363,14 +367,16 @@ class TestRequireTLSAUTH:
 
 
 class TestTLSContext:
-    def test_verify_mode_nochange(self, ssl_context_server):
+    def test_verify_mode_nochange(self, ssl_context_server: ssl.SSLContext):
         context = ssl_context_server
         for mode in (ssl.CERT_NONE, ssl.CERT_OPTIONAL):  # noqa: DUO122
             context.verify_mode = mode
             _ = Server(Sink(), tls_context=context)
             assert context.verify_mode == mode
 
-    def test_certreq_warn(self, caplog, ssl_context_server):
+    def test_certreq_warn(
+        self, caplog: pytest.LogCaptureFixture, ssl_context_server: ssl.SSLContext
+    ):
         context = ssl_context_server
         context.verify_mode = ssl.CERT_REQUIRED
         _ = Server(Sink(), tls_context=context)
@@ -379,7 +385,9 @@ class TestTLSContext:
         assert "tls_context.verify_mode not in" in logmsg
         assert "might cause client connection problems" in logmsg
 
-    def test_nocertreq_chkhost_warn(self, caplog, ssl_context_server):
+    def test_nocertreq_chkhost_warn(
+        self, caplog: pytest.LogCaptureFixture, ssl_context_server: ssl.SSLContext
+    ):
         context = ssl_context_server
         context.verify_mode = ssl.CERT_OPTIONAL  # noqa: DUO122
         context.check_hostname = True

--- a/housekeep.py
+++ b/housekeep.py
@@ -126,7 +126,7 @@ def move_prof(verbose: bool = False):
         print(flush=True)
 
 
-def pycache_clean(verbose=False):
+def pycache_clean(verbose: bool = False):
     """Cleanup __pycache__ dirs & bytecode files (if any)"""
     aiosmtpdpath = Path(".")
     for i, f in enumerate(aiosmtpdpath.rglob("*.py[co]"), start=1):
@@ -199,7 +199,7 @@ def dispatch_superclean():
 # endregion
 
 
-def get_opts(argv):
+def get_opts(argv: list[str]):
     # From: https://stackoverflow.com/a/49999185/149900
     class NoAction(argparse.Action):
         def __init__(self, **kwargs):

--- a/housekeep.py
+++ b/housekeep.py
@@ -66,7 +66,7 @@ TERM_WIDTH, TERM_HEIGHT = shutil.get_terminal_size()
 # region #### Helper funcs ############################################################
 
 
-def deldir(targ: Path, verbose: bool = True):
+def deldir(targ: Path, verbose: bool = True) -> None:
     if not targ.exists():
         return
     rev_items = sorted(targ.rglob("*"), reverse=True)
@@ -92,7 +92,7 @@ def deldir(targ: Path, verbose: bool = True):
 # region #### Functional blocks #######################################################
 
 
-def dump_env():
+def dump_env() -> None:
     dumpdir = Path(DUMP_DIR)
     dumpdir.mkdir(exist_ok=True)
     with (dumpdir / f"ENV.{TOX_ENV_NAME}.py").open("wt") as fout:
@@ -100,7 +100,7 @@ def dump_env():
         pprint.pprint(dict(os.environ), stream=fout)
 
 
-def move_prof(verbose: bool = False):
+def move_prof(verbose: bool = False) -> None:
     """Move profiling files to per-testenv dirs"""
     profpath = Path("prof")
     # fmt: off
@@ -126,7 +126,7 @@ def move_prof(verbose: bool = False):
         print(flush=True)
 
 
-def pycache_clean(verbose: bool = False):
+def pycache_clean(verbose: bool = False) -> None:
     """Cleanup __pycache__ dirs & bytecode files (if any)"""
     aiosmtpdpath = Path(".")
     for i, f in enumerate(aiosmtpdpath.rglob("*.py[co]"), start=1):
@@ -141,7 +141,7 @@ def pycache_clean(verbose: bool = False):
         print(flush=True)
 
 
-def rm_work():
+def rm_work() -> None:
     """Remove work dirs & files. They are .gitignore'd anyways."""
     print(f"{Style.BRIGHT}Removing work dirs ... ", end="", flush=True)
     # The reason we list WORKDIRS explicitly is because we don't want to accidentally
@@ -164,28 +164,28 @@ def rm_work():
 # region #### Dispatchers #############################################################
 
 
-def dispatch_prep():
+def dispatch_prep() -> None:
     """
     Prepare work directories and dump env vars
     """
     dump_env()
 
 
-def dispatch_gather():
+def dispatch_gather() -> None:
     """
     Gather inspection results into per-testenv dirs
     """
     move_prof()
 
 
-def dispatch_remcache():
+def dispatch_remcache() -> None:
     """
     Remove all .py[co] files and all __pycache__ dirs
     """
     pycache_clean()
 
 
-def dispatch_superclean():
+def dispatch_superclean() -> None:
     """
     Total cleaning of all test artifacts
     """
@@ -199,7 +199,7 @@ def dispatch_superclean():
 # endregion
 
 
-def get_opts(argv: list[str]):
+def get_opts(argv: list[str]) -> argparse.Namespace:
     # From: https://stackoverflow.com/a/49999185/149900
     class NoAction(argparse.Action):
         def __init__(self, **kwargs):
@@ -244,7 +244,7 @@ def get_opts(argv: list[str]):
     return parser.parse_args(argv)
 
 
-def python_interp_details():
+def python_interp_details() -> None:
     print(f"{Fore.CYAN}\u259E\u259E\u259E Python interpreter details:")
     details = sys.version.splitlines() + sys.executable.splitlines()
     for ln in details:

--- a/housekeep.py
+++ b/housekeep.py
@@ -202,12 +202,12 @@ def dispatch_superclean() -> None:
 def get_opts(argv: list[str]) -> argparse.Namespace:
     # From: https://stackoverflow.com/a/49999185/149900
     class NoAction(argparse.Action):
-        def __init__(self, **kwargs):
+        def __init__(self, **kwargs) -> None:
             kwargs.setdefault("default", argparse.SUPPRESS)
             kwargs.setdefault("nargs", 0)
             super().__init__(**kwargs)
 
-        def __call__(self, *args, **kwargs):
+        def __call__(self, *args, **kwargs) -> None:
             pass
 
     dispers = {

--- a/setup.cfg
+++ b/setup.cfg
@@ -117,8 +117,6 @@ ignore =
     # Explicit is better than implicit, range(0, val) is more explicit than range(val).
     PIE808
 per-file-ignores =
-    # FIXME add the 45 missing type annotations
-    aiosmtpd/tests/test_*:ANN001
     # S101: Pytest uses assert
     aiosmtpd/tests/*:S101
     aiosmtpd/tests/test_proxyprotocol.py:DUO102

--- a/setup.cfg
+++ b/setup.cfg
@@ -120,8 +120,11 @@ per-file-ignores =
     # S101: Pytest uses assert
     aiosmtpd/tests/*:S101
     aiosmtpd/tests/test_proxyprotocol.py:DUO102
-    aiosmtpd/qa/*:TAE001
     aiosmtpd/docs/_exts/autoprogramm.py:C801
+    aiosmtpd/controller.py:ANN001,ANN201,ANN202,ANN204,TAE001
+    aiosmtpd/handlers.py:ANN001,ANN201,ANN204,TAE001
+    aiosmtpd/smtp.py:ANN001,ANN201,ANN202,ANN204,TAE001
+    aiosmtpd/proxy_protocol.py:ANN204
 # flake8-coding
 no-accept-encodings = True
 # flake8-copyright
@@ -132,11 +135,7 @@ copyright-author = The aiosmtpd Developers
 # flake8-annotations-complexity
 max-annotations-complexity = 4
 # flake8-annotations-coverage
-min-coverage-percents = 12
-# flake8-annotations
-suppress-none-returning = True
-suppress-dummy-args = True
-allow-untyped-defs = True
+min-coverage-percents = 100
 
 # flake8-import-order
 application-import-names = aiosmtpd


### PR DESCRIPTION
## What do these changes do?
Add missing annotations to all files that are not part of the public API.
## Are there changes in behavior for the user?
No.
## Related issue number
No.
## Checklist
- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] tox testenvs have been executed in the following environments:
  - [x] Linux (Ubuntu 18.04, Ubuntu 20.04, Arch): `{py39,py310,py311,py312}-{nocov,cov,diffcov}, qa, docs, static`
  - [ ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- [ ] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file