### PR TITLE
Fix authenticated relayer password verification

### DIFF
--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -13,7 +13,7 @@ Fixed/Improved
 * Dropped Python 3.8, PyPy 3.8
 * Added PyPy 3.11, dropped PyPy 3.9
 * Fixed the authenticated relayer example to verify passwords with their stored salts
-  (Closes #475)
+  and report incompatible databases at startup (Closes #475)
 
 
 1.4.6 (2024-05-18)

--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -12,6 +12,8 @@ Fixed/Improved
 
 * Dropped Python 3.8, PyPy 3.8
 * Added PyPy 3.11, dropped PyPy 3.9
+* Fixed the authenticated relayer example to verify passwords with their stored salts
+  (Closes #475)
 
 
 1.4.6 (2024-05-18)

--- a/aiosmtpd/docs/NEWS.rst
+++ b/aiosmtpd/docs/NEWS.rst
@@ -13,7 +13,8 @@ Fixed/Improved
 * Dropped Python 3.8, PyPy 3.8
 * Added PyPy 3.11, dropped PyPy 3.9
 * Fixed the authenticated relayer example to verify passwords with their stored salts
-  and report incompatible databases at startup (Closes #475)
+  and report incompatible databases at startup. The example now also keeps its
+  controller running until shutdown (Closes #475)
 
 
 1.4.6 (2024-05-18)

--- a/aiosmtpd/tests/test_authenticated_relayer_example.py
+++ b/aiosmtpd/tests/test_authenticated_relayer_example.py
@@ -4,6 +4,7 @@
 import asyncio
 import sqlite3
 from contextlib import closing
+from pathlib import Path
 
 import pytest
 
@@ -13,7 +14,7 @@ from examples.authenticated_relayer.make_user_db import make_user_db
 from aiosmtpd.smtp import LoginPassword
 
 
-def test_authenticator_uses_stored_salt(tmp_path):
+def test_authenticator_uses_stored_salt(tmp_path: Path) -> None:
     auth_db = tmp_path / "mail.db"
     make_user_db(auth_db, {"alice": b"correct password"})
     authenticator = relayer.Authenticator(auth_db)
@@ -37,7 +38,7 @@ def test_authenticator_uses_stored_salt(tmp_path):
     assert not invalid_username.success
 
 
-def test_authenticator_rejects_legacy_database(tmp_path):
+def test_authenticator_rejects_legacy_database(tmp_path: Path) -> None:
     auth_db = tmp_path / "mail.db"
     with closing(sqlite3.connect(auth_db)) as conn:
         conn.execute("CREATE TABLE userauth (username text, hashpass text)")
@@ -47,7 +48,9 @@ def test_authenticator_rejects_legacy_database(tmp_path):
         relayer.Authenticator(auth_db)
 
 
-def test_main_task_keeps_controller_running(tmp_path, monkeypatch):
+def test_main_task_keeps_controller_running(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     auth_db = tmp_path / "mail.db"
     make_user_db(auth_db, {"alice": b"correct password"})
     monkeypatch.setattr(relayer, "DB_AUTH", auth_db)
@@ -55,20 +58,20 @@ def test_main_task_keeps_controller_running(tmp_path, monkeypatch):
     stopped = False
 
     class DummyController:
-        def __init__(self, *args, **kwargs):
+        def __init__(self, *args: object, **kwargs: object) -> None:
             pass
 
-        def start(self):
+        def start(self) -> None:
             nonlocal started
             started = True
 
-        def stop(self):
+        def stop(self) -> None:
             nonlocal stopped
             stopped = True
 
     monkeypatch.setattr(relayer, "Controller", DummyController)
 
-    async def exercise():
+    async def exercise() -> None:
         task = asyncio.create_task(relayer.amain())
         await asyncio.sleep(0)
         assert started
@@ -81,20 +84,22 @@ def test_main_task_keeps_controller_running(tmp_path, monkeypatch):
     assert stopped
 
 
-def test_main_task_cleans_up_controller_when_start_fails(tmp_path, monkeypatch):
+def test_main_task_cleans_up_controller_when_start_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     auth_db = tmp_path / "mail.db"
     make_user_db(auth_db, {"alice": b"correct password"})
     monkeypatch.setattr(relayer, "DB_AUTH", auth_db)
     stopped = False
 
     class DummyController:
-        def __init__(self, *args, **kwargs):
+        def __init__(self, *args: object, **kwargs: object) -> None:
             pass
 
-        def start(self):
+        def start(self) -> None:
             raise RuntimeError("partial startup failure")
 
-        def stop(self):
+        def stop(self) -> None:
             nonlocal stopped
             stopped = True
 

--- a/aiosmtpd/tests/test_authenticated_relayer_example.py
+++ b/aiosmtpd/tests/test_authenticated_relayer_example.py
@@ -1,6 +1,11 @@
 # Copyright 2014-2021 The aiosmtpd Developers
 # SPDX-License-Identifier: Apache-2.0
 
+import sqlite3
+from contextlib import closing
+
+import pytest
+
 from examples.authenticated_relayer.make_user_db import make_user_db
 from examples.authenticated_relayer.server import Authenticator
 
@@ -29,3 +34,13 @@ def test_authenticator_uses_stored_salt(tmp_path):
     assert not wrong_password.success
     assert not unknown_user.success
     assert not invalid_username.success
+
+
+def test_authenticator_rejects_legacy_database(tmp_path):
+    auth_db = tmp_path / "mail.db"
+    with closing(sqlite3.connect(auth_db)) as conn:
+        conn.execute("CREATE TABLE userauth (username text, hashpass text)")
+        conn.commit()
+
+    with pytest.raises(RuntimeError, match="recreate it with make_user_db.py"):
+        Authenticator(auth_db)

--- a/aiosmtpd/tests/test_authenticated_relayer_example.py
+++ b/aiosmtpd/tests/test_authenticated_relayer_example.py
@@ -1,0 +1,31 @@
+# Copyright 2014-2021 The aiosmtpd Developers
+# SPDX-License-Identifier: Apache-2.0
+
+from examples.authenticated_relayer.make_user_db import make_user_db
+from examples.authenticated_relayer.server import Authenticator
+
+from aiosmtpd.smtp import LoginPassword
+
+
+def test_authenticator_uses_stored_salt(tmp_path):
+    auth_db = tmp_path / "mail.db"
+    make_user_db(auth_db, {"alice": b"correct password"})
+    authenticator = Authenticator(auth_db)
+
+    accepted = authenticator(
+        None, None, None, "PLAIN", LoginPassword(b"alice", b"correct password")
+    )
+    wrong_password = authenticator(
+        None, None, None, "PLAIN", LoginPassword(b"alice", b"wrong password")
+    )
+    unknown_user = authenticator(
+        None, None, None, "PLAIN", LoginPassword(b"bob", b"correct password")
+    )
+    invalid_username = authenticator(
+        None, None, None, "PLAIN", LoginPassword(b"\xff", b"correct password")
+    )
+
+    assert accepted.success
+    assert not wrong_password.success
+    assert not unknown_user.success
+    assert not invalid_username.success

--- a/aiosmtpd/tests/test_authenticated_relayer_example.py
+++ b/aiosmtpd/tests/test_authenticated_relayer_example.py
@@ -79,3 +79,28 @@ def test_main_task_keeps_controller_running(tmp_path, monkeypatch):
 
     asyncio.run(exercise())
     assert stopped
+
+
+def test_main_task_cleans_up_controller_when_start_fails(tmp_path, monkeypatch):
+    auth_db = tmp_path / "mail.db"
+    make_user_db(auth_db, {"alice": b"correct password"})
+    monkeypatch.setattr(relayer, "DB_AUTH", auth_db)
+    stopped = False
+
+    class DummyController:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            raise RuntimeError("partial startup failure")
+
+        def stop(self):
+            nonlocal stopped
+            stopped = True
+
+    monkeypatch.setattr(relayer, "Controller", DummyController)
+
+    with pytest.raises(RuntimeError, match="partial startup failure"):
+        asyncio.run(relayer.amain())
+
+    assert stopped

--- a/aiosmtpd/tests/test_authenticated_relayer_example.py
+++ b/aiosmtpd/tests/test_authenticated_relayer_example.py
@@ -1,13 +1,14 @@
 # Copyright 2014-2021 The aiosmtpd Developers
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 import sqlite3
 from contextlib import closing
 
 import pytest
 
+from examples.authenticated_relayer import server as relayer
 from examples.authenticated_relayer.make_user_db import make_user_db
-from examples.authenticated_relayer.server import Authenticator
 
 from aiosmtpd.smtp import LoginPassword
 
@@ -15,7 +16,7 @@ from aiosmtpd.smtp import LoginPassword
 def test_authenticator_uses_stored_salt(tmp_path):
     auth_db = tmp_path / "mail.db"
     make_user_db(auth_db, {"alice": b"correct password"})
-    authenticator = Authenticator(auth_db)
+    authenticator = relayer.Authenticator(auth_db)
 
     accepted = authenticator(
         None, None, None, "PLAIN", LoginPassword(b"alice", b"correct password")
@@ -43,4 +44,38 @@ def test_authenticator_rejects_legacy_database(tmp_path):
         conn.commit()
 
     with pytest.raises(RuntimeError, match="recreate it with make_user_db.py"):
-        Authenticator(auth_db)
+        relayer.Authenticator(auth_db)
+
+
+def test_main_task_keeps_controller_running(tmp_path, monkeypatch):
+    auth_db = tmp_path / "mail.db"
+    make_user_db(auth_db, {"alice": b"correct password"})
+    monkeypatch.setattr(relayer, "DB_AUTH", auth_db)
+    started = False
+    stopped = False
+
+    class DummyController:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            nonlocal started
+            started = True
+
+        def stop(self):
+            nonlocal stopped
+            stopped = True
+
+    monkeypatch.setattr(relayer, "Controller", DummyController)
+
+    async def exercise():
+        task = asyncio.create_task(relayer.amain())
+        await asyncio.sleep(0)
+        assert started
+        assert not task.done()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(exercise())
+    assert stopped

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2014-2021 The aiosmtpd Developers
+# SPDX-License-Identifier: Apache-2.0

--- a/examples/authenticated_relayer/make_user_db.py
+++ b/examples/authenticated_relayer/make_user_db.py
@@ -18,18 +18,23 @@ USER_AND_PASSWORD = {
 }
 
 
-if __name__ == '__main__':
-    dbfp = Path(DB_FILE).absolute()
+def make_user_db(db_file=DB_FILE, users=USER_AND_PASSWORD):
+    dbfp = Path(db_file).absolute()
     if dbfp.exists():
         dbfp.unlink()
-    conn = sqlite3.connect(DB_FILE)
+    conn = sqlite3.connect(dbfp)
     curs = conn.cursor()
-    curs.execute("CREATE TABLE userauth (username text, hashpass text)")
-    insert_up = "INSERT INTO userauth VALUES (?, ?)"
-    for u, p in USER_AND_PASSWORD.items():
-        h = pbkdf2_hmac("sha256", p, secrets.token_bytes(), 1000000).hex()
-        curs.execute(insert_up, (u, h))
+    curs.execute("CREATE TABLE userauth (username text, salt blob, hashpass text)")
+    insert_up = "INSERT INTO userauth VALUES (?, ?, ?)"
+    for username, password in users.items():
+        salt = secrets.token_bytes()
+        hashpass = pbkdf2_hmac("sha256", password, salt, 1000000).hex()
+        curs.execute(insert_up, (username, salt, hashpass))
     conn.commit()
     conn.close()
     assert dbfp.exists()
     print(f"database created at {dbfp}")
+
+
+if __name__ == '__main__':
+    make_user_db()

--- a/examples/authenticated_relayer/server.py
+++ b/examples/authenticated_relayer/server.py
@@ -6,6 +6,7 @@ import hmac
 import logging
 import sqlite3
 import sys
+from contextlib import closing
 from functools import lru_cache
 from hashlib import pbkdf2_hmac
 from pathlib import Path
@@ -23,6 +24,15 @@ DB_AUTH = Path("mail.db~")
 class Authenticator:
     def __init__(self, auth_database):
         self.auth_db = Path(auth_database)
+        with closing(sqlite3.connect(self.auth_db)) as conn:
+            columns = {
+                row[1] for row in conn.execute("PRAGMA table_info(userauth)")
+            }
+        if not {"username", "salt", "hashpass"} <= columns:
+            raise RuntimeError(
+                "incompatible authentication database; recreate it with "
+                "make_user_db.py"
+            )
 
     def __call__(self, server, session, envelope, mechanism, auth_data):
         fail_nothandled = AuthResult(success=False, handled=False)
@@ -35,12 +45,10 @@ class Authenticator:
         except UnicodeDecodeError:
             return fail_nothandled
         password = auth_data.password
-        conn = sqlite3.connect(self.auth_db)
-        curs = conn.execute(
-            "SELECT salt, hashpass FROM userauth WHERE username=?", (username,)
-        )
-        credentials = curs.fetchone()
-        conn.close()
+        with closing(sqlite3.connect(self.auth_db)) as conn:
+            credentials = conn.execute(
+                "SELECT salt, hashpass FROM userauth WHERE username=?", (username,)
+            ).fetchone()
         if not credentials:
             return fail_nothandled
         salt, hash_db = credentials

--- a/examples/authenticated_relayer/server.py
+++ b/examples/authenticated_relayer/server.py
@@ -97,8 +97,9 @@ async def amain():
         port=8025,
         authenticator=Authenticator(DB_AUTH)
     )
+    cont.start()
     try:
-        cont.start()
+        await asyncio.Event().wait()
     finally:
         cont.stop()
 
@@ -108,10 +109,7 @@ if __name__ == '__main__':
         print(f"Please create {DB_AUTH} first using make_user_db.py")
         sys.exit(1)
     logging.basicConfig(level=logging.DEBUG)
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    loop.create_task(amain())  # type: ignore[unused-awaitable]
     try:
-        loop.run_forever()
+        asyncio.run(amain())
     except KeyboardInterrupt:
         print("User abort indicated")

--- a/examples/authenticated_relayer/server.py
+++ b/examples/authenticated_relayer/server.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import hmac
 import logging
-import secrets
 import sqlite3
 import sys
 from functools import lru_cache
@@ -12,7 +12,6 @@ from pathlib import Path
 from smtplib import SMTP as SMTPCLient
 from typing import Dict
 
-import dns.resolver
 from aiosmtpd.controller import Controller
 from aiosmtpd.smtp import AuthResult, LoginPassword
 
@@ -31,24 +30,30 @@ class Authenticator:
             return fail_nothandled
         if not isinstance(auth_data, LoginPassword):
             return fail_nothandled
-        username = auth_data.login
+        try:
+            username = auth_data.login.decode("utf-8")
+        except UnicodeDecodeError:
+            return fail_nothandled
         password = auth_data.password
-        hashpass = pbkdf2_hmac("sha256", password, secrets.token_bytes(), 1000000).hex()
         conn = sqlite3.connect(self.auth_db)
         curs = conn.execute(
-            "SELECT hashpass FROM userauth WHERE username=?", (username,)
+            "SELECT salt, hashpass FROM userauth WHERE username=?", (username,)
         )
-        hash_db = curs.fetchone()
+        credentials = curs.fetchone()
         conn.close()
-        if not hash_db:
+        if not credentials:
             return fail_nothandled
-        if hashpass != hash_db[0]:
+        salt, hash_db = credentials
+        hashpass = pbkdf2_hmac("sha256", password, salt, 1000000).hex()
+        if not hmac.compare_digest(hashpass, hash_db):
             return fail_nothandled
         return AuthResult(success=True)
 
 
 @lru_cache(maxsize=256)
 def get_mx(domain):
+    import dns.resolver
+
     records = dns.resolver.resolve(domain, "MX")
     if not records:
         return None

--- a/examples/authenticated_relayer/server.py
+++ b/examples/authenticated_relayer/server.py
@@ -97,8 +97,8 @@ async def amain():
         port=8025,
         authenticator=Authenticator(DB_AUTH)
     )
-    cont.start()
     try:
+        cont.start()
         await asyncio.Event().wait()
     finally:
         cont.stop()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Store each user's PBKDF2 salt in the authenticated relayer example database and use that salt when verifying a login. The authenticator decodes SMTP login bytes before querying SQLite, compares password digests with `hmac.compare_digest()`, and rejects incompatible legacy databases with regeneration guidance.

The example now propagates startup errors, remains active until shutdown, and cleans up its controller after cancellation or partial startup failure. Regression tests cover successful and failed authentication, the legacy schema, controller lifetime, and startup cleanup.

## Are there changes in behavior for the user?

Yes. Credentials generated by `make_user_db.py` can now authenticate successfully. Existing databases using the old schema must be regenerated because their salts were never stored and cannot be recovered.

## Related issue number

Fixes #475

## Checklist

- [ ] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Relevant test environments have been executed:
  - [x] Linux, Python 3.13: full suite, 570 passed
  - [x] Linux, Python 3.13: QA, 9 passed
  - [x] Linux, Python 3.13: MyPy and flake8 passed
- [x] Documentation reflects the changes
- [x] Added a news entry to `NEWS.rst`

Drafted with OpenAI Codex; personal review by the contributor remains required before the PR is marked ready.
