### PR TITLE
Remove obsolete "type: ignore" comment

### DIFF
--- a/aiosmtpd/controller.py
+++ b/aiosmtpd/controller.py
@@ -457,9 +457,7 @@ class UnixSocketMixin(BaseController, metaclass=ABCMeta):  # pragma: no-unixsock
                 self._factory_invoker,
                 path=self.unix_socket,
                 ssl=self.ssl_context,
-                # Silence mypy warning as cleanup_socket is not yet annotated in
-                # typeshed: https://github.com/python/typeshed/issues/15742
-                cleanup_socket=False,  # type: ignore[call-arg]
+                cleanup_socket=False,
             )
 
         return self.loop.create_unix_server(


### PR DESCRIPTION
https://github.com/python/typeshed/issues/15742 is now fixed so this should not be needed any more

<!-- Thank you for your contribution! -->

## What do these changes do?

Removes a "type: ignore" comment which should no longer be needed.

## Are there changes in behavior for the user?

No.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Use the "closing keywords" such as "Closes" or "Fixes" to automatically link to Issues. -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] tox testenvs have been executed in the following environments:
  <!-- These are just examples; add/remove as necessary -->
  - [ ] Linux (Ubuntu 18.04, Ubuntu 20.04, Arch): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, qa, docs`
  - [ ] Windows (7, 10): `{py36,py37,py38,py39}-{nocov,cov,diffcov}`
  - [ ] WSL 1.0 (Ubuntu 18.04): `{py36,py37,py38,py39}-{nocov,cov,diffcov}, pypy3-{nocov,cov}, qa, docs`
  - [ ] FreeBSD (12.2, 12.1, 11.4): `{py36,pypy3}-{nocov,cov,diffcov}, qa`
  - [ ] Cygwin: `py36-{nocov,cov,diffcov}, qa, docs`
- [ ] Documentation reflects the changes
- [ ] Add a news fragment into the `NEWS.rst` file
  <!-- Delete the following bullet points prior to submitting the PR -->
  * Add under the "aiosmtpd-next" section, creating one if necessary
    * You may create subsections to group the changes, if you like
  * Use full sentences with correct case and punctuation
  * Refer to relevant Issue if applicable
