### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -66,7 +66,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        pyver: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        pyver: ['3.10', '3.11', '3.12', '3.13']
         os: [ubuntu, macos, windows]
         include:
           - pyver: pypy-3.11
@@ -86,7 +86,7 @@ jobs:
       uses: py-actions/py-dependency-install@v4
       with:
         path: requirements.txt
-    - name: Fetch master branch 
+    - name: Fetch master branch
       # Needed for aiosmtpd.qa.test_0packaging.TestVersion.test_ge_master,
       # it runs a "git show" command which will fail if the master branch
       # does not exist locally
@@ -98,7 +98,7 @@ jobs:
           ${{ github.event.repository.default_branch }}
       run: >-
         git fetch origin
-        "${GITHUB_REPOSITORY_DEFAULT_BRANCH}:${GITHUB_REPOSITORY_DEFAULT_BRANCH}" 
+        "${GITHUB_REPOSITORY_DEFAULT_BRANCH}:${GITHUB_REPOSITORY_DEFAULT_BRANCH}"
     - name: Run unittests
       run: pytest
       env:

--- a/README.rst
+++ b/README.rst
@@ -61,10 +61,9 @@ Requirements
 Supported Platforms
 -----------------------
 
-``aiosmtpd`` has been tested on **CPython**>=3.9 and |PyPy|_>=3.9
+``aiosmtpd`` has been tested on **CPython**>=3.10 and |PyPy|_>=3.10
 for the following platforms (in alphabetical order):
 
-* Cygwin (as of 2022-12-22, only for CPython 3.9)
 * MacOS 11 and 12
 * Ubuntu 18.04
 * Ubuntu 20.04
@@ -170,7 +169,7 @@ In general, the ``-e`` parameter to tox specifies one (or more) **testenv**
 to run (separate using comma if more than one testenv). The following testenvs
 have been configured and tested:
 
-* ``{py39,py310,py311,py312,pypy3,pypy311}-{nocov,cov,diffcov,profile}``
+* ``{py310,py311,py312,pypy3,pypy311}-{nocov,cov,diffcov,profile}``
 
   Specifies the interpreter to run and the kind of testing to perform.
 
@@ -182,10 +181,7 @@ have been configured and tested:
   - ``profile`` = no coverage testing, but code profiling instead.
     This must be **invoked manually** using the ``-e`` parameter
 
-  **Note 1:** As of 2021-02-23,
-  only the ``{py39}-{nocov,cov}`` combinations work on **Cygwin**.
-
-  **Note 2:** It is also possible to use whatever Python version is used when
+  **Note:** It is also possible to use whatever Python version is used when
   invoking ``tox`` by using the ``py`` target, but you must explicitly include
   the type of testing you want. For example::
 

--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -10,8 +10,8 @@
 Fixed/Improved
 --------------
 
-* Dropped Python 3.8, PyPy 3.8
-* Added PyPy 3.11, dropped PyPy 3.9
+* Dropped Python 3.8 and 3.9, PyPy 3.8 and 3.9
+* Added PyPy 3.11
 
 
 1.4.6 (2024-05-18)

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ classifiers =
     Operating System :: POSIX :: BSD :: FreeBSD
     Operating System :: POSIX :: Linux
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -32,7 +31,7 @@ classifiers =
 
 [options]
 zip_safe = false
-python_requires = >=3.9
+python_requires = >=3.10
 packages = find:
 include_package_data = true
 setup_requires =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.9.0
-envlist = qa, static, docs, py{39,310,311,312,py3}-{nocov,cov,diffcov}
+envlist = qa, static, docs, py{310,311,312,py3}-{nocov,cov,diffcov}
 skip_missing_interpreters = True
 
 [testenv]
@@ -37,7 +37,6 @@ deps =
 setenv =
     cov: COVERAGE_FILE={toxinidir}/_dump/.coverage
     nocov: PYTHONASYNCIODEBUG=1
-    py39: INTERP=py39
     py310: INTERP=py310
     py311: INTERP=py311
     py312: INTERP=py312


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Drop Python 3.9 references from README, GHA ci-cd workflow, tox.ini, setup.cfg

## Are there changes in behavior for the user?

Yes – no more Python 3.9 support.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Use the "closing keywords" such as "Closes" or "Fixes" to automatically link to Issues. -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [ ] Linux (Ubuntu 18.04, Ubuntu 20.04, Arch): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, qa, docs`
  - [ ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- [ ] Documentation reflects the changes
- [x] Add a news fragment into the `NEWS.rst` file
  <!-- Delete the following bullet points prior to submitting the PR -->
  * Add under the "aiosmtpd-next" section, creating one if necessary
    * You may create subsections to group the changes, if you like
  * Use full sentences with correct case and punctuation
  * Refer to relevant Issue if applicable
